### PR TITLE
Bug 1873043: Stop annotating origin tests with [Suite:openshift]

### DIFF
--- a/openshift-hack/e2e/annotate/annotate.go
+++ b/openshift-hack/e2e/annotate/annotate.go
@@ -228,9 +228,6 @@ func (r *ginkgoTestRenamer) generateRename(name, parentName string, node types.T
 			name += " [Suite:openshift/conformance/parallel]"
 		}
 	}
-	if isGoModulePath(node.CodeLocation().FileName, "github.com/openshift/origin", "test") && !strings.Contains(name, "[Suite:openshift") {
-		name += " [Suite:openshift]"
-	}
 	if isGoModulePath(node.CodeLocation().FileName, "k8s.io/kubernetes", "test/e2e") {
 		name += " [Suite:k8s]"
 	}


### PR DESCRIPTION
The detection logic was error-prone (different results based on the repo existing in GOPATH vs not) and whether a test comes from origin can be inferred from the absence of the `[Suite:k8s]` tag.
