### PR TITLE
UPSTREAM: 77874: fix CVE-2019-11244: `kubectl --http-cache=<world-accssible dir>

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -172,7 +172,7 @@ func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
 }
 
 func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Object) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0750); err != nil {
 		return err
 	}
 
@@ -191,7 +191,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	err = os.Chmod(f.Name(), 0755)
+	err = os.Chmod(f.Name(), 0660)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper.go
@@ -18,6 +18,7 @@ package disk
 
 import (
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/gregjones/httpcache"
@@ -35,6 +36,8 @@ type cacheRoundTripper struct {
 // corresponding requests.
 func newCacheRoundTripper(cacheDir string, rt http.RoundTripper) http.RoundTripper {
 	d := diskv.New(diskv.Options{
+		PathPerm: os.FileMode(0750),
+		FilePerm: os.FileMode(0660),
 		BasePath: cacheDir,
 		TempDir:  filepath.Join(cacheDir, ".diskv-temp"),
 	})


### PR DESCRIPTION
/assign @deads2k 