### PR TITLE
Bug 1735404 - UPSTREAM:80827: 'kubectl get' count binaryData keys on ConfigMap

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1725,7 +1725,7 @@ func printConfigMap(obj *api.ConfigMap, options printers.PrintOptions) ([]metav1
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)), translateTimestampSince(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)+len(obj.BinaryData)), translateTimestampSince(obj.CreationTimestamp))
 	return []metav1beta1.TableRow{row}, nil
 }
 


### PR DESCRIPTION
`kubectl get` and `oc extract` count binaryData keys on ConfigMap

Needed for https://bugzilla.redhat.com/show_bug.cgi?id=1735404

/assign @soltysh 