### PR TITLE
UPSTREAM: <drop>: updated files affecting codegen

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -39,7 +39,7 @@ function kfind() {
     # include the "special" vendor directories which are actually part
     # of the Kubernetes source tree - generators will use these for
     # including certain core API concepts.
-    find -H . ./vendor/k8s.io/apimachinery ./vendor/k8s.io/apiserver \
+    find -H . ./vendor/k8s.io/apimachinery ./vendor/k8s.io/apiserver ./vendor/k8s.io/kube-aggregator ./vendor/k8s.io/sample-apiserver \
         \(                         \
         -not \(                    \
             \(                     \

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -38,7 +38,35 @@ generated_files=($(
         -o -wholename '*/vendor/*' \
         -o -wholename '*/codecgen-*-1234.generated.go' \
       \) -prune \
-    \) -name '*.generated.go' | LC_ALL=C sort -r))
+    \) -name '*.generated.go' | LC_ALL=C sort -r
+
+  find ./vendor/k8s.io/kube-aggregator/ -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './staging' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/codecgen-*-1234.generated.go' \
+      \) -prune \
+    \) -name '*.generated.go' | LC_ALL=C sort -r
+
+  find ./vendor/k8s.io/metrics/ \
+    -name '*.generated.go' | LC_ALL=C sort -r
+
+  find ./vendor/k8s.io/apiserver/ -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './staging' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/codecgen-*-1234.generated.go' \
+      \) -prune \
+    \) -name '*.generated.go' | LC_ALL=C sort -r
+))
 
 # We only work for deps within this prefix.
 my_prefix="k8s.io/kubernetes"


### PR DESCRIPTION
These files have to be updated in order to generate code, but we can't bring them back through upstream picks.  This took a while to sort out....