### PR TITLE
UPSTREAM: <carry>: Enable timeout validator to run in kube-apiserver

### DIFF
--- a/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_idp.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_idp.go
@@ -72,10 +72,10 @@ func validateOAuthSpec(spec configv1.OAuthSpec) field.ErrorList {
 	}
 
 	// TODO move to ValidateTokenConfig
-	timeout := spec.TokenConfig.AccessTokenInactivityTimeoutSeconds
-	if timeout > 0 && timeout < MinimumInactivityTimeoutSeconds {
+	timeout := spec.TokenConfig.AccessTokenInactivityTimeout
+	if timeout != nil && timeout.Seconds() < MinimumInactivityTimeoutSeconds {
 		errs = append(errs, field.Invalid(
-			specPath.Child("tokenConfig", "accessTokenInactivityTimeoutSeconds"), timeout,
+			specPath.Child("tokenConfig", "accessTokenInactivityTimeout"), timeout,
 			fmt.Sprintf("the minimum acceptable token timeout value is %d seconds",
 				MinimumInactivityTimeoutSeconds)))
 	}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_idp_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_idp_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -143,9 +145,12 @@ func TestValidateOAuthSpec(t *testing.T) {
 			args: args{
 				spec: configv1.OAuthSpec{
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: -50,
+						AccessTokenInactivityTimeout: &metav1.Duration{Duration: -50 * time.Second},
 					},
 				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "tokenConfig", "accessTokenInactivityTimeout"), metav1.Duration{Duration: -50 * time.Second}, fmt.Sprintf("the minimum acceptable token timeout value is %d seconds", MinimumInactivityTimeoutSeconds)),
 			},
 		},
 		{
@@ -153,7 +158,7 @@ func TestValidateOAuthSpec(t *testing.T) {
 			args: args{
 				spec: configv1.OAuthSpec{
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: 32578,
+						AccessTokenInactivityTimeout: &metav1.Duration{Duration: 32578 * time.Second},
 					},
 				},
 			},
@@ -163,9 +168,12 @@ func TestValidateOAuthSpec(t *testing.T) {
 			args: args{
 				spec: configv1.OAuthSpec{
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: 0,
+						AccessTokenInactivityTimeout: &metav1.Duration{Duration: 0},
 					},
 				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "tokenConfig", "accessTokenInactivityTimeout"), metav1.Duration{Duration: 0 * time.Second}, fmt.Sprintf("the minimum acceptable token timeout value is %d seconds", MinimumInactivityTimeoutSeconds)),
 			},
 		},
 		{
@@ -173,12 +181,12 @@ func TestValidateOAuthSpec(t *testing.T) {
 			args: args{
 				spec: configv1.OAuthSpec{
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: 250,
+						AccessTokenInactivityTimeout: &metav1.Duration{Duration: 250 * time.Second},
 					},
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "tokenConfig", "accessTokenInactivityTimeoutSeconds"), 250, fmt.Sprintf("the minimum acceptable token timeout value is %d seconds", MinimumInactivityTimeoutSeconds)),
+				field.Invalid(field.NewPath("spec", "tokenConfig", "accessTokenInactivityTimeout"), metav1.Duration{Duration: 250 * time.Second}, fmt.Sprintf("the minimum acceptable token timeout value is %d seconds", MinimumInactivityTimeoutSeconds)),
 			},
 		},
 		{
@@ -246,8 +254,8 @@ func TestValidateOAuthSpec(t *testing.T) {
 						},
 					},
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: -1,
-						AccessTokenMaxAgeSeconds:            216000,
+						AccessTokenInactivityTimeout: &metav1.Duration{Duration: 300 * time.Second},
+						AccessTokenMaxAgeSeconds:     216000,
 					},
 					Templates: configv1.OAuthTemplates{
 						Login:             configv1.SecretNameReference{Name: "my-login-template"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR has changes to enable timeout validator in kube-apiserver. The timeout validator will not have any effect unless a timeout value is configured in `KubeAPIServerConfig`.

Depends openshift/cluster-kube-apiserver-operator#874 and openshift/oauth-server#49 to work

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
