### PR TITLE
suppresses errConnKilled error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -33,10 +33,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestGetClientIP(t *testing.T) {
@@ -401,8 +401,8 @@ func TestConnectWithRedirects(t *testing.T) {
 			}
 
 			netdialer := &net.Dialer{
-				Timeout:   wait.ForeverTestTimeout,
-				KeepAlive: wait.ForeverTestTimeout,
+				Timeout:   time.Second * 30,
+				KeepAlive: time.Second * 30,
 			}
 			dialer := DialerFunc(func(req *http.Request) (net.Conn, error) {
 				conn, err := netdialer.Dial("tcp", req.URL.Host)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 
 	"strings"
@@ -454,4 +455,24 @@ func ChooseBindAddressForInterface(intfName string) (net.IP, error) {
 		}
 	}
 	return nil, fmt.Errorf("unable to select an IP from %s network interface", intfName)
+}
+
+// AbortHandlerErrors holds a list of errors that signal the API server to abort and HTTP handler.
+// Errors on that list have are handled differently,
+// for example they suppress logging of a stack trace to the server's error log
+var AbortHandlerErrors = []error{http.ErrAbortHandler}
+
+// IsAbortHandlerError determines if the given error is on the AbortHandlerErrors list.
+// Errors on that list signal the API server to abort an HTTP handler and have special treatment.
+// For example they suppress logging of a stack trace to the server's error log
+func IsAbortHandlerError(rawError interface{}) bool {
+	if rawError == nil {
+		return false
+	}
+	for _, knownAbortError := range AbortHandlerErrors {
+		if rawError == knownAbortError {
+			return true
+		}
+	}
+	return false
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -18,11 +18,11 @@ package runtime
 
 import (
 	"fmt"
-	"net/http"
 	"runtime"
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/klog/v2"
 )
 
@@ -59,7 +59,7 @@ func HandleCrash(additionalHandlers ...func(interface{})) {
 
 // logPanic logs the caller tree when a panic occurs (except in the special case of http.ErrAbortHandler).
 func logPanic(r interface{}) {
-	if r == http.ErrAbortHandler {
+	if net.IsAbortHandlerError(r) {
 		// honor the http.ErrAbortHandler sentinel panic value:
 		//   ErrAbortHandler is a sentinel panic value to abort a handler.
 		//   While any panic from ServeHTTP aborts the response to the client,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -37,6 +37,7 @@ import (
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
@@ -225,7 +226,7 @@ func finishRequest(timeout time.Duration, fn resultFunc) (result runtime.Object,
 			panicReason := recover()
 			if panicReason != nil {
 				// do not wrap the sentinel ErrAbortHandler panic value
-				if panicReason != http.ErrAbortHandler {
+				if !net.IsAbortHandlerError(panicReason) {
 					// Same as stdlib http server code. Manually allocate stack
 					// trace buffer size to prevent excessively large logs
 					const size = 64 << 10

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -19,16 +19,16 @@ package filters
 import (
 	"net/http"
 
-	"k8s.io/klog/v2"
-
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/server/httplog"
+	"k8s.io/klog/v2"
 )
 
 // WithPanicRecovery wraps an http Handler to recover and log panics (except in the special case of http.ErrAbortHandler panics, which suppress logging).
 func WithPanicRecovery(handler http.Handler, isTerminating func() bool) http.Handler {
 	return withPanicRecovery(handler, func(w http.ResponseWriter, req *http.Request, err interface{}) {
-		if err == http.ErrAbortHandler {
+		if net.IsAbortHandlerError(err) {
 			// honor the http.ErrAbortHandler sentinel panic value:
 			//   ErrAbortHandler is a sentinel panic value to abort a handler.
 			//   While any panic from ServeHTTP aborts the response to the client,


### PR DESCRIPTION
`errConnKilled` is thrown when a response has been already sent to the client and the handler timed out
in that case, the changes introduced in this PR  will suppress logging of a stack trace to the server's error log.


Applies to OpenShiftAPI server and OAuthAPIServer as well.
I will open an upstream PR.