### PR TITLE
Bug 1877793: Force releasing the lock on exit for KS

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -212,6 +212,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 				}
 			},
 		}
+		cc.LeaderElection.ReleaseOnCancel = true
 		leaderElector, err := leaderelection.NewLeaderElector(*cc.LeaderElection)
 		if err != nil {
 			return fmt.Errorf("couldn't create leader elector: %v", err)


### PR DESCRIPTION
I missed forcing release on cancel for KS in the hurry last time. Just noticed it while backporting.

/cc @soltysh @deads2k 