### PR TITLE
Bug 1903999: Httplog response code is always zero

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -140,10 +140,11 @@ func InstallReadyzHandler(mux mux, checks ...HealthChecker) {
 	InstallPathHandler(mux, "/readyz", checks...)
 }
 
-// InstallReadyzHandlerWithHealthyFunc is like InstallReadyzHandler, but in addition call firstTimeReady
-// the first time /readyz succeeds.
+// InstallReadyzHandlerWithHealthyFunc is like InstallReadyzHandler but allows for small customization
+// - calls firstTimeHealthy the first time /readyz succeeds.
+// - disables putting a stacktrace for httplog so that it doesn't log stack trace when HTTP 500 response is returned
 func InstallReadyzHandlerWithHealthyFunc(mux mux, firstTimeReady func(), checks ...HealthChecker) {
-	InstallPathHandlerWithHealthyFunc(mux, "/readyz", firstTimeReady, checks...)
+	InstallPathHandlerWithHealthyFunc(mux, "/readyz", firstTimeReady, true, checks...)
 }
 
 // InstallLivezHandler registers handlers for liveness checking on the path
@@ -160,12 +161,13 @@ func InstallLivezHandler(mux mux, checks ...HealthChecker) {
 // InstallPathHandler more than once for the same path and mux will
 // result in a panic.
 func InstallPathHandler(mux mux, path string, checks ...HealthChecker) {
-	InstallPathHandlerWithHealthyFunc(mux, path, nil, checks...)
+	InstallPathHandlerWithHealthyFunc(mux, path, nil, false, checks...)
 }
 
-// InstallPathHandlerWithHealthyFunc is like InstallPathHandler, but calls firstTimeHealthy exactly once
-// when the handler succeeds for the first time.
-func InstallPathHandlerWithHealthyFunc(mux mux, path string, firstTimeHealthy func(), checks ...HealthChecker) {
+// InstallPathHandlerWithHealthyFunc is like InstallPathHandler but:
+// - calls firstTimeHealthy exactly once when the handler succeeds for the first time
+// - allows for disabling putting a stacktrace for httplog for the current request so that the output is condensed
+func InstallPathHandlerWithHealthyFunc(mux mux, path string, firstTimeHealthy func(), disableStacktraceForHttpLog bool, checks ...HealthChecker) {
 	if len(checks) == 0 {
 		klog.V(5).Info("No default health checks specified. Installing the ping handler.")
 		checks = []HealthChecker{PingHealthz}
@@ -184,9 +186,9 @@ func InstallPathHandlerWithHealthyFunc(mux mux, path string, firstTimeHealthy fu
 			/* component = */ "",
 			/* deprecated */ false,
 			/* removedRelease */ "",
-			handleRootHealth(name, firstTimeHealthy, checks...)))
+			handleRootHealth(name, firstTimeHealthy, disableStacktraceForHttpLog, checks...)))
 	for _, check := range checks {
-		mux.Handle(fmt.Sprintf("%s/%v", path, check.Name()), adaptCheckToHandler(check.Check))
+		mux.Handle(fmt.Sprintf("%s/%v", path, check.Name()), adaptCheckToHandler(check.Check, disableStacktraceForHttpLog))
 	}
 }
 
@@ -221,7 +223,7 @@ func getExcludedChecks(r *http.Request) sets.String {
 }
 
 // handleRootHealth returns an http.HandlerFunc that serves the provided checks.
-func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChecker) http.HandlerFunc {
+func handleRootHealth(name string, firstTimeHealthy func(), disableStacktraceForHttpLog bool, checks ...HealthChecker) http.HandlerFunc {
 	var notifyOnce sync.Once
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -255,8 +257,14 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 		}
 		// always be verbose on failure
 		if len(failedChecks) > 0 {
+			// update the stacktrace predicate so that httplog's output is condensed
+			// this handler is used for health checking on the paths like /healthz or /readyz
+			// for some (/readyz) the StatusInternalServerError is considered as a "normal" response code to signal the other end
+			if disableStacktraceForHttpLog {
+				httplog.DisableStackTraceForRequest(r)
+			}
 			klog.V(2).Infof("%s check failed: %s\n%v", strings.Join(failedChecks, ","), name, failedVerboseLogOutput.String())
-			http.Error(httplog.Unlogged(r, w), fmt.Sprintf("%s%s check failed", individualCheckOutput.String(), name), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("%s%s check failed", individualCheckOutput.String(), name), http.StatusInternalServerError)
 			return
 		}
 
@@ -279,10 +287,13 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 }
 
 // adaptCheckToHandler returns an http.HandlerFunc that serves the provided checks.
-func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
+func adaptCheckToHandler(c func(r *http.Request) error, disableStacktraceForHttpLog bool) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		err := c(r)
 		if err != nil {
+			if disableStacktraceForHttpLog {
+				httplog.DisableStackTraceForRequest(r)
+			}
 			http.Error(w, fmt.Sprintf("internal server error: %v", err), http.StatusInternalServerError)
 		} else {
 			fmt.Fprint(w, "ok")

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -135,6 +135,15 @@ func Unlogged(req *http.Request, w http.ResponseWriter) http.ResponseWriter {
 	return w
 }
 
+// DisableStackTraceForRequest stops putting a stacktrace into the log.
+func DisableStackTraceForRequest(req *http.Request) {
+	rl := respLoggerFromContext(req)
+	if rl == nil {
+		return
+	}
+	rl.StacktraceWhen(func(int) bool { return false })
+}
+
 // StacktraceWhen sets the stacktrace logging predicate, which decides when to log a stacktrace.
 // There's a default, so you don't need to call this unless you don't like the default.
 func (rl *respLogger) StacktraceWhen(pred StacktracePred) *respLogger {


### PR DESCRIPTION
It turned out that httplog was suddenly disabled for `health checks on the paths like /healthz or /readyz`.

I suspect it was disabled because by default we attach a stack trace for requests with >= 500 HTTP status code which can be verbose (an example below).

I decided to expose a function that allows for disabling putting a stack trace into to log only for `/readyz` handler. Since an HTTP `500` is considered a normal response to signal a LB to stop sending traffic for that path. 



A response with a stack trace:
```
 httplog.go:94] "HTTP" verb="GET" URI="/readyz" latency="3.53127ms" userAgent="ELB-HealthChecker/2.0" srcIP="10.0.91.198:58092" resp=500 statusStack="\ngoroutine 286383 [running]:\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog.(*respLogger).recordStatus(0xc00ec44ee0, 0x1f4)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog/httplog.go:248 +0xcf\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog.(*respLogger).WriteHeader(0xc00ec44ee0, 0x1f4)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog/httplog.go:227 +0x35\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*baseTimeoutWriter).WriteHeader(0xc00ea69ec0, 0x1f4)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:226 +0xb2\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/metrics.(*ResponseWriterDelegator).WriteHeader(0xc0375840f0, 0x1f4)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:571 +0x45\nnet/http.Error(0x5669c60, 0xc00937be40, 0xc0375daa00, 0x625, 0x1f4)\n\t/usr/lib/golang/src/net/http/server.go:2066 +0x1f6\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz.handleRootHealth.func1(0x5669c60, 0xc00937be40, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz/healthz.go:258 +0x64b\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/metrics.InstrumentHandlerFunc.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:474 +0x2ba\nnet/http.HandlerFunc.ServeHTTP(0xc00f75fae0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*pathHandler).ServeHTTP(0xc02dd9db40, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:241 +0x6fa\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).ServeHTTP(0xc004916070, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:234 +0x8c\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.director.ServeHTTP(0x4da0ead, 0xf, 0xc0009e3050, 0xc004916070, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/handler.go:154 +0x87f\nk8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver.withOAuthInfo.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go:54 +0x6f\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd530, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:95 +0x165\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd560, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAuthorization.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:64 +0x59a\nnet/http.HandlerFunc.ServeHTTP(0xc00a251b80, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:71 +0x186\nnet/http.HandlerFunc.ServeHTTP(0xc00a251bc0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:95 +0x165\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd5f0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8d00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.WithPriorityAndFairness.func1.4()\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:127 +0x3c6\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle.func1()\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:122 +0x15e\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish(0xc029e20bb0, 0xc037920b40, 0xc0173a8390)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:319 +0x42\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle(0xc0009246e0, 0x56704a0, 0xc014d41fb0, 0xc029e20b00, 0x56711a0, 0xc037188e80, 0xc0173a82a0, 0xc0173a82b0, 0xc037920a20)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:115 +0x7aa\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.WithPriorityAndFairness.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:130 +0x5c3\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd680, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:71 +0x186\nnet/http.HandlerFunc.ServeHTTP(0xc00a251c00, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:95 +0x165\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd710, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithImpersonation.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go:50 +0x23e6\nnet/http.HandlerFunc.ServeHTTP(0xc00a251c40, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:71 +0x186\nnet/http.HandlerFunc.ServeHTTP(0xc00a251c80, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:95 +0x165\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd7a0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:54 +0x750\nnet/http.HandlerFunc.ServeHTTP(0xc00a251cc0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:71 +0x186\nnet/http.HandlerFunc.ServeHTTP(0xc00a251d00, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:95 +0x165\nnet/http.HandlerFunc.ServeHTTP(0xc0045dd8c0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8c00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAuthentication.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8a00)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/authentication.go:70 +0x6d2\nnet/http.HandlerFunc.ServeHTTP(0xc00e13fa90, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8a00)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8900)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:80 +0x38a\nnet/http.HandlerFunc.ServeHTTP(0xc00a251d80, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8900)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.WithCORS.func1(0x7f0695d9e438, 0xc00937be20, 0xc0371f8900)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/cors.go:75 +0x1d9\nnet/http.HandlerFunc.ServeHTTP(0xc00306aba0, 0x7f0695d9e438, 0xc00937be20, 0xc0371f8900)\n\t/usr/lib/golang/src/net/http/server.go:2054 +0x44\nk8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1(0xc0385796e0, 0xc006615960, 0x56712a0, 0xc00937be20, 0xc0371f8900)\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:111 +0xb8\ncreated by k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP\n\t/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:97 +0x1cc\n" addedInfo="\nlogging error output: \"[+]ping ok\\n[+]log ok\\n[+]etcd ok\\n[+]api-openshift-apiserver-available ok\\n[+]api-openshift-oauth-apiserver-available ok\\n[+]informer-sync ok\\n[+]poststarthook/openshift.io-StartOAuthInformers ok\\n[+]poststarthook/start-kube-apiserver-admission-initializer ok\\n[+]poststarthook/quota.openshift.io-clusterquotamapping ok\\n[+]poststarthook/openshift.io-startkubeinformers ok\\n[+]poststarthook/openshift.io-openshift-apiserver-reachable ok\\n[+]poststarthook/openshift.io-oauth-apiserver-reachable ok\\n[+]poststarthook/openshift.io-TokenTimeoutUpdater ok\\n[+]poststarthook/generic-apiserver-start-informers ok\\n[+]poststarthook/priority-and-fairness-config-consumer ok\\n[+]poststarthook/priority-and-fairness-filter ok\\n[+]poststarthook/start-apiextensions-informers ok\\n[+]poststarthook/start-apiextensions-controllers ok\\n[+]poststarthook/crd-informer-synced ok\\n[+]poststarthook/bootstrap-controller ok\\n[+]poststarthook/rbac/bootstrap-roles ok\\n[+]poststarthook/scheduling/bootstrap-system-priority-classes ok\\n[+]poststarthook/priority-and-fairness-config-producer ok\\n[+]poststarthook/start-cluster-authentication-info-controller ok\\n[+]poststarthook/aggregator-reload-proxy-client-cert ok\\n[+]poststarthook/start-kube-aggregator-informers ok\\n[+]poststarthook/apiservice-registration-controller ok\\n[+]poststarthook/apiservice-status-available-controller ok\\n[+]poststarthook/apiservice-wait-for-first-sync ok\\n[+]poststarthook/kube-apiserver-autoregistration ok\\n[+]autoregister-completion ok\\n[+]poststarthook/apiservice-openapi-controller ok\\n[-]shutdown failed: reason withheld\\nreadyz check failed\\n\"\n"
```

a response without the stack trace:
```
I1216 15:41:43.108966      17 httplog.go:94] "HTTP" verb="GET" URI="/readyz" latency="4.899291ms" userAgent="ELB-HealthChecker/2.0" srcIP="10.0.221.206:22463" resp=500
```


TODO:
- check `watch` endpoint