### PR TITLE
check to see if the kubelet's kubeclient get indicates that it is abo…

### DIFF
--- a/pkg/kubelet/somethingugly/who-did-what.go
+++ b/pkg/kubelet/somethingugly/who-did-what.go
@@ -1,0 +1,78 @@
+// this is ugly, no question, but it's a very easy way to track who did what to what
+package somethingugly
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type action struct {
+	dumpData bool
+
+	when     time.Time
+	ns       string
+	name     string
+	oldPhase v1.PodPhase
+	newPhase v1.PodPhase
+}
+
+func (a action) String() string {
+	return a.ns + "/" + a.name + " " + a.when.Format(time.StampMilli) + " old=\"" + string(a.oldPhase) + "\" new=\"" + string(a.newPhase) + "\""
+}
+
+// give ourselves some slack to handle storms
+var actionCh = make(chan action, 1000)
+
+var actionsByPod = map[string][]action{}
+
+func init() {
+	go consumeActions()
+}
+
+func ChangePhase(ns, name string, oldPhase, newPhase v1.PodPhase) {
+	actionCh <- action{
+		dumpData: false,
+		when:     time.Now(),
+		ns:       ns,
+		name:     name,
+		oldPhase: oldPhase,
+		newPhase: newPhase,
+	}
+}
+
+func Dump(ns, name string) {
+	actionCh <- action{
+		dumpData: true,
+		ns:       ns,
+		name:     name,
+	}
+}
+
+func getKey(in action) string {
+	return fmt.Sprintf("%v/%v", in.ns, in.name)
+}
+
+// single threaded so I don't have to money with locks
+func consumeActions() {
+	for {
+		currAction := <-actionCh
+
+		// we want to see data for a particular key
+		if currAction.dumpData {
+			actions := actionsByPod[getKey(currAction)]
+			for _, currDisplay := range actions {
+				fmt.Printf("   #### %v\n", currDisplay)
+			}
+			continue
+		}
+
+		// see if we can get away without cleaning up the lists.  I think we only have a few thousand pods in e2e and these are small objects
+		actionsByPod[getKey(currAction)] = append(actionsByPod[getKey(currAction)], currAction)
+
+		if false {
+			break
+		}
+	}
+}


### PR DESCRIPTION
…ut to move phases back in time

If the kubelet sees the difference (likely since it's in a patch), then the apiserver is returning proper data and something is moving kubelet status back in time.  This output will include timestamps so we can see if this likely due to some kind of race (sub second) or a coding error (more than a second).