### PR TITLE
Bug 1887278: UPSTREAM: 95236: vsphere: improve logging message on node cache refresh event

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1512,7 +1512,7 @@ func (vs *VSphere) SecretAdded(obj interface{}) {
 		return
 	}
 
-	klog.V(4).Infof("secret added: %+v", obj)
+	klog.V(4).Infof("refreshing node cache for secret: %s/%s", secret.Namespace, secret.Name)
 	vs.refreshNodesForSecretChange()
 }
 
@@ -1536,7 +1536,7 @@ func (vs *VSphere) SecretUpdated(obj interface{}, newObj interface{}) {
 		return
 	}
 
-	klog.V(4).Infof("secret updated: %+v", newObj)
+	klog.V(4).Infof("refreshing node cache for secret: %s/%s", secret.Namespace, secret.Name)
 	vs.refreshNodesForSecretChange()
 }
 


### PR DESCRIPTION
To be able to backport this to 4.6 I need to land this in master first. 

/assign @tnozicka 