### PR TITLE
Bug 1866836: UPSTREAM: 95009: Remove ext2 + ext3 tests

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -378,9 +378,6 @@ func InitISCSIDriver() testsuites.TestDriver {
 			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
-				"ext2",
-				// TODO: fix iSCSI driver can work with ext3
-				//"ext3",
 				"ext4",
 			),
 			TopologyKeys: []string{v1.LabelHostname},
@@ -560,9 +557,6 @@ func InitRbdDriver() testsuites.TestDriver {
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
-				"ext2",
-				// TODO: fix rbd driver can work with ext3
-				//"ext3",
 				"ext4",
 			),
 			Capabilities: map[testsuites.Capability]bool{
@@ -1076,7 +1070,6 @@ func InitCinderDriver() testsuites.TestDriver {
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
-				"ext3",
 			),
 			TopologyKeys: []string{v1.LabelZoneFailureDomain},
 			Capabilities: map[testsuites.Capability]bool{
@@ -1515,7 +1508,6 @@ func InitAzureDiskDriver() testsuites.TestDriver {
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
-				"ext3",
 				"ext4",
 				"xfs",
 			),
@@ -1656,8 +1648,6 @@ func InitAwsDriver() testsuites.TestDriver {
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
-				"ext2",
-				"ext3",
 				"ext4",
 				"xfs",
 				"ntfs",
@@ -1813,8 +1803,6 @@ var (
 	localVolumeSupportedFsTypes        = map[utils.LocalVolumeType]sets.String{
 		utils.LocalVolumeBlock: sets.NewString(
 			"", // Default fsType
-			"ext2",
-			"ext3",
 			"ext4",
 			//"xfs", disabled see issue https://github.com/kubernetes/kubernetes/issues/74095
 		),


### PR DESCRIPTION
Testing with the default FS (ext4) is IMO enough, ext2/ext3 does not add much
value. It's handled by the same kernel module anyway.

Leave ext2/ext3 only in GCE PD which is tested in kubernetes/kubernetes CI
jobs regularly to catch regressions.

@openshift/storage 