### PR TITLE
Bug 1816812: Allow test images to be in a single mirror

### DIFF
--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -18,7 +18,10 @@ package image
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 type result struct {
@@ -133,5 +136,30 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 				t.Errorf("got %q, want %q", s, tt.out.result)
 			}
 		})
+	}
+}
+
+func TestGetOriginalImageConfigs(t *testing.T) {
+	if len(GetOriginalImageConfigs()) == 0 {
+		t.Fatalf("original map should not be empty")
+	}
+}
+
+func TestGetMappedImageConfigs(t *testing.T) {
+	originals := map[int]Config{
+		0: {registry: "docker.io", name: "source/repo", version: "1.0"},
+	}
+	mapping := GetMappedImageConfigs(originals, "quay.io/repo/for-test")
+
+	actual := make(map[string]string)
+	for i, mapping := range mapping {
+		source := originals[i]
+		actual[source.GetE2EImage()] = mapping.GetE2EImage()
+	}
+	expected := map[string]string{
+		"docker.io/source/repo:1.0": "quay.io/repo/for-test:e2e-0-docker-io-source-repo-1-0-72R4aXm7YnxQ4_ek",
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal(diff.ObjectReflectDiff(expected, actual))
 	}
 }


### PR DESCRIPTION
In downstream contexts, it's extremely useful to be able to combine all the "testable" images in Kubernetes into a single repo so that a user could mirror these offline in one chunk, and audit the set of images for changes. For instance, within OpenShift we would like to have a single place we can place all the images used by all the tests with a single authentication scheme. While some images are not "real" and can't be mirrored (for instance, the images that point to an auth protected registry), that is not the majority.
    
This code makes it possible to specify an environment variable KUBE_TEST_REPO that maps the static strings of the registry to a single repository by placing the uniqueness in a tag. For instance:
    
    KUBE_TEST_REPO=quay.io/openshift/community-e2e-images

would translate `k8s.gcr.io/prometheus-to-sd:v0.5.0` to `quay.io/openshift/community-e2e-images:e2e-30-k8s-gcr-io-prometheus-to-sd-v0-5-0-6JI59Yih4oaj3oQOjRfhyQ`.
    
The tag is a safe form of the name, plus the index (the constant within manifest.go), plus a hash of the full input. The length of the tag is constrained to the minimum of hash + index + the safe name.

The public method is changed to return two maps - index to original name and index to test repo name. These maps would be the same if the env var is not set.

In order to enable offline test execution we need to be able to collect all images used by Kube e2e into a single repo and then
mirror them. This structure may be useful upstream in the future, but some assessment of the particular pattern in use will be
necessary to determine the best outcome. 

The presence of the env var switches all pullable images to use a single repository (which has been prepared by openshift-tests)
except for those images that are explicitly not intended to be pulled (those tests can't run offline anyway). The original map
is returned so the mirror can identify the mapping in use between hardcoded value and external value.

See openshift/origin#24887 for more details.

Upstream PR kubernetes#93510.