### PR TITLE
UPSTREAM: 93658: test/e2e: fail test rather than flooding logs if PVC watch is closed prematurely

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -892,7 +892,11 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			loop:
 				for {
 					select {
-					case event := <-pvcWatch.ResultChan():
+					case event, ok := <-pvcWatch.ResultChan():
+						if !ok {
+							framework.Failf("PVC watch ended prematurely")
+						}
+
 						framework.Logf("PVC event %s: %#v", event.Type, event.Object)
 						switch event.Type {
 						case watch.Modified:


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Backports https://github.com/kubernetes/kubernetes/pull/93658 . This PR addresses an incorrectly written test where we didn't fail the test if the watch was closed prematurely.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```