### PR TITLE
Bug 1889094: leaking secret credentials for vSphere

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1500,7 +1500,7 @@ func (vs *VSphere) SecretAdded(obj interface{}) {
 		return
 	}
 
-	klog.V(4).Infof("secret added: %+v", obj)
+	klog.V(4).Infof("refreshing node cache for secret: %s/%s", secret.Namespace, secret.Name)
 	vs.refreshNodesForSecretChange()
 }
 
@@ -1524,7 +1524,7 @@ func (vs *VSphere) SecretUpdated(obj interface{}, newObj interface{}) {
 		return
 	}
 
-	klog.V(4).Infof("secret updated: %+v", newObj)
+	klog.V(4).Infof("refreshing node cache for secret: %s/%s", secret.Namespace, secret.Name)
 	vs.refreshNodesForSecretChange()
 }
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kubernetes/kubernetes/pull/95241 which mitigates the problem described in https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8563 (also https://sysdig.com/blog/cve-2020-8563-vsphere-credentials-cloud-controller-manager/) 

vSphere credentials will no longer be shown at a high kubelet verbosity - https://github.com/openshift/machine-config-operator/blob/master/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml#L13