### PR TITLE
UPSTREAM: <carry>: only create valid LateConnections/GracefulTermination events

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -658,9 +658,6 @@ func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...
 		InvolvedObject: ref,
 		Reason:         reason,
 		Message:        fmt.Sprintf(messageFmt, args...),
-		FirstTimestamp: t,
-		LastTimestamp:  t,
-		Count:          1,
 		Type:           eventType,
 		Source:         corev1.EventSource{Component: "apiserver", Host: host},
 	}


### PR DESCRIPTION
Fixing:
```
W0804 12:17:12.025542      19 genericapiserver.go:671] failed to create event openshift-kube-apiserver/kube-apiserver-ip-10-0-211-44.ec2.internal.16280fcae657f7ab: Event "kube-apiserver-ip-10-0-211-44.ec2.internal.16280fcae657f7ab" is invalid: [eventTime: Required value, firstTimestamp: Invalid value: "": needs to be unset, lastTimestamp: Invalid value: "": needs to be unset, count: Invalid value: "": needs to be unset, source: Invalid value: "": needs to be unset]
```