### PR TITLE
DO NOT MERGE - UPSTREAM: 94866: Add pod resource metrics

### DIFF
--- a/pkg/scheduler/metrics/BUILD
+++ b/pkg/scheduler/metrics/BUILD
@@ -26,7 +26,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/scheduler/metrics/resources:all-srcs",
+    ],
     tags = ["automanaged"],
 )
 

--- a/pkg/scheduler/metrics/resources/BUILD
+++ b/pkg/scheduler/metrics/resources/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resources.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/metrics/resources",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/metrics/resources/resources.go
+++ b/pkg/scheduler/metrics/resources/resources.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resources provides a metrics collector that reports the
+// resource consumption (requests and limits) of the pods in the cluster
+// as the scheduler and kubelet would interpret it.
+package resources
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/component-base/metrics"
+)
+
+type resourceLifecycleDescriptors struct {
+	total *metrics.Desc
+}
+
+func (d resourceLifecycleDescriptors) Describe(ch chan<- *metrics.Desc) {
+	ch <- d.total
+}
+
+type resourceMetricsDescriptors struct {
+	requests resourceLifecycleDescriptors
+	limits   resourceLifecycleDescriptors
+}
+
+func (d resourceMetricsDescriptors) Describe(ch chan<- *metrics.Desc) {
+	d.requests.Describe(ch)
+	d.limits.Describe(ch)
+}
+
+var podResourceDesc = resourceMetricsDescriptors{
+	requests: resourceLifecycleDescriptors{
+		total: metrics.NewDesc("kube_pod_resource_request",
+			"Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.",
+			[]string{"namespace", "pod", "node", "scheduler", "priority", "resource", "unit"},
+			nil,
+			metrics.ALPHA,
+			""),
+	},
+	limits: resourceLifecycleDescriptors{
+		total: metrics.NewDesc("kube_pod_resource_limit",
+			"Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.",
+			[]string{"namespace", "pod", "node", "scheduler", "priority", "resource", "unit"},
+			nil,
+			metrics.ALPHA,
+			""),
+	},
+}
+
+// Handler creates a collector from the provided podLister and returns an http.Handler that
+// will report the requested metrics in the prometheus format. It does not include any other
+// metrics.
+func Handler(podLister corelisters.PodLister) http.Handler {
+	collector := NewPodResourcesMetricsCollector(podLister)
+	registry := metrics.NewKubeRegistry()
+	registry.CustomMustRegister(collector)
+	return metrics.HandlerWithReset(registry, metrics.HandlerOpts{})
+}
+
+// Check if resourceMetricsCollector implements necessary interface
+var _ metrics.StableCollector = &podResourceCollector{}
+
+// NewPodResourcesMetricsCollector registers a O(pods) cardinality metric that
+// reports the current resources requested by all pods on the cluster within
+// the Kubernetes resource model. Metrics are broken down by pod, node, resource,
+// and phase of lifecycle. Each pod returns two series per resource - one for
+// their aggregate usage (required to schedule) and one for their phase specific
+// usage. This allows admins to assess the cost per resource at different phases
+// of startup and compare to actual resource usage.
+func NewPodResourcesMetricsCollector(podLister corelisters.PodLister) metrics.StableCollector {
+	return &podResourceCollector{
+		lister: podLister,
+	}
+}
+
+type podResourceCollector struct {
+	metrics.BaseStableCollector
+	lister corelisters.PodLister
+}
+
+func (c *podResourceCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	podResourceDesc.Describe(ch)
+}
+
+func (c *podResourceCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	pods, err := c.lister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+	reuseReqs, reuseLimits := make(v1.ResourceList, 4), make(v1.ResourceList, 4)
+	for _, p := range pods {
+		_, reqs, _, limits, _, terminal := podRequestsAndLimitsByLifecycle(p, reuseReqs, reuseLimits)
+		if terminal {
+			// terminal pods are excluded from resource usage calculations
+			continue
+		}
+		for _, t := range []struct {
+			desc    resourceLifecycleDescriptors
+			total   v1.ResourceList
+			running v1.ResourceList
+		}{
+			{
+				desc:  podResourceDesc.requests,
+				total: reqs,
+			},
+			{
+				desc:  podResourceDesc.limits,
+				total: limits,
+			},
+		} {
+			for resourceName, val := range t.total {
+				var unitName string
+				switch resourceName {
+				case v1.ResourceCPU:
+					unitName = "cores"
+				case v1.ResourceMemory:
+					unitName = "bytes"
+				case v1.ResourceStorage:
+					unitName = "bytes"
+				case v1.ResourceEphemeralStorage:
+					unitName = "bytes"
+				default:
+					switch {
+					case isHugePageResourceName(resourceName):
+						unitName = "bytes"
+					case isAttachableVolumeResourceName(resourceName):
+						unitName = "integer"
+					}
+				}
+				var priority string
+				if p.Spec.Priority != nil {
+					priority = strconv.FormatInt(int64(*p.Spec.Priority), 10)
+				}
+				recordMetricWithUnit(ch, t.desc.total, resourceName, unitName, val, p.Namespace, p.Name, p.Spec.NodeName, p.Spec.SchedulerName, priority)
+			}
+		}
+	}
+}
+
+func recordMetricWithUnit(
+	ch chan<- metrics.Metric,
+	desc *metrics.Desc,
+	resourceName v1.ResourceName,
+	unit string,
+	val resource.Quantity,
+	namespace, name, nodeName, schedulerName, priority string,
+) {
+	if val.IsZero() {
+		return
+	}
+	ch <- metrics.NewLazyConstMetric(desc, metrics.GaugeValue,
+		val.AsApproximateFloat64(),
+		namespace, name, nodeName, schedulerName, priority, string(resourceName), unit,
+	)
+}
+
+// addResourceList adds the resources in newList to list
+func addResourceList(list, newList v1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// maxResourceList sets list to the greater of list/newList for every resource
+// either list
+func maxResourceList(list, new v1.ResourceList) {
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+			continue
+		} else {
+			if quantity.Cmp(value) > 0 {
+				list[name] = quantity.DeepCopy()
+			}
+		}
+	}
+}
+
+// podRequestsAndLimitsByLifecycle returns a dictionary of all defined resources summed up for all
+// containers of the pod. If PodOverhead feature is enabled, pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity. If the pod is assigned to a node and non-terminal, the current requests and
+// limits are returned for the pod. The caller may avoid allocations of resource lists by passing
+// a requests and limits list to the function, which will be cleared before use.
+func podRequestsAndLimitsByLifecycle(pod *v1.Pod, reuseReqs, reuseLimits v1.ResourceList) (lifecycle string, reqs, currentReqs, limits, currentLimits v1.ResourceList, terminal bool) {
+	var initializing, running bool
+	switch {
+	case len(pod.Spec.NodeName) == 0:
+		lifecycle = "Pending"
+	case pod.Status.Phase == v1.PodSucceeded, pod.Status.Phase == v1.PodFailed:
+		lifecycle = "Completed"
+		terminal = true
+	default:
+		if len(pod.Spec.InitContainers) > 0 && !hasConditionStatus(pod.Status.Conditions, v1.PodInitialized, v1.ConditionTrue) {
+			lifecycle = "Initializing"
+			initializing = true
+		} else {
+			lifecycle = "Running"
+			running = true
+		}
+	}
+	if terminal {
+		return
+	}
+
+	// attempt to reuse the maps if passed, or allocate otherwise
+	if reuseReqs != nil {
+		reqs = reuseReqs
+		for k := range reqs {
+			delete(reqs, k)
+		}
+	} else {
+		reqs = make(v1.ResourceList, 4)
+	}
+	if reuseLimits != nil {
+		limits = reuseLimits
+		for k := range limits {
+			delete(limits, k)
+		}
+	} else {
+		limits = make(v1.ResourceList, 4)
+	}
+
+	for _, container := range pod.Spec.Containers {
+		addResourceList(reqs, container.Resources.Requests)
+		addResourceList(limits, container.Resources.Limits)
+	}
+	// init containers define the minimum of any resource
+	for _, container := range pod.Spec.InitContainers {
+		maxResourceList(reqs, container.Resources.Requests)
+		maxResourceList(limits, container.Resources.Limits)
+	}
+
+	// if PodOverhead feature is supported, add overhead for running a pod
+	// to the sum of reqeuests and to non-zero limits:
+	if pod.Spec.Overhead != nil {
+		addResourceList(reqs, pod.Spec.Overhead)
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
+				value.Add(quantity)
+				limits[name] = value
+			}
+		}
+	}
+
+	if initializing || running {
+		currentReqs = reqs
+		currentLimits = limits
+	}
+
+	return
+}
+
+func hasConditionStatus(conditions []v1.PodCondition, name v1.PodConditionType, status v1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type != name {
+			continue
+		}
+		return condition.Status == status
+	}
+	return false
+}
+
+func isHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix)
+}
+
+func isAttachableVolumeResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceAttachableVolumesPrefix)
+}

--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -1,0 +1,559 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resources provides a metrics collector that reports the
+// resource consumption (requests and limits) of the pods in the cluster
+// as the scheduler and kubelet would interpret it.
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+type metricSeries struct {
+	name   string
+	labels map[string]string
+	value  float64
+}
+
+func (s *metricSeries) Record(m metrics.Metric) error {
+	var prom io_prometheus_client.Metric
+	if err := m.Write(&prom); err != nil {
+		return err
+	}
+	return nil
+}
+
+type fakePodLister struct {
+	pods []*v1.Pod
+}
+
+func (l *fakePodLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
+	return l.pods, nil
+}
+
+func (l *fakePodLister) Pods(namespace string) corelisters.PodNamespaceLister {
+	panic("not implemented")
+}
+
+func Test_podResourceCollector_Handler(t *testing.T) {
+	h := Handler(&fakePodLister{pods: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+			Spec: v1.PodSpec{
+				NodeName: "node-one",
+				InitContainers: []v1.Container{
+					{Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"cpu":    resource.MustParse("2"),
+							"custom": resource.MustParse("3"),
+						},
+						Limits: v1.ResourceList{
+							"memory": resource.MustParse("1G"),
+							"custom": resource.MustParse("5"),
+						},
+					}},
+				},
+				Containers: []v1.Container{
+					{Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"cpu":    resource.MustParse("1"),
+							"custom": resource.MustParse("0"),
+						},
+						Limits: v1.ResourceList{
+							"memory": resource.MustParse("2G"),
+							"custom": resource.MustParse("6"),
+						},
+					}},
+				},
+			},
+			Status: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+				},
+			},
+		},
+	}})
+
+	r := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/metrics/resources", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.ServeHTTP(r, req)
+
+	expected := `# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+# TYPE kube_pod_resource_limit gauge
+kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 6
+kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2e+09
+# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+# TYPE kube_pod_resource_request gauge
+kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 2
+kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 3
+`
+	out := r.Body.String()
+	if expected != out {
+		t.Fatal(out)
+	}
+}
+
+func Test_podResourceCollector_CollectWithStability(t *testing.T) {
+	int32p := func(i int32) *int32 {
+		return &i
+	}
+
+	tests := []struct {
+		name string
+
+		pods     []*v1.Pod
+		expected string
+	}{
+		{},
+		{
+			name: "no containers",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+				},
+			},
+		},
+		{
+			name: "no resources",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{},
+						Containers:     []v1.Container{},
+					},
+				},
+			},
+		},
+		{
+			name: "request only",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1
+				`,
+		},
+		{
+			name: "limits only",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+				},
+			},
+			expected: `      
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1
+				`,
+		},
+		{
+			name: "terminal pods are excluded",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-unscheduled-succeeded"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+					// until node name is set, phase is ignored
+					Status: v1.PodStatus{Phase: v1.PodSucceeded},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-succeeded"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+					Status: v1.PodStatus{Phase: v1.PodSucceeded},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-failed"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+					Status: v1.PodStatus{Phase: v1.PodFailed},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-unknown"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+					Status: v1.PodStatus{Phase: v1.PodUnknown},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-pending"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						InitContainers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						Conditions: []v1.PodCondition{
+							{Type: "ArbitraryCondition", Status: v1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo-unscheduled-succeeded",priority="",resource="cpu",scheduler="",unit="cores"} 1
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo-pending",priority="",resource="cpu",scheduler="",unit="cores"} 1
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo-unknown",priority="",resource="cpu",scheduler="",unit="cores"} 1
+				`,
+		},
+		{
+			name: "zero resource should be excluded",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":                    resource.MustParse("0"),
+									"custom":                 resource.MustParse("0"),
+									"test.com/custom-metric": resource.MustParse("0"),
+								},
+								Limits: v1.ResourceList{
+									"cpu":                    resource.MustParse("0"),
+									"custom":                 resource.MustParse("0"),
+									"test.com/custom-metric": resource.MustParse("0"),
+								},
+							}},
+						},
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":                    resource.MustParse("0"),
+									"custom":                 resource.MustParse("0"),
+									"test.com/custom-metric": resource.MustParse("0"),
+								},
+								Limits: v1.ResourceList{
+									"cpu":                    resource.MustParse("0"),
+									"custom":                 resource.MustParse("0"),
+									"test.com/custom-metric": resource.MustParse("0"),
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: ``,
+		},
+		{
+			name: "optional field labels",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						SchedulerName: "default-scheduler",
+						Priority:      int32p(0),
+						NodeName:      "node-one",
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="0",resource="cpu",scheduler="default-scheduler",unit="cores"} 1
+				`,
+		},
+		{
+			name: "init containers and regular containers when initialized",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						InitContainers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("2"),
+									"custom": resource.MustParse("3"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("1G"),
+									"custom": resource.MustParse("5"),
+								},
+							}},
+						},
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("1"),
+									"custom": resource.MustParse("0"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("2G"),
+									"custom": resource.MustParse("6"),
+								},
+							}},
+						},
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 6
+				kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2e+09
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 2
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 3
+				`,
+		},
+		{
+			name: "init containers and regular containers when initializing",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						NodeName: "node-one",
+						InitContainers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("2"),
+									"custom": resource.MustParse("3"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("1G"),
+									"custom": resource.MustParse("5"),
+								},
+							}},
+						},
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("1"),
+									"custom": resource.MustParse("0"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("2G"),
+									"custom": resource.MustParse("6"),
+								},
+							}},
+						},
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{Type: "AnotherCondition", Status: v1.ConditionUnknown},
+							{Type: v1.PodInitialized, Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 6
+				kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2e+09
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 2
+				kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 3
+				`,
+		},
+		{
+			name: "aggregate container requests and limits",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"cpu": resource.MustParse("1")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("2")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"memory": resource.MustParse("1G")},
+								Limits:   v1.ResourceList{"memory": resource.MustParse("2G")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"cpu": resource.MustParse("0.5")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("1.25")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{"memory": resource.MustParse("2G")},
+							}},
+						},
+					},
+				},
+			},
+			expected: `            
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 3.25
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 4e+09
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1.5
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 1e+09
+				`,
+		},
+		{
+			name: "overhead added to requests and limits",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						Overhead: v1.ResourceList{
+							"cpu":    resource.MustParse("0.25"),
+							"memory": resource.MustParse("0.75G"),
+							"custom": resource.MustParse("0.5"),
+						},
+						InitContainers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("2"),
+									"custom": resource.MustParse("3"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("1G"),
+									"custom": resource.MustParse("5"),
+								},
+							}},
+						},
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"cpu":    resource.MustParse("1"),
+									"custom": resource.MustParse("0"),
+								},
+								Limits: v1.ResourceList{
+									"memory": resource.MustParse("2G"),
+									"custom": resource.MustParse("6"),
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="custom",scheduler="",unit=""} 6.5
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2.75e+09
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 2.25
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="custom",scheduler="",unit=""} 3.5
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 7.5e+08
+				`,
+		},
+		{
+			name: "units for standard resources",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"storage":           resource.MustParse("5"),
+									"ephemeral-storage": resource.MustParse("6"),
+								},
+								Limits: v1.ResourceList{
+									"hugepages-x":            resource.MustParse("1"),
+									"hugepages-":             resource.MustParse("2"),
+									"attachable-volumes-aws": resource.MustParse("3"),
+									"attachable-volumes-":    resource.MustParse("4"),
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="attachable-volumes-",scheduler="",unit="integer"} 4
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="attachable-volumes-aws",scheduler="",unit="integer"} 3
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="hugepages-",scheduler="",unit="bytes"} 2
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="hugepages-x",scheduler="",unit="bytes"} 1
+				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="ephemeral-storage",scheduler="",unit="bytes"} 6
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="storage",scheduler="",unit="bytes"} 5
+				`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewPodResourcesMetricsCollector(&fakePodLister{pods: tt.pods})
+			registry := metrics.NewKubeRegistry()
+			registry.CustomMustRegister(c)
+			err := testutil.GatherAndCompare(registry, strings.NewReader(tt.expected))
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	math "math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -439,6 +440,36 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 		number, exponent := rounded.AsCanonicalBase1024Bytes(out)
 		suffix, _ := quantitySuffixer.constructBytes(2, exponent*10, format)
 		return number, suffix
+	}
+}
+
+// AsApproximateFloat64 returns a float64 representation of the quantity which may
+// lose precision. If the value of the quantity is outside the range of a float64
+// +Inf/-Inf will be returned.
+func (q *Quantity) AsApproximateFloat64() float64 {
+	var base float64
+	var exponent int
+	if q.d.Dec != nil {
+		base, _ = big.NewFloat(0).SetInt(q.d.Dec.UnscaledBig()).Float64()
+		exponent = int(-q.d.Dec.Scale())
+	} else {
+		base = float64(q.i.value)
+		exponent = int(q.i.scale)
+	}
+	if exponent == 0 {
+		return base
+	}
+
+	// multiply by the appropriate exponential scale
+	switch q.Format {
+	case DecimalExponent, DecimalSI:
+		return base * math.Pow10(exponent)
+	default:
+		// fast path for exponents that can fit in 64 bits
+		if exponent > 0 && exponent < 7 {
+			return base * float64(int64(1)<<(exponent*10))
+		}
+		return base * math.Pow(2, float64(exponent*10))
 	}
 }
 


### PR DESCRIPTION
Testing only, adds support for pod resource metrics in the scheduler
for early evaluation and verification against OpenShift use cases.
Will be part of 1.20 as alpha and expected to be part of rebase.