### PR TITLE
Bug 1881225: UPSTREAM: carry: Fix panic in GenericAPIServer.installReadyz function 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -343,6 +343,8 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		// Default to treating watch as a long-running operation
 		// Generic API servers have no inherent long-running subresources
 		LongRunningFunc: genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString()),
+
+		hasBeenReadyCh: make(chan struct{}),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
@@ -101,6 +101,11 @@ func WithLateConnectionFilter(handler http.Handler) http.Handler {
 func WithNonReadyRequestLogging(handler http.Handler, hasBeenReadyCh <-chan struct{}) http.Handler {
 	var nonReadyRequestReceived atomic.Bool
 
+	if hasBeenReadyCh == nil {
+		klog.Error("WithNonReadyRequestLogging: hasBeenReadyCh is nil, not setting up the handler")
+		return handler
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if hasBeenReadyCh != nil {
 			select {


### PR DESCRIPTION
We are seeing the following panic: 
```
E0921 17:27:50.817978      17 wrap.go:39] apiserver panic'd on GET /readyz?verbose=1
http2: panic serving 35.243.152.199:2279: close of nil channel
```
`hasBeenReadyCh` is always nil, I don't see it being created anywhere. 

Panic originates from here
https://github.com/openshift/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/healthz.go#L106