### PR TITLE
bug 1880279: [e2e] scheduling: Pod should avoid nodes that have avoidPod annotation: fail when not all pods are properly deleted

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -250,7 +250,7 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		defer func() {
 			// Resize the replication controller to zero to get rid of pods.
 			if err := e2erc.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, rc.Name); err != nil {
-				framework.Logf("Failed to cleanup replication controller %v: %v.", rc.Name, err)
+				framework.Failf("Failed to cleanup replication controller %v: %v.", rc.Name, err)
 			}
 		}()
 


### PR DESCRIPTION
Fail when e2erc.DeleteRCAndWaitForGC returns an error to discover the reason why the pods are not deleted properly
