### PR TITLE
UPSTREAM: 95719: Add plugin name and volume mode to PV metrics

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -10343,6 +10343,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC": "should create none metrics for pvc controller before creating any PV or PVC [Suite:openshift/conformance/serial] [Suite:k8s]",
 
+	"[Top Level] [sig-storage] [Serial] Volume metrics PVController should create total pv count metrics for with plugin and volume mode labels after creating pv": "should create total pv count metrics for with plugin and volume mode labels after creating pv [Suite:openshift/conformance/serial] [Suite:k8s]",
+
 	"[Top Level] [sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only": "should create unbound pv count metrics for pvc controller after creating pv only [Suite:openshift/conformance/serial] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only": "should create unbound pvc count metrics for pvc controller after creating pvc only [Suite:openshift/conformance/serial] [Suite:k8s]",

--- a/pkg/controller/volume/persistentvolume/metrics/BUILD
+++ b/pkg/controller/volume/persistentvolume/metrics/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -313,7 +313,7 @@ func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
 	go wait.Until(ctrl.volumeWorker, time.Second, stopCh)
 	go wait.Until(ctrl.claimWorker, time.Second, stopCh)
 
-	metrics.Register(ctrl.volumes.store, ctrl.claims)
+	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
 
 	<-stopCh
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The PV Controller contains pv_collector_(un)bound_pv_count metrics that count nubmer of PVs by the StorageName. The StorageName is however not that important information when monitoring larger number of clusters since it doesn't really determine the type of storage. The PR makes this metric more informative by adding also the plugin name and volume mode to the metric.

**Does this PR introduce a user-facing change?**:

```release-note
There is a new pv_collector_total_pv_count metric that counts persistent volumes by the volume plugin name and volume mode.
```