### PR TITLE
Bug 1770017: kubelet: do not rerun init containers if any main containers have status

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -742,6 +742,18 @@ func findNextInitContainerToRun(pod *v1.Pod, podStatus *kubecontainer.PodStatus)
 		return nil, nil, true
 	}
 
+	// If any of the main containers have status and are Running, then all init containers must
+	// have been executed at some point in the past.  However, they could have been removed
+	// from the container runtime now, and if we proceed, it would appear as if they
+	// never ran and will re-execute improperly.
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		status := podStatus.FindContainerStatusByName(container.Name)
+		if status != nil && status.State == kubecontainer.ContainerStateRunning {
+			return nil, nil, true
+		}
+	}
+
 	// If there are failed containers, return the status of the last failed one.
 	for i := len(pod.Spec.InitContainers) - 1; i >= 0; i-- {
 		container := &pod.Spec.InitContainers[i]


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1770017

picked from https://github.com/kubernetes/kubernetes/pull/96572

@rphillips @joelsmith @derekwaynecarr 

/hold
until upstream thaws and upstream PR merges

