### PR TITLE
Bug 1893972: UPSTREAM: 96144: Skip the sig-storage e2e test as early as possible

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -149,6 +149,9 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	dInfo := driver.GetDriverInfo()
 	var isSupported bool
 
+	// 0. Check with driver specific logic
+	driver.SkipUnsupportedTest(pattern)
+
 	// 1. Check if Whether volType is supported by driver from its interface
 	switch pattern.VolType {
 	case testpatterns.InlineVolume:
@@ -177,9 +180,6 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
 		e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
 	}
-
-	// 3. Check with driver specific logic
-	driver.SkipUnsupportedTest(pattern)
 }
 
 // VolumeResource is a generic implementation of TestResource that wil be able to


### PR DESCRIPTION
Speed up our e2e tests a bit by skipping tests earlier.

https://github.com/kubernetes/kubernetes/pull/96144
cc @openshift/storage 
