### PR TITLE
UPSTREAM: 74840: kube-proxy: Drop packets in INVALID state

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -34,7 +34,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1313,6 +1313,16 @@ func (proxier *Proxier) syncProxyRules() {
 			writeLine(proxier.natRules, args...)
 		}
 	}
+
+	// Drop the packets in INVALID state, which would potentially cause
+	// unexpected connection reset.
+	// https://github.com/kubernetes/kubernetes/issues/74839
+	writeLine(proxier.filterRules,
+		"-A", string(kubeForwardChain),
+		"-m", "conntrack",
+		"--ctstate", "INVALID",
+		"-j", "DROP",
+	)
 
 	// If the masqueradeMark has been added then we want to forward that same
 	// traffic, this allows NodePort traffic to be forwarded even if the default


### PR DESCRIPTION
Cherry-pick of a07169bc which is already in `sdn-4.3-kubernetes-1.16.0]`. Fixes a problem where in a high-traffic cluster, lost ACKs could result a connection being forcibly closed.

First half of https://bugzilla.redhat.com/show_bug.cgi?id=1762298; this needs to be pulled in to openshift/sdn after it merges.

/cc @squeed @dcbw 