### PR TITLE
Bug 1881225: UPSTREAM: <carry>: apiserver: create hasBeenReadyCh channel

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -343,6 +343,8 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		// Default to treating watch as a long-running operation
 		// Generic API servers have no inherent long-running subresources
 		LongRunningFunc: genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString()),
+
+		hasBeenReadyCh: make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
Builds on https://github.com/openshift/kubernetes/pull/364.