### PR TITLE
Bug 1896244: UPSTREAM: 96467: Add GinkgoRecover to a local storage go routine

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -530,6 +530,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			ginkgo.By(fmt.Sprintf("Creating %v pods periodically", numConcurrentPods))
 			stop := make(chan struct{})
 			go wait.Until(func() {
+				defer ginkgo.GinkgoRecover()
 				podsLock.Lock()
 				defer podsLock.Unlock()
 


### PR DESCRIPTION
All goroutines must have 'defer ginkgo.GinkgoRecover()' for ginkgo to
report errors correctly.

https://github.com/kubernetes/kubernetes/pull/96467
https://bugzilla.redhat.com/show_bug.cgi?id=1896244

I checked we got the other PR https://github.com/kubernetes/kubernetes/pull/91632 through rebase.

@openshift/storage 