### PR TITLE
DO NOT MERGE: Add per pod/namespace eviction counter to assess impact

### DIFF
--- a/pkg/registry/core/pod/storage/metrics.go
+++ b/pkg/registry/core/pod/storage/metrics.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const metricsSubsystem = "kube_apiserver"
+
+var (
+	// EvictionsTotal is the number of successful evictions performed.
+	// This metric is incremented exactly one time per pod.
+	evictionsTotal = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      metricsSubsystem,
+			Name:           "evictions_total",
+			Help:           "The number of successful evictions performed for each pod. This is incremented exactly once when a pod is marked deleted.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+)
+
+var registerMetricsOnce sync.Once
+
+// registerMetrics registers storage metrics.
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(evictionsTotal)
+	})
+}


### PR DESCRIPTION
We do not know what multiple of workload is disrupted during an upgrade
(whether we on average evict pods once, twice, or more as they bounce
around the cluster on node upgrades). Add a test metric (this would not
be acceptable to merge because of cardinality bounding) to quantify
this in test scenarios.

Just for testing