### PR TITLE
Bug 1894645: Fix cinder crash

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -281,7 +281,7 @@ func (os *OpenStack) setConfigFromSecret() error {
 
 	secret, err := os.secretLister.Secrets(os.secretNamespace).Get(os.secretName)
 	if err != nil {
-		klog.Errorf("Cannot get secret %s in namespace %s. error: %q", os.secretName, os.secretNamespace, err)
+		klog.Errorf("cannot get secret %s in namespace %s. error: %q", os.secretName, os.secretNamespace, err)
 		return err
 	}
 
@@ -290,11 +290,11 @@ func (os *OpenStack) setConfigFromSecret() error {
 
 		err = gcfg.ReadStringInto(cfg, string(content))
 		if err != nil {
-			return fmt.Errorf("cannot parse data from the secret")
+			return fmt.Errorf("cannot parse data from the secret: %s", err)
 		}
 		provider, err := newProvider(*cfg)
 		if err != nil {
-			return fmt.Errorf("cannot initialize cloud provider using data from the secret")
+			return fmt.Errorf("cannot initialize cloud provider using data from the secret: %s", err)
 		}
 		os.provider = provider
 		os.region = cfg.Global.Region
@@ -312,9 +312,10 @@ func (os *OpenStack) ensureCloudProviderWasInitialized() error {
 
 	if os.secretName != "" && os.secretNamespace != "" {
 		err := os.setConfigFromSecret()
-		if err == nil {
-			return nil
+		if err != nil {
+			return fmt.Errorf("cloud provider is not initialized: %s", err)
 		}
+		return nil
 	}
 
 	return fmt.Errorf("cloud provider is not initialized")

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -876,6 +876,10 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 }
 
 func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
+	if err := os.ensureCloudProviderWasInitialized(); err != nil {
+		return nil, err
+	}
+
 	bsVersion := ""
 	if forceVersion == "" {
 		bsVersion = os.bsOpts.BSVersion


### PR DESCRIPTION
OpenStack cloud provider in kube-controller-manager should check that it's initialized before it's dereferenced.

The second patch is optional and makes sure that errors in parsing clouds.conf are actually displayed. Otherwise the cluster admin sees "cloud provider is not initialized", which is not really useful.

**Beware: the second patch can be merged only if it can't ever reveal user secrets.** Please review carefully. It's better to remove it if we're not sure.

/assign @Fedosin 