### PR TITLE
Bug 1879837: UPSTREAM: 94986: drop managed fields from audit entries

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request_test.go
@@ -18,11 +18,17 @@ package audit
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
-
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogAnnotation(t *testing.T) {
@@ -53,4 +59,167 @@ func TestMaybeTruncateUserAgent(t *testing.T) {
 	}
 	req.Header.Set("User-Agent", ua)
 	assert.NotEqual(t, ua, maybeTruncateUserAgent(req))
+}
+
+func TestCopyWithoutManagedFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   runtime.Object
+		expected runtime.Object
+	}{
+		{
+			name:   "object specified is not a meta.Accessor or a list",
+			object: &metav1.Status{},
+		},
+		{
+			name: "object specified is a meta.Accessor and has managed fields",
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+						{Manager: "b", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+		},
+		{
+			name: "object specified is a list and its items have managed fields",
+			object: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "ns1",
+							ManagedFields: []metav1.ManagedFieldsEntry{
+								{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+								{Manager: "b", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "ns2",
+							ManagedFields: []metav1.ManagedFieldsEntry{
+								{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+								{Manager: "d", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "ns1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "ns2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "object specified is a Table and objects in its rows have managed fields",
+			object: &metav1.Table{
+				Rows: []metav1.TableRow{
+					{
+						Object: runtime.RawExtension{
+							Object: &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "foo",
+									Namespace: "ns1",
+									ManagedFields: []metav1.ManagedFieldsEntry{
+										{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+										{Manager: "b", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: runtime.RawExtension{
+							Object: &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "bar",
+									Namespace: "ns2",
+									ManagedFields: []metav1.ManagedFieldsEntry{
+										{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+										{Manager: "d", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{Time: time.Now()}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &metav1.Table{
+				Rows: []metav1.TableRow{
+					{
+						Object: runtime.RawExtension{
+							Object: &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "foo",
+									Namespace: "ns1",
+								},
+							},
+						},
+					},
+					{
+						Object: runtime.RawExtension{
+							Object: &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "bar",
+									Namespace: "ns2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objectGot, ok, err := copyWithoutManagedFields(test.object)
+
+			if test.expected == nil {
+				if err != nil {
+					t.Errorf("expected error to be nil, but got %v", err)
+				}
+				if ok {
+					t.Error("expected ok to be false, but got true")
+				}
+				if objectGot != nil {
+					t.Errorf("expected the object returned to be nil, but got %v", objectGot)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected error to be nil, but got %v", err)
+			}
+			if !ok {
+				t.Error("expected ok to be true, but got false")
+			}
+			if !reflect.DeepEqual(test.expected, objectGot) {
+				t.Errorf("expected and actual do not match, diff: %s", cmp.Diff(test.expected, objectGot))
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
The `ManagedFields` of an object in the audit entries are not very useful and it consumes storage space pretty quickly especially in a big cluster under load.
drop the managed fields of the objects from the audit entries when we are logging request and response bodies.

**Does this PR introduce a user-facing change?**:

```release-note
ManagedFields of request and response bodies are discarded in audit logs
```
