### PR TITLE
Bug 1889420: Add dangling volume check for vsphere

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -311,6 +311,17 @@ func (nm *NodeManager) GetNodeDetails() ([]NodeDetails, error) {
 	return nodeDetails, nil
 }
 
+// GetNodeNames returns list of nodes that are known to vsphere cloudprovider.
+// These are typically nodes that make up k8s cluster.
+func (nm *NodeManager) GetNodeNames() []k8stypes.NodeName {
+	nodes := nm.getNodes()
+	var nodeNameList []k8stypes.NodeName
+	for _, node := range nodes {
+		nodeNameList = append(nodeNameList, k8stypes.NodeName(node.Name))
+	}
+	return nodeNameList
+}
+
 func (nm *NodeManager) refreshNodes() (errList []error) {
 	for nodeName := range nm.getNodes() {
 		nodeInfo, err := nm.getRefreshedNodeInfo(convertToK8sType(nodeName))

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1221,9 +1221,15 @@ func (vs *VSphere) DisksAreAttached(nodeVolumes map[k8stypes.NodeName][]string) 
 			}
 
 		}
+		klog.V(4).Infof("DisksAreAttached successfully executed. result: %+v", attached)
+		// There could be nodes in cluster which do not have any pods with vsphere volumes running on them
+		// such nodes won't be part of nodeVolumes map because attach-detach controller does not keep track
+		// such nodes. But such nodes may still have dangling volumes on them and hence we need to scan all the
+		// remaining nodes which weren't scanned by code previously.
+		vs.BuildMissingVolumeNodeMap(ctx)
 		// any volume which we could not verify will be removed from the map.
 		vs.vsphereVolumeMap.RemoveUnverified()
-		klog.V(4).Infof("DisksAreAttach successfully executed. result: %+v", attached)
+		klog.V(4).Infof("current node volume map is: %+v", vs.vsphereVolumeMap.volumeNodeMap)
 		return disksAttached, nil
 	}
 	requestTime := time.Now()

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/find"
@@ -606,6 +607,123 @@ func (vs *VSphere) checkDiskAttached(ctx context.Context, nodes []k8stypes.NodeN
 		vclib.VerifyVolumePathsForVMDevices(vmDevices, nodeVolumes[nodeName], convertToString(nodeName), attached)
 	}
 	return nodesToRetry, nil
+}
+
+// BuildMissingVolumeNodeMap builds a map of volumes and nodes which are not known to attach detach controller.
+// There could be nodes in cluster which do not have any pods with vsphere volumes running on them
+// such nodes won't be part of disk verification check because attach-detach controller does not keep track
+// such nodes. But such nodes may still have dangling volumes on them and hence we need to scan all the
+// remaining nodes which weren't scanned by code previously.
+func (vs *VSphere) BuildMissingVolumeNodeMap(ctx context.Context) {
+	nodeNames := vs.nodeManager.GetNodeNames()
+	// Segregate nodes according to VC-DC
+	dcNodes := make(map[string][]k8stypes.NodeName)
+
+	for _, nodeName := range nodeNames {
+		// if given node is not in node volume map
+		if !vs.vsphereVolumeMap.CheckForNode(nodeName) {
+			nodeInfo, err := vs.nodeManager.GetNodeInfo(nodeName)
+			if err != nil {
+				klog.V(4).Infof("Failed to get node info: %+v. err: %+v", nodeInfo.vm, err)
+				continue
+			}
+			vcDC := nodeInfo.vcServer + nodeInfo.dataCenter.String()
+			dcNodes[vcDC] = append(dcNodes[vcDC], nodeName)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	for _, nodeNames := range dcNodes {
+		// Start go routines per VC-DC to check disks are attached
+		wg.Add(1)
+		go func(nodes []k8stypes.NodeName) {
+			err := vs.checkNodeDisks(ctx, nodeNames)
+			if err != nil {
+				klog.Errorf("Failed to check disk attached for nodes: %+v. err: %+v", nodes, err)
+			}
+			wg.Done()
+		}(nodeNames)
+	}
+	wg.Wait()
+}
+
+func (vs *VSphere) checkNodeDisks(ctx context.Context, nodeNames []k8stypes.NodeName) error {
+	var vmList []*vclib.VirtualMachine
+	var nodeInfo NodeInfo
+	var err error
+
+	for _, nodeName := range nodeNames {
+		nodeInfo, err = vs.nodeManager.GetNodeInfo(nodeName)
+		if err != nil {
+			return err
+		}
+		vmList = append(vmList, nodeInfo.vm)
+	}
+
+	// Making sure session is valid
+	_, err = vs.getVSphereInstanceForServer(nodeInfo.vcServer, ctx)
+	if err != nil {
+		return err
+	}
+
+	// If any of the nodes are not present property collector query will fail for entire operation
+	vmMoList, err := nodeInfo.dataCenter.GetVMMoList(ctx, vmList, []string{"config.hardware.device", "name", "config.uuid"})
+	if err != nil {
+		if vclib.IsManagedObjectNotFoundError(err) {
+			klog.V(4).Infof("checkNodeDisks: ManagedObjectNotFound for property collector query for nodes: %+v vms: %+v", nodeNames, vmList)
+			// Property Collector Query failed
+			// VerifyVolumePaths per VM
+			for _, nodeName := range nodeNames {
+				nodeInfo, err := vs.nodeManager.GetNodeInfo(nodeName)
+				if err != nil {
+					return err
+				}
+				devices, err := nodeInfo.vm.VirtualMachine.Device(ctx)
+				if err != nil {
+					if vclib.IsManagedObjectNotFoundError(err) {
+						klog.V(4).Infof("checkNodeDisks: ManagedObjectNotFound for Kubernetes node: %s with vSphere Virtual Machine reference: %v", nodeName, nodeInfo.vm)
+						continue
+					}
+					return err
+				}
+				klog.V(4).Infof("Verifying Volume Paths by devices for node %s and VM %s", nodeName, nodeInfo.vm)
+				vs.vsphereVolumeMap.Add(nodeName, devices)
+			}
+			return nil
+		}
+		return err
+	}
+
+	vmMoMap := make(map[string]mo.VirtualMachine)
+	for _, vmMo := range vmMoList {
+		if vmMo.Config == nil {
+			klog.Errorf("Config is not available for VM: %q", vmMo.Name)
+			continue
+		}
+		klog.V(9).Infof("vmMoMap vmname: %q vmuuid: %s", vmMo.Name, strings.ToLower(vmMo.Config.Uuid))
+		vmMoMap[strings.ToLower(vmMo.Config.Uuid)] = vmMo
+	}
+
+	klog.V(9).Infof("vmMoMap: +%v", vmMoMap)
+
+	for _, nodeName := range nodeNames {
+		node, err := vs.nodeManager.GetNode(nodeName)
+		if err != nil {
+			return err
+		}
+		nodeUUID, err := GetNodeUUID(&node)
+		if err != nil {
+			klog.Errorf("Node Discovery failed to get node uuid for node %s with error: %v", node.Name, err)
+			return err
+		}
+		nodeUUID = strings.ToLower(nodeUUID)
+		klog.V(9).Infof("Verifying volume for node %s with nodeuuid %q: %v", nodeName, nodeUUID, vmMoMap)
+		vmMo := vmMoMap[nodeUUID]
+		vmDevices := object.VirtualDeviceList(vmMo.Config.Hardware.Device)
+		vs.vsphereVolumeMap.Add(nodeName, vmDevices)
+	}
+	return nil
 }
 
 func (vs *VSphere) GetNodeNameFromProviderID(providerID string) (string, error) {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1889420

cc @openshift/sig-storage 

The dangling volume mechanism in vsphere has one limitation though - since this code relies on verifying-volumes -as-attached feature of ADC, there must be at least one pod running with *any* vsphere/attachable volumes in the cluster.  This means that, if a cluster had only one pod with vsphere volume and that volume was attached to wrong node (i.e dangling to wrong node), then this mechanism won't work. In practice I hope, it is unlikely that we will have just one pod in the cluster and that will be with a dangling volume.