### PR TITLE
bug 1888663: wait for oauth-apiserver accessibility

### DIFF
--- a/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -80,7 +80,8 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 	// END HANDLER CHAIN
 
 	openshiftAPIServiceReachabilityCheck := newOpenshiftAPIServiceReachabilityCheck()
-	genericConfig.ReadyzChecks = append(genericConfig.ReadyzChecks, openshiftAPIServiceReachabilityCheck)
+	oauthAPIServiceReachabilityCheck := newOAuthPIServiceReachabilityCheck()
+	genericConfig.ReadyzChecks = append(genericConfig.ReadyzChecks, openshiftAPIServiceReachabilityCheck, oauthAPIServiceReachabilityCheck)
 
 	genericConfig.AddPostStartHookOrDie("openshift.io-startkubeinformers", func(context genericapiserver.PostStartHookContext) error {
 		go openshiftInformers.Start(context.StopCh)
@@ -88,6 +89,10 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 	})
 	genericConfig.AddPostStartHookOrDie("openshift.io-openshift-apiserver-reachable", func(context genericapiserver.PostStartHookContext) error {
 		go openshiftAPIServiceReachabilityCheck.checkForConnection(context)
+		return nil
+	})
+	genericConfig.AddPostStartHookOrDie("openshift.io-oauth-apiserver-reachable", func(context genericapiserver.PostStartHookContext) error {
+		go oauthAPIServiceReachabilityCheck.checkForConnection(context)
 		return nil
 	})
 	enablement.AppendPostStartHooksOrDie(genericConfig)


### PR DESCRIPTION
This has impacts on z-stream upgrade availability.  We added an oauth-apiserver as part of a transition for keycloak and other external authentication providers.  This change provides logic for waiting on SDN routability to those pods the same as we did for the openshift-apiserver.  We have seen in upgrade logs that there is meaningful time that we have to wait.

/hold

holding so we can see the output in the log showing we made contact with oauth APIs.

/cherrypick release-4.6