### PR TITLE
UPSTREAM: <carry>: wrap termCh and graceful termination in a select

### DIFF
--- a/cmd/watch-termination/main.go
+++ b/cmd/watch-termination/main.go
@@ -131,8 +131,11 @@ func run() int {
 
 		if *gracefulTerminatioPeriod > 2*time.Second {
 			go func() {
-				<-termCh
-				<-time.After(*gracefulTerminatioPeriod - 2*time.Second)
+				select {
+				case <-termCh:
+					return
+				case <-time.After(*gracefulTerminatioPeriod - 2*time.Second):
+				}
 
 				deleteLockOnce.Do(func() {
 					klog.Infof("Graceful termination time nearly passed and kube-apiserver has still not terminated. Deleting termination lock file %q to avoid a false positive.", *terminationLock)


### PR DESCRIPTION
The go routine has two channels... termCh which is waiting on a close event, and the timeout within time.After. Both channels are being running serially, when they should be watched in parallel (with a select) to either return early after a successful close, or fall through on a timer expiration.

/cc @sttts @deads2k @sjenning 