### PR TITLE
Bug 1902710: UPSTREAM: 89726: Backward support for old KVM driver

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -496,6 +496,8 @@ func (os *OpenStack) GetDevicePathBySerialID(volumeID string) string {
 		fmt.Sprintf("virtio-%s", volumeID[:20]),
 		// KVM virtio-scsi
 		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID[:20]),
+		// older KVM virtio-scsi
+		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID),
 		// ESXi
 		fmt.Sprintf("wwn-0x%s", strings.Replace(volumeID, "-", "", -1)),
 	}


### PR DESCRIPTION
With newer versions of OpenStack/libvirt, the path of the attached block storage volume now contains the full volume ID when using virtio-scsi.

The problem is described in the upstream OpenStack cloud provider repository on github [1] and k8s/community [2] and was fixed already for the external cloud provider [3]. However, the fix was never merged for the in-tree cloud provider [4].

Without this change, the Cinder PVC times out attaching the storage to the node when using virtio-scsi and the in-tree cinder provisioned on OSP16.

Kubelet logs show:
Nov 30 12:38:35 mandre-psi-pub-stlh7-worker-0-b4xhh hyperkube[1868]: W1130 12:38:35.640309    1868 openstack_volumes.go:576] Failed to find device for the volumeID: "bcc21b3e-23fa-4464-844c-62506e298744"
Nov 30 12:38:35 mandre-psi-pub-stlh7-worker-0-b4xhh hyperkube[1868]: E1130 12:38:35.640319    1868 attacher.go:249] Error: could not find attached Cinder disk "bcc21b3e-23fa-4464-844c-62506e298744" (path: ""): <nil>

[1] https://github.com/kubernetes/cloud-provider-openstack/issues/852
[2] https://github.com/kubernetes/community/issues/4797
[2] https://github.com/kubernetes/cloud-provider-openstack/pull/853
[3] https://github.com/kubernetes/kubernetes/pull/89726