### PR TITLE
Bug 1891518: UPSTREAM: <carry>: maintains OpenShift specific ResourceQuota evaluators

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -427,6 +427,9 @@ func startResourceQuotaController(ctx ControllerContext) (http.Handler, bool, er
 	listerFuncForResource := generic.ListerFuncForResourceFunc(ctx.InformerFactory.ForResource)
 	quotaConfiguration := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
 
+	quotaEvaluators := quotaConfiguration.Evaluators()
+	quotaEvaluators = append(quotaEvaluators, openShiftResourceQuotaEvaluators(listerFuncForResource)...)
+
 	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
 		QuotaClient:               resourceQuotaControllerClient.CoreV1(),
 		ResourceQuotaInformer:     ctx.InformerFactory.Core().V1().ResourceQuotas(),
@@ -436,7 +439,7 @@ func startResourceQuotaController(ctx ControllerContext) (http.Handler, bool, er
 		DiscoveryFunc:             discoveryFunc,
 		IgnoredResourcesFunc:      quotaConfiguration.IgnoredResources,
 		InformersStarted:          ctx.InformersStarted,
-		Registry:                  generic.NewRegistry(quotaConfiguration.Evaluators()),
+		Registry:                  generic.NewRegistry(quotaEvaluators),
 	}
 	if resourceQuotaControllerClient.CoreV1().RESTClient().GetRateLimiter() != nil {
 		if err := ratelimiter.RegisterMetricAndTrackRateLimiterUsage("resource_quota_controller", resourceQuotaControllerClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {

--- a/cmd/kube-controller-manager/app/patch_core.go
+++ b/cmd/kube-controller-manager/app/patch_core.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/quota/v1"
+	"k8s.io/kubernetes/pkg/quota/v1/generic"
+
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+var legacyObjectCountAliases = map[schema.GroupVersionResource]corev1.ResourceName{
+	imagev1.GroupVersion.WithResource("imagestreams"): imagev1.ResourceImageStreams,
+}
+
+// openShiftResourceQuotaEvaluators returns OpenShift specific quota evaluators
+func openShiftResourceQuotaEvaluators(listerFuncForResource quota.ListerForResourceFunc) []quota.Evaluator {
+	result := []quota.Evaluator{}
+
+	// these evaluators require an alias for backwards compatibility
+	for gvr, alias := range legacyObjectCountAliases {
+		result = append(result,
+			generic.NewObjectCountEvaluator(gvr.GroupResource(), generic.ListResourceUsingListerFunc(listerFuncForResource, gvr), alias))
+	}
+
+	return result
+}


### PR DESCRIPTION
for backward compatability we need to maintain "openshift.io/imagestreams" alias for "count/imagestreams.image.openshift.io"
to dynamically update quota for imagestreams resources.
