### PR TITLE
Openshift 4.2 fix unidling

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -505,8 +505,6 @@ type ProxyServer struct {
 	OOMScoreAdj            *int32
 	ResourceContainer      string
 	ConfigSyncPeriod       time.Duration
-	ServiceEventHandler    config.ServiceHandler
-	EndpointsEventHandler  config.EndpointsHandler
 	HealthzServer          *healthcheck.HealthzServer
 }
 
@@ -662,11 +660,11 @@ func (s *ProxyServer) Run() error {
 	// only notify on changes, and the initial update (on process start) may be lost if no handlers
 	// are registered yet.
 	serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.ConfigSyncPeriod)
-	serviceConfig.RegisterEventHandler(s.ServiceEventHandler)
+	serviceConfig.RegisterEventHandler(s.Proxier)
 	go serviceConfig.Run(wait.NeverStop)
 
 	endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), s.ConfigSyncPeriod)
-	endpointsConfig.RegisterEventHandler(s.EndpointsEventHandler)
+	endpointsConfig.RegisterEventHandler(s.Proxier)
 	go endpointsConfig.Run(wait.NeverStop)
 
 	// This has to start after the calls to NewServiceConfig and NewEndpointsConfig because those

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
@@ -136,8 +135,6 @@ func newProxyServer(
 	}
 
 	var proxier proxy.ProxyProvider
-	var serviceEventHandler proxyconfig.ServiceHandler
-	var endpointsEventHandler proxyconfig.EndpointsHandler
 
 	proxyMode := getProxyMode(string(config.Mode), iptInterface, kernelHandler, ipsetInterface, iptables.LinuxKernelCompatTester{})
 	nodeIP := net.ParseIP(config.BindAddress)
@@ -152,7 +149,7 @@ func newProxyServer(
 		}
 
 		// TODO this has side effects that should only happen when Run() is invoked.
-		proxierIPTables, err := iptables.NewProxier(
+		proxier, err = iptables.NewProxier(
 			iptInterface,
 			utilsysctl.New(),
 			execer,
@@ -171,9 +168,6 @@ func newProxyServer(
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
 		metrics.RegisterMetrics()
-		proxier = proxierIPTables
-		serviceEventHandler = proxierIPTables
-		endpointsEventHandler = proxierIPTables
 		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
 		klog.V(0).Info("Tearing down inactive rules.")
 		// TODO this has side effects that should only happen when Run() is invoked.
@@ -187,7 +181,7 @@ func newProxyServer(
 		}
 	} else if proxyMode == proxyModeIPVS {
 		klog.V(0).Info("Using ipvs Proxier.")
-		proxierIPVS, err := ipvs.NewProxier(
+		proxier, err = ipvs.NewProxier(
 			iptInterface,
 			ipvsInterface,
 			ipsetInterface,
@@ -210,24 +204,16 @@ func newProxyServer(
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
 		metrics.RegisterMetrics()
-		proxier = proxierIPVS
-		serviceEventHandler = proxierIPVS
-		endpointsEventHandler = proxierIPVS
 		klog.V(0).Info("Tearing down inactive rules.")
 		// TODO this has side effects that should only happen when Run() is invoked.
 		userspace.CleanupLeftovers(iptInterface)
 		iptables.CleanupLeftovers(iptInterface)
 	} else {
 		klog.V(0).Info("Using userspace Proxier.")
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsConfigHandler.
-		loadBalancer := userspace.NewLoadBalancerRR()
-		// set EndpointsConfigHandler to our loadBalancer
-		endpointsEventHandler = loadBalancer
 
 		// TODO this has side effects that should only happen when Run() is invoked.
-		proxierUserspace, err := userspace.NewProxier(
-			loadBalancer,
+		proxier, err = userspace.NewProxier(
+			userspace.NewLoadBalancerRR(),
 			net.ParseIP(config.BindAddress),
 			iptInterface,
 			execer,
@@ -240,8 +226,6 @@ func newProxyServer(
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		serviceEventHandler = proxierUserspace
-		proxier = proxierUserspace
 
 		// Remove artifacts from the iptables and ipvs Proxier, if not on Windows.
 		klog.V(0).Info("Tearing down inactive rules.")
@@ -277,8 +261,6 @@ func newProxyServer(
 		OOMScoreAdj:            config.OOMScoreAdj,
 		ResourceContainer:      config.ResourceContainer,
 		ConfigSyncPeriod:       config.ConfigSyncPeriod.Duration,
-		ServiceEventHandler:    serviceEventHandler,
-		EndpointsEventHandler:  endpointsEventHandler,
 		HealthzServer:          healthzServer,
 	}, nil
 }

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 	"k8s.io/kubernetes/pkg/proxy/winuserspace"
@@ -94,13 +93,11 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	}
 
 	var proxier proxy.ProxyProvider
-	var serviceEventHandler proxyconfig.ServiceHandler
-	var endpointsEventHandler proxyconfig.EndpointsHandler
 
 	proxyMode := getProxyMode(string(config.Mode), winkernel.WindowsKernelCompatTester{})
 	if proxyMode == proxyModeKernelspace {
 		klog.V(0).Info("Using Kernelspace Proxier.")
-		proxierKernelspace, err := winkernel.NewProxier(
+		proxier, err = winkernel.NewProxier(
 			config.IPTables.SyncPeriod.Duration,
 			config.IPTables.MinSyncPeriod.Duration,
 			config.IPTables.MasqueradeAll,
@@ -115,23 +112,14 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		proxier = proxierKernelspace
-		endpointsEventHandler = proxierKernelspace
-		serviceEventHandler = proxierKernelspace
 	} else {
 		klog.V(0).Info("Using userspace Proxier.")
 		execer := exec.New()
 		var netshInterface utilnetsh.Interface
 		netshInterface = utilnetsh.New(execer)
 
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsConfigHandler.
-		loadBalancer := winuserspace.NewLoadBalancerRR()
-
-		// set EndpointsConfigHandler to our loadBalancer
-		endpointsEventHandler = loadBalancer
-		proxierUserspace, err := winuserspace.NewProxier(
-			loadBalancer,
+		proxier, err = winuserspace.NewProxier(
+			winuserspace.NewLoadBalancerRR(),
 			net.ParseIP(config.BindAddress),
 			netshInterface,
 			*utilnet.ParsePortRangeOrDie(config.PortRange),
@@ -142,28 +130,24 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		proxier = proxierUserspace
-		serviceEventHandler = proxierUserspace
 		klog.V(0).Info("Tearing down pure-winkernel proxy rules.")
 		winkernel.CleanupLeftovers()
 	}
 
 	return &ProxyServer{
-		Client:                client,
-		EventClient:           eventClient,
-		Proxier:               proxier,
-		Broadcaster:           eventBroadcaster,
-		Recorder:              recorder,
-		ProxyMode:             proxyMode,
-		NodeRef:               nodeRef,
-		MetricsBindAddress:    config.MetricsBindAddress,
-		EnableProfiling:       config.EnableProfiling,
-		OOMScoreAdj:           config.OOMScoreAdj,
-		ResourceContainer:     config.ResourceContainer,
-		ConfigSyncPeriod:      config.ConfigSyncPeriod.Duration,
-		ServiceEventHandler:   serviceEventHandler,
-		EndpointsEventHandler: endpointsEventHandler,
-		HealthzServer:         healthzServer,
+		Client:             client,
+		EventClient:        eventClient,
+		Proxier:            proxier,
+		Broadcaster:        eventBroadcaster,
+		Recorder:           recorder,
+		ProxyMode:          proxyMode,
+		NodeRef:            nodeRef,
+		MetricsBindAddress: config.MetricsBindAddress,
+		EnableProfiling:    config.EnableProfiling,
+		OOMScoreAdj:        config.OOMScoreAdj,
+		ResourceContainer:  config.ResourceContainer,
+		ConfigSyncPeriod:   config.ConfigSyncPeriod.Duration,
+		HealthzServer:      healthzServer,
 	}, nil
 }
 

--- a/pkg/kubemark/BUILD
+++ b/pkg/kubemark/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//pkg/kubelet/dockershim:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/proxy:go_default_library",
-        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/iptables:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/mount:go_default_library",

--- a/pkg/proxy/BUILD
+++ b/pkg/proxy/BUILD
@@ -17,7 +17,8 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/proxy",
     deps = [
         "//pkg/api/v1/service:go_default_library",
-	"//pkg/proxy/metrics:go_default_library",
+	    "//pkg/proxy/metrics:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/proxy/iptables/proxier_openshift.go
+++ b/pkg/proxy/iptables/proxier_openshift.go
@@ -1,0 +1,13 @@
+package iptables
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -21,10 +21,14 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/proxy/config"
 )
 
 // ProxyProvider is the interface provided by proxier implementations.
 type ProxyProvider interface {
+	config.EndpointsHandler
+	config.ServiceHandler
+
 	// Sync immediately synchronizes the ProxyProvider's current state to proxy rules.
 	Sync()
 	// SyncLoop runs periodic work.

--- a/pkg/proxy/userspace/BUILD
+++ b/pkg/proxy/userspace/BUILD
@@ -21,7 +21,9 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/util:go_default_library",
+        "//pkg/util/async:go_default_library",
         "//pkg/util/conntrack:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/slice:go_default_library",
@@ -85,6 +87,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",
     ],

--- a/pkg/proxy/userspace/loadbalancer.go
+++ b/pkg/proxy/userspace/loadbalancer.go
@@ -19,6 +19,7 @@ package userspace
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"net"
 )
 
@@ -31,4 +32,6 @@ type LoadBalancer interface {
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)
 	ServiceHasEndpoints(service proxy.ServicePortName) bool
+
+	proxyconfig.EndpointsHandler
 }

--- a/pkg/proxy/userspace/proxier_openshift.go
+++ b/pkg/proxy/userspace/proxier_openshift.go
@@ -1,0 +1,13 @@
+package userspace
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/proxy"
 	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/utils/exec"
@@ -84,6 +86,16 @@ func waitForClosedPortUDP(p *Proxier, proxyPort int) error {
 		time.Sleep(1 * time.Millisecond)
 	}
 	return fmt.Errorf("port %d still open", proxyPort)
+}
+
+func waitForServiceInfo(p *Proxier, service proxy.ServicePortName) (*ServiceInfo, bool) {
+	var svcInfo *ServiceInfo
+	var exists bool
+	wait.PollImmediate(50*time.Millisecond, 3*time.Second, func() (bool, error) {
+		svcInfo, exists = p.getServiceInfo(service)
+		return exists, nil
+	})
+	return svcInfo, exists
 }
 
 // udpEchoServer is a simple echo server in UDP, intended for testing the proxy.
@@ -225,6 +237,15 @@ func waitForNumProxyClients(t *testing.T, s *ServiceInfo, want int, timeout time
 	t.Errorf("expected %d ProxyClients live, got %d", want, got)
 }
 
+func startProxier(p *Proxier, t *testing.T) {
+	go func() {
+		p.SyncLoop()
+	}()
+	waitForNumProxyLoops(t, p, 0)
+	p.OnServiceSynced()
+	p.OnEndpointsSynced()
+}
+
 func TestTCPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
 	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
@@ -242,7 +263,8 @@ func TestTCPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -269,7 +291,8 @@ func TestUDPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -296,7 +319,8 @@ func TestUDPProxyTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -335,7 +359,8 @@ func TestMultiPortProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfoP, err := p.addServiceOnPort(serviceP, "TCP", 0, time.Second)
 	if err != nil {
@@ -364,7 +389,8 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace},
@@ -379,7 +405,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		}}},
 	})
 	waitForNumProxyLoops(t, p, 2)
-	svcInfo, exists := p.getServiceInfo(serviceP)
+	svcInfo, exists := waitForServiceInfo(p, serviceP)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", serviceP)
 	}
@@ -387,7 +413,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		t.Errorf("unexpected serviceInfo for %s: %#v", serviceP, svcInfo)
 	}
 
-	svcInfo, exists = p.getServiceInfo(serviceQ)
+	svcInfo, exists = waitForServiceInfo(p, serviceQ)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", serviceQ)
 	}
@@ -403,7 +429,9 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 
 // Helper: Stops the proxy for the named service.
 func stopProxyByName(proxier *Proxier, service proxy.ServicePortName) error {
-	info, found := proxier.getServiceInfo(service)
+	proxier.mu.Lock()
+	defer proxier.mu.Unlock()
+	info, found := proxier.serviceMap[service]
 	if !found {
 		return fmt.Errorf("unknown service: %s", service)
 	}
@@ -427,7 +455,8 @@ func TestTCPProxyStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -471,7 +500,8 @@ func TestUDPProxyStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -494,9 +524,9 @@ func TestUDPProxyStop(t *testing.T) {
 
 func TestTCPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	servicePortName := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: servicePortName.Namespace, Name: servicePortName.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
@@ -509,28 +539,22 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
-	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
-	if err != nil {
-		t.Fatalf("error adding new service: %#v", err)
-	}
-	conn, err := net.Dial("tcp", joinHostPort("", svcInfo.proxyPort))
-	if err != nil {
-		t.Fatalf("error connecting to proxy: %v", err)
-	}
-	conn.Close()
-	waitForNumProxyLoops(t, p, 1)
-
-	p.OnServiceDelete(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: servicePortName.Name, Namespace: servicePortName.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
 			Name:     "p",
-			Port:     int32(svcInfo.proxyPort),
+			Port:     9997,
 			Protocol: "TCP",
 		}}},
-	})
-	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
+	}
+
+	p.OnServiceAdd(service)
+	waitForNumProxyLoops(t, p, 1)
+	p.OnServiceDelete(service)
+	if err := waitForClosedPortTCP(p, int(service.Spec.Ports[0].Port)); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
@@ -553,7 +577,8 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -598,7 +623,8 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -634,7 +660,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	})
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", service)
 	}
@@ -660,7 +686,8 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -696,7 +723,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Protocol: "UDP",
 		}}},
 	})
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -721,7 +748,8 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -742,7 +770,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -769,7 +797,8 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -789,7 +818,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	if err := waitForClosedPortUDP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -814,7 +843,8 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -839,7 +869,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -867,7 +897,8 @@ func TestProxyUpdatePortal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -894,7 +925,16 @@ func TestProxyUpdatePortal(t *testing.T) {
 		}}},
 	}
 	p.OnServiceUpdate(svcv0, svcv1)
-	_, exists := p.getServiceInfo(service)
+
+	// Wait for the service to be removed because it had an empty ClusterIP
+	var exists bool
+	for i := 0; i < 50; i++ {
+		_, exists = p.getServiceInfo(service)
+		if !exists {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if exists {
 		t.Fatalf("service with empty ClusterIP should not be included in the proxy")
 	}
@@ -923,12 +963,178 @@ func TestProxyUpdatePortal(t *testing.T) {
 	}
 	p.OnServiceUpdate(svcv2, svcv3)
 	lb.OnEndpointsAdd(endpoint)
-	svcInfo, exists = p.getServiceInfo(service)
+	svcInfo, exists = waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("service with ClusterIP set not found in the proxy")
 	}
 	testEchoTCP(t, "127.0.0.1", svcInfo.proxyPort)
 	waitForNumProxyLoops(t, p, 1)
+}
+
+type fakeRunner struct{}
+
+// assert fakeAsyncRunner is a ProxyProvider
+var _ asyncRunnerInterface = &fakeRunner{}
+
+func (f fakeRunner) Run() {
+}
+
+func (f fakeRunner) Loop(stop <-chan struct{}) {
+}
+
+func TestOnServiceAddChangeMap(t *testing.T) {
+	fexec := makeFakeExec()
+
+	// Use long minSyncPeriod so we can test that immediate syncs work
+	p, err := createProxier(NewLoadBalancerRR(), net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Minute, udpIdleTimeoutForTest, newProxySocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake out sync runner
+	p.syncRunner = fakeRunner{}
+
+	serviceMeta := metav1.ObjectMeta{Namespace: "testnamespace", Name: "testname"}
+	service := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     99,
+			Protocol: "TCP",
+		}}},
+	}
+
+	serviceUpdate := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.5", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     100,
+			Protocol: "TCP",
+		}}},
+	}
+
+	serviceUpdate2 := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.6", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     101,
+			Protocol: "TCP",
+		}}},
+	}
+
+	type onServiceTest struct {
+		detail         string
+		changes        []serviceChange
+		expectedChange *serviceChange
+	}
+
+	tests := []onServiceTest{
+		{
+			detail: "add",
+			changes: []serviceChange{
+				{current: service},
+			},
+			expectedChange: &serviceChange{
+				current: service,
+			},
+		},
+		{
+			detail: "add+update=add",
+			changes: []serviceChange{
+				{current: service},
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+			},
+			expectedChange: &serviceChange{
+				current: serviceUpdate,
+			},
+		},
+		{
+			detail: "add+del=none",
+			changes: []serviceChange{
+				{current: service},
+				{previous: service},
+			},
+		},
+		{
+			detail: "update+update=update",
+			changes: []serviceChange{
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+				{
+					previous: serviceUpdate,
+					current:  serviceUpdate2,
+				},
+			},
+			expectedChange: &serviceChange{
+				previous: service,
+				current:  serviceUpdate2,
+			},
+		},
+		{
+			detail: "update+del=del",
+			changes: []serviceChange{
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+				{previous: serviceUpdate},
+			},
+			// change collapsing always keeps the oldest service
+			// info since correct unmerging depends on the least
+			// recent update, not the most current.
+			expectedChange: &serviceChange{
+				previous: service,
+			},
+		},
+		{
+			detail: "del+add=update",
+			changes: []serviceChange{
+				{previous: service},
+				{current: serviceUpdate},
+			},
+			expectedChange: &serviceChange{
+				previous: service,
+				current:  serviceUpdate,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		for _, change := range test.changes {
+			p.serviceChange(change.previous, change.current, test.detail)
+		}
+
+		if test.expectedChange != nil {
+			if len(p.serviceChanges) != 1 {
+				t.Fatalf("[%s] expected 1 service change but found %d", test.detail, len(p.serviceChanges))
+			}
+			expectedService := test.expectedChange.current
+			if expectedService == nil {
+				expectedService = test.expectedChange.previous
+			}
+			svcName := types.NamespacedName{Namespace: expectedService.Namespace, Name: expectedService.Name}
+
+			change, ok := p.serviceChanges[svcName]
+			if !ok {
+				t.Fatalf("[%s] did not find service change for %v", test.detail, svcName)
+			}
+			if !reflect.DeepEqual(change.previous, test.expectedChange.previous) {
+				t.Fatalf("[%s] change previous service and expected previous service don't match\nchange: %+v\nexp:    %+v", test.detail, change.previous, test.expectedChange.previous)
+			}
+			if !reflect.DeepEqual(change.current, test.expectedChange.current) {
+				t.Fatalf("[%s] change current service and expected current service don't match\nchange: %+v\nexp:    %+v", test.detail, change.current, test.expectedChange.current)
+			}
+		} else {
+			if len(p.serviceChanges) != 0 {
+				t.Fatalf("[%s] expected no service changes but found %d", test.detail, len(p.serviceChanges))
+			}
+		}
+	}
 }
 
 func makeFakeExec() *fakeexec.FakeExec {

--- a/pkg/proxy/winuserspace/BUILD
+++ b/pkg/proxy/winuserspace/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/util/ipconfig:go_default_library",
         "//pkg/util/netsh:go_default_library",
         "//pkg/util/slice:go_default_library",

--- a/pkg/proxy/winuserspace/loadbalancer.go
+++ b/pkg/proxy/winuserspace/loadbalancer.go
@@ -19,6 +19,7 @@ package winuserspace
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"net"
 )
 
@@ -30,4 +31,6 @@ type LoadBalancer interface {
 	NewService(service proxy.ServicePortName, sessionAffinityType v1.ServiceAffinity, stickyMaxAgeMinutes int) error
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)
+
+	proxyconfig.EndpointsHandler
 }

--- a/pkg/proxy/winuserspace/proxier.go
+++ b/pkg/proxy/winuserspace/proxier.go
@@ -444,6 +444,22 @@ func (proxier *Proxier) OnServiceDelete(service *v1.Service) {
 func (proxier *Proxier) OnServiceSynced() {
 }
 
+func (proxier *Proxier) OnEndpointsAdd(endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsAdd(endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsUpdate(oldEndpoints, endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsDelete(endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsDelete(endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsSynced() {
+	proxier.loadBalancer.OnEndpointsSynced()
+}
+
 func sameConfig(info *serviceInfo, service *v1.Service, protocol v1.Protocol, listenPort int) bool {
 	return info.protocol == protocol && info.portal.port == listenPort && info.sessionAffinityType == service.Spec.SessionAffinity
 }


### PR DESCRIPTION
Moving the upstream commits out of https://github.com/openshift/sdn/pull/8

This backports upstream PR 71735, and adds a small carry patch to allow tweaking internal proxy sync semantics.