### PR TITLE
No PetSet client in client/unversioned

### DIFF
--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -44,6 +44,7 @@ type Interface interface {
 	PersistentVolumeClaimsNamespacer
 	ComponentStatusesInterface
 	ConfigMapsNamespacer
+	Apps() AppsInterface
 	Autoscaling() AutoscalingInterface
 	Batch() BatchInterface
 	Extensions() ExtensionsInterface

--- a/pkg/client/unversioned/testclient/fake_petsets.go
+++ b/pkg/client/unversioned/testclient/fake_petsets.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/apps"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePetSets implements PetSetsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakePetSets struct {
+	Fake      *FakeApps
+	Namespace string
+}
+
+func (c *FakePetSets) Get(name string) (*apps.PetSet, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("petsets", c.Namespace, name), &apps.PetSet{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*apps.PetSet), err
+}
+
+func (c *FakePetSets) List(opts api.ListOptions) (*apps.PetSetList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("petsets", c.Namespace, opts), &apps.PetSetList{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.PetSetList), err
+}
+
+func (c *FakePetSets) Create(rs *apps.PetSet) (*apps.PetSet, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("petsets", c.Namespace, rs), rs)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*apps.PetSet), err
+}
+
+func (c *FakePetSets) Update(rs *apps.PetSet) (*apps.PetSet, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("petsets", c.Namespace, rs), rs)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*apps.PetSet), err
+}
+
+func (c *FakePetSets) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("petsets", c.Namespace, name), &apps.PetSet{})
+	return err
+}
+
+func (c *FakePetSets) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("petsets", c.Namespace, opts))
+}
+
+func (c *FakePetSets) UpdateStatus(rs *apps.PetSet) (result *apps.PetSet, err error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("petsets", "status", c.Namespace, rs), rs)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*apps.PetSet), err
+}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -277,6 +277,10 @@ func (c *Fake) Namespaces() client.NamespaceInterface {
 	return &FakeNamespaces{Fake: c}
 }
 
+func (c *Fake) Apps() client.AppsInterface {
+	return &FakeApps{c}
+}
+
 func (c *Fake) Autoscaling() client.AutoscalingInterface {
 	return &FakeAutoscaling{c}
 }
@@ -313,6 +317,19 @@ func (c *Fake) SwaggerSchema(version unversioned.GroupVersion) (*swagger.ApiDecl
 
 	c.Invokes(action, nil)
 	return &swagger.ApiDeclaration{}, nil
+}
+
+// NewSimpleFakeApps returns a client that will respond with the provided objects
+func NewSimpleFakeApps(objects ...runtime.Object) *FakeApps {
+	return &FakeApps{Fake: NewSimpleFake(objects...)}
+}
+
+type FakeApps struct {
+	*Fake
+}
+
+func (c *FakeApps) PetSets(namespace string) client.PetSetInterface {
+	return &FakePetSets{Fake: c, Namespace: namespace}
 }
 
 // NewSimpleFakeAutoscaling returns a client that will respond with the provided objects


### PR DESCRIPTION
Missed pick of https://github.com/kubernetes/kubernetes/pull/29655. Next, origin will need to specify b81a8de8103922dd77163296e161baf64f19f158 in `Godeps.json` which should have been included with https://github.com/openshift/origin/commit/eb0dc7917a66c5a61c1c231745b1109310b2c944.