### PR TITLE
WIP: UPSTREAM: golang/x/net: 74: http2: add configuration options when constructing http2 transport

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -33,6 +33,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -132,7 +133,8 @@ func SetTransportDefaults(t *http.Transport) *http.Transport {
 	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
 		klog.Infof("HTTP2 has been explicitly disabled")
 	} else if allowsHTTP2(t) {
-		if err := http2.ConfigureTransport(t); err != nil {
+		o := &http2.TransportOptions{ReadIdleTimeout: 10 * time.Second, PingTimeout: 10 * time.Second}
+		if err := http2.ConfigureTransportWithOptions(t, o); err != nil {
 			klog.Warningf("Transport failed http2 configuration: %v", err)
 		}
 	}


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1873114

Trying to test if upstream PR fixes the bug where NIC resets cause kubelet API server connection to break.

@smarterclayton @russellb 