### PR TITLE
UPSTREAM: 95252: Kube-proxy: Perf-fix: Shrink INPUT chain 

### DIFF
--- a/cmd/kube-proxy/app/server_patch.go
+++ b/cmd/kube-proxy/app/server_patch.go
@@ -1,0 +1,9 @@
+package app
+
+import (
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+)
+
+func (o *Options) GetConfig() *kubeproxyconfig.KubeProxyConfiguration {
+	return o.config
+}

--- a/pkg/proxy/iptables/proxier_openshift.go
+++ b/pkg/proxy/iptables/proxier_openshift.go
@@ -1,0 +1,13 @@
+package iptables
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/pkg/proxy/userspace/proxier_openshift.go
+++ b/pkg/proxy/userspace/proxier_openshift.go
@@ -1,0 +1,13 @@
+package userspace
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}


### PR DESCRIPTION
Need to rebase sdn on this branch.
This PR has three commits:
- UPSTREAM: 95252: Kube-proxy: Perf-fix: Shrink INPUT chain (It is for 1879607, but the bug is not linked to this patch. I'll link it to the rebase on sdn to avoid branch confusion and invalid-bug tag.)
- UPSTREAM: <carry>: kube-proxy: make wiring in kubeproxy easy until we sort out config (its a carry that gets passed on)
- UPSTREAM: <carry>: Allow low-level tweaking of proxy sync flow (its a carry that gets carried)
