### PR TITLE
openshift.spec: build debuginfo

### DIFF
--- a/openshift.spec
+++ b/openshift.spec
@@ -1,5 +1,3 @@
-#debuginfo not supported with Go
-%global debug_package %{nil}
 # modifying the Go binaries breaks the DWARF debugging
 %global __os_install_post %{_rpmconfigdir}/brp-compress
 


### PR DESCRIPTION
enable https://issues.redhat.com/browse/RFE-786

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It removes the line blocking the creation of a debuginfo RPM.
This allows debugging with symbols.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/RFE-786


**Special notes for your reviewer**:
should be "cherry-picked" back to previous releases in openshift/origin

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
