### PR TITLE
Bug 1870337: UPSTREAM: 96310: PV e2e: fix race in NFS recycling test

### DIFF
--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -307,6 +307,11 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 				framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
 				framework.Logf("Pod exited without failure; the volume has been recycled.")
+
+				// Delete the PVC and wait for the recycler to finish before the NFS server gets shutdown during cleanup.
+				framework.Logf("Removing second PVC, waiting for the recycler to finish before cleanup.")
+				framework.ExpectNoError(e2epv.DeletePVCandValidatePV(c, ns, pvc, pv, v1.VolumeAvailable))
+				pvc = nil
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
The e2e test for NFS volumes using Recycle reclaim policy may leak recycler pods due to a race in the cleanup code. The test uses two pods with two PVCs claiming the same PV with Recycle policy, the second pod then verifies the PV was properly wiped. The test also uses its own NFS server pod that gets shutdown after the test finishes. The issue is that the cleanup code also deletes the second PVC and therefore triggers the recycler pod creation again. It may happen that the NFS server is shut down before the recycler finishes and since the volume can't be written to or unmounted by the recycler pod it remains hung.

This patch adds one more delete-and-wait cycle at the end of the test to ensure the PV was recycled before it's safe to shutdown the NFS server.

```release-note
NONE
```