### PR TITLE
Bug 1881144: UPSTREAM: 95003: Fail a test on pre-provisioned Cinder volume deletion error

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1184,6 +1184,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 }
 
 func (v *cinderVolume) DeleteVolume() {
+	id := v.volumeID
 	name := v.volumeName
 
 	// Try to delete the volume for several seconds - it takes
@@ -1192,16 +1193,23 @@ func (v *cinderVolume) DeleteVolume() {
 	var err error
 	timeout := time.Second * 120
 
-	framework.Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
+	framework.Logf("Waiting up to %v for removal of cinder volume %s / %s", timeout, id, name)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
-		output, err = exec.Command("cinder", "delete", name).CombinedOutput()
+		output, err = exec.Command("cinder", "delete", id).CombinedOutput()
 		if err == nil {
-			framework.Logf("Cinder volume %s deleted", name)
+			framework.Logf("Cinder volume %s deleted", id)
 			return
 		}
-		framework.Logf("Failed to delete volume %s: %v", name, err)
+		framework.Logf("Failed to delete volume %s / %s: %v\n%s", id, name, err, string(output))
 	}
-	framework.Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
+	// Timed out, try to get "cinder show <volume>" output for easier debugging
+	showOutput, showErr := exec.Command("cinder", "show", id).CombinedOutput()
+	if showErr != nil {
+		framework.Logf("Failed to show volume %s / %s: %v\n%s", id, name, showErr, string(showOutput))
+	} else {
+		framework.Logf("Volume %s / %s:\n%s", id, name, string(showOutput))
+	}
+	framework.Failf("Failed to delete pre-provisioned volume %s / %s: %v\n%s", id, name, err, string(output[:]))
 }
 
 // GCE


### PR DESCRIPTION
This should stop leaking Cinder volumes in tests as a side-effect.

cc @storage