### PR TITLE
UPSTREAM: 54257: Use GetByKey() in lister NonNamespacedGet

### DIFF
--- a/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
@@ -55,8 +54,7 @@ func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector
 
 // Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 func (s *externalAdmissionHookConfigurationLister) Get(name string) (*admissionregistration.ExternalAdmissionHookConfiguration, error) {
-	key := &admissionregistration.ExternalAdmissionHookConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
@@ -55,8 +54,7 @@ func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the InitializerConfiguration from the index for a given name.
 func (s *initializerConfigurationLister) Get(name string) (*admissionregistration.InitializerConfiguration, error) {
-	key := &admissionregistration.InitializerConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/pkg/client/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1"
@@ -55,8 +54,7 @@ func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector
 
 // Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 func (s *externalAdmissionHookConfigurationLister) Get(name string) (*v1alpha1.ExternalAdmissionHookConfiguration, error) {
-	key := &v1alpha1.ExternalAdmissionHookConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/pkg/client/listers/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1"
@@ -55,8 +54,7 @@ func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the InitializerConfiguration from the index for a given name.
 func (s *initializerConfigurationLister) Get(name string) (*v1alpha1.InitializerConfiguration, error) {
-	key := &v1alpha1.InitializerConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authentication/internalversion/tokenreview.go
+++ b/pkg/client/listers/authentication/internalversion/tokenreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authentication "k8s.io/kubernetes/pkg/apis/authentication"
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*authenticatio
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*authentication.TokenReview, error) {
-	key := &authentication.TokenReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authentication/v1/tokenreview.go
+++ b/pkg/client/listers/authentication/v1/tokenreview.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/apis/authentication/v1"
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1.TokenRevie
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1.TokenReview, error) {
-	key := &v1.TokenReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authentication/v1beta1/tokenreview.go
+++ b/pkg/client/listers/authentication/v1beta1/tokenreview.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1beta1.Token
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1beta1.TokenReview, error) {
-	key := &v1beta1.TokenReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*a
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*authorization.SelfSubjectAccessReview, error) {
-	key := &authorization.SelfSubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*autho
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*authorization.SubjectAccessReview, error) {
-	key := &authorization.SubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/v1/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1/selfsubjectaccessreview.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1.SelfSubjectAccessReview, error) {
-	key := &v1.SelfSubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/v1/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1/subjectaccessreview.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1.Su
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1.SubjectAccessReview, error) {
-	key := &v1.SubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1beta1/selfsubjectaccessreview.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1beta1.SelfSubjectAccessReview, error) {
-	key := &v1beta1.SelfSubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/v1beta1/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1beta1/subjectaccessreview.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1bet
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1beta1.SubjectAccessReview, error) {
-	key := &v1beta1.SubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates"
@@ -55,8 +54,7 @@ func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*certificates.CertificateSigningRequest, error) {
-	key := &certificates.CertificateSigningRequest{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/pkg/client/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
@@ -55,8 +54,7 @@ func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.CertificateSigningRequest, error) {
-	key := &v1beta1.CertificateSigningRequest{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/componentstatus.go
+++ b/pkg/client/listers/core/internalversion/componentstatus.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *componentStatusLister) List(selector labels.Selector) (ret []*api.Compo
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*api.ComponentStatus, error) {
-	key := &api.ComponentStatus{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/namespace.go
+++ b/pkg/client/listers/core/internalversion/namespace.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *namespaceLister) List(selector labels.Selector) (ret []*api.Namespace, 
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*api.Namespace, error) {
-	key := &api.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/node.go
+++ b/pkg/client/listers/core/internalversion/node.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *nodeLister) List(selector labels.Selector) (ret []*api.Node, err error)
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*api.Node, error) {
-	key := &api.Node{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/persistentvolume.go
+++ b/pkg/client/listers/core/internalversion/persistentvolume.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*api.Pers
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*api.PersistentVolume, error) {
-	key := &api.PersistentVolume{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1/componentstatus.go
+++ b/pkg/client/listers/core/v1/componentstatus.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
@@ -55,8 +54,7 @@ func (s *componentStatusLister) List(selector labels.Selector) (ret []*v1.Compon
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
-	key := &v1.ComponentStatus{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1/namespace.go
+++ b/pkg/client/listers/core/v1/namespace.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
@@ -55,8 +54,7 @@ func (s *namespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, e
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
-	key := &v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1/node.go
+++ b/pkg/client/listers/core/v1/node.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
@@ -55,8 +54,7 @@ func (s *nodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) 
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*v1.Node, error) {
-	key := &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/v1/persistentvolume.go
+++ b/pkg/client/listers/core/v1/persistentvolume.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
@@ -55,8 +54,7 @@ func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*v1.Persi
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) {
-	key := &v1.PersistentVolume{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -55,8 +54,7 @@ func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*extensi
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*extensions.PodSecurityPolicy, error) {
-	key := &extensions.PodSecurityPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -55,8 +54,7 @@ func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*extens
 
 // Get retrieves the ThirdPartyResource from the index for a given name.
 func (s *thirdPartyResourceLister) Get(name string) (*extensions.ThirdPartyResource, error) {
-	key := &extensions.ThirdPartyResource{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -55,8 +54,7 @@ func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, error) {
-	key := &v1beta1.PodSecurityPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/listers/extensions/v1beta1/thirdpartyresource.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -55,8 +54,7 @@ func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ThirdPartyResource from the index for a given name.
 func (s *thirdPartyResourceLister) Get(name string) (*v1beta1.ThirdPartyResource, error) {
-	key := &v1beta1.ThirdPartyResource{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/imagepolicy/internalversion/imagereview.go
+++ b/pkg/client/listers/imagepolicy/internalversion/imagereview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	imagepolicy "k8s.io/kubernetes/pkg/apis/imagepolicy"
@@ -55,8 +54,7 @@ func (s *imageReviewLister) List(selector labels.Selector) (ret []*imagepolicy.I
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*imagepolicy.ImageReview, error) {
-	key := &imagepolicy.ImageReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/pkg/client/listers/imagepolicy/v1alpha1/imagereview.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1"
@@ -55,8 +54,7 @@ func (s *imageReviewLister) List(selector labels.Selector) (ret []*v1alpha1.Imag
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*v1alpha1.ImageReview, error) {
-	key := &v1alpha1.ImageReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/internalversion/clusterrole.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrole.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*rbac.ClusterR
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*rbac.ClusterRole, error) {
-	key := &rbac.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*rbac.C
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*rbac.ClusterRoleBinding, error) {
-	key := &rbac.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/v1alpha1/clusterrole.go
+++ b/pkg/client/listers/rbac/v1alpha1/clusterrole.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1alpha1.Clus
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
-	key := &v1alpha1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1alph
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBinding, error) {
-	key := &v1alpha1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/v1beta1/clusterrole.go
+++ b/pkg/client/listers/rbac/v1beta1/clusterrole.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1beta1.Clust
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
-	key := &v1beta1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/v1beta1/clusterrolebinding.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding, error) {
-	key := &v1beta1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/storage/internalversion/storageclass.go
+++ b/pkg/client/listers/storage/internalversion/storageclass.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*storage.Stor
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*storage.StorageClass, error) {
-	key := &storage.StorageClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/storage/v1/storageclass.go
+++ b/pkg/client/listers/storage/v1/storageclass.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubernetes/pkg/apis/storage/v1"
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1.StorageCl
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
-	key := &v1.StorageClass{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/storage/v1beta1/storageclass.go
+++ b/pkg/client/listers/storage/v1beta1/storageclass.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.Stor
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
-	key := &v1beta1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -21,7 +21,6 @@ package internalversion
 import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*apiextensions.CustomResourceDefinition, error) {
-	key := &apiextensions.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
-	key := &v1beta1.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -323,8 +323,7 @@ func (s *$.type|private$Lister) $.type|publicPlural$(namespace string) $.type|pu
 var typeLister_NonNamespacedGet = `
 // Get retrieves the $.type|public$ from the index for a given name.
 func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
-  key := &$.type|raw${ObjectMeta: $.objectMeta|raw${Name: name}}
-  obj, exists, err := s.indexer.Get(key)
+  obj, exists, err := s.indexer.GetByKey(name)
   if err != nil {
     return nil, err
   }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration"
@@ -55,8 +54,7 @@ func (s *aPIServiceLister) List(selector labels.Selector) (ret []*apiregistratio
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*apiregistration.APIService, error) {
-	key := &apiregistration.APIService{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -55,8 +54,7 @@ func (s *aPIServiceLister) List(selector labels.Selector) (ret []*v1beta1.APISer
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*v1beta1.APIService, error) {
-	key := &v1beta1.APIService{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Get() function of non-namespace lister passes a temporary object to
indexer.Get() in order to fetch the actual object from the indexer. This
may cause Go to allocate the temporary object on the heap instead of the
stack, as it is passed into interfaces. For non-namespaced objects,
Get(&Type{ObjectMeta: v1.ObjectMeta{Name: name}}) should be equivalent
to GetByKey(name).

This could be the root cause of excessive allocations, e.g. in tests
clusterRoleLister.Get() has trigger 4 billion allocations. See
https://github.com/openshift/origin/issues/16954

Signed-off-by: Christian Heimes <cheimes@redhat.com>
