### PR TITLE
UPSTREAM: 89885: Bug 1850149: Include / prefix in the instance ID output

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
@@ -227,7 +227,7 @@ func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string
 	}
 	localName := types.NodeName(md.Name)
 	if localName == name {
-		return md.UUID, nil
+		return "/" + md.UUID, nil
 	}
 
 	srv, err := getServerByName(i.compute, name)


### PR DESCRIPTION
When we want to read an instance ID from the metadata service, cloud provider doesn't include "/" prefix, which is required for successful parsing of the provider ID later.
This commit adds the missing "/" prefix to the output.