### PR TITLE
UPSTREAM: <carry>: Skip "subPath should be able to unmount" NFS test

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -8851,7 +8851,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] stress multiple pods should access different volumes repeatedly [Slow] [Serial]": "multiple pods should access different volumes repeatedly [Slow] [Serial] [Suite:k8s]",
 
-	"[Top Level] [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted": "should be able to unmount after the subpath directory is deleted [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted": "should be able to unmount after the subpath directory is deleted [Disabled:Broken] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should fail if non-existent subpath is outside the volume [Slow][LinuxOnly]": "should fail if non-existent subpath is outside the volume [Slow][LinuxOnly] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -80,6 +80,10 @@ var (
 
 			// A fix is in progress: https://github.com/openshift/origin/pull/24709
 			`Multi-AZ Clusters should spread the pods of a replication controller across zones`,
+
+			// NFS umount is broken in kernels 5.7+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1854379
+			`\[sig-storage\].*\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\].*subPath should be able to unmount after the subpath directory is deleted`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
Due to a kernel bug https://bugzilla.redhat.com/show_bug.cgi?id=1854379
in Linux 5.7+ this test fails - the bind-mounted NFS share cannot be
cleanly unmounted, gets "Stale file handle" error instead

RHCOS uses 4.18 kernel, so it doesn't affect OCP, but its blocking OKD (which uses Fedora kernel) tests and machine-os-content promotions. The test would be re-enabled once kernel is fixed in Fedora CoreOS

/kind bug
/kind failing-test

