### PR TITLE
Bug 1889891: UPSTREAM: 94774: Fix misusage of RLock in timeCache lru.Cache.Get()

### DIFF
--- a/pkg/kubelet/time_cache.go
+++ b/pkg/kubelet/time_cache.go
@@ -27,7 +27,7 @@ import (
 
 // timeCache stores a time keyed by uid
 type timeCache struct {
-	lock  sync.RWMutex
+	lock  sync.Mutex
 	cache *lru.Cache
 }
 
@@ -53,8 +53,8 @@ func (c *timeCache) Remove(uid types.UID) {
 }
 
 func (c *timeCache) Get(uid types.UID) (time.Time, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	value, ok := c.cache.Get(uid)
 	if !ok {
 		return time.Time{}, false


### PR DESCRIPTION
Backports 94774

```
Lru's Get() method also updates the least recent usage information. So, we should not use RLock() and even RWLock here.
An alternative fix is just using github.com/hashicorp/golang-lru, but that will introduce more diffs. If that is the better fix, I can also do that.
```

Ref: https://github.com/kubernetes/kubernetes/pull/94774