### PR TITLE
Bug 1893776: UPSTREAM: 96054: Allow debugging kubelet image pull times

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -203,7 +203,7 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           RuntimeOperationsDurationKey,
 			Help:           "Duration in seconds of runtime operations. Broken down by operation type.",
-			Buckets:        metrics.DefBuckets,
+			Buckets:        metrics.ExponentialBuckets(.005, 2.5, 14),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"operation_type"},


### PR DESCRIPTION
Backports https://github.com/kubernetes/kubernetes/pull/96054

Adds additional buckets to the kubelet_runtime_operations_duration_seconds metric.