### PR TITLE
UPSTREAM: 66707: Fix that fails to resize pvc of cinder volume.

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -235,6 +235,7 @@ func (volumes *VolumesV3) getVolume(volumeID string) (Volume, error) {
 		ID:               volumeV3.ID,
 		Name:             volumeV3.Name,
 		Status:           volumeV3.Status,
+		Size:             volumeV3.Size,
 	}
 
 	if len(volumeV3.Attachments) > 0 {


### PR DESCRIPTION
Hello,

This is related to the following PR https://github.com/kubernetes/kubernetes/pull/66707
and https://github.com/kubernetes/kubernetes/issues/66687

The fix is present on Openshift 4, but I would need it working on 3.11

Should I also update the vendoring on openshift/origin repo to reflect this change as well ?
https://github.com/openshift/origin/blob/release-3.11/glide.yaml#L37

Thank you very much for your help.
