### PR TITLE
WIP: azure: do not delete nodes from single LB backend pool

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1125,6 +1125,10 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found wanted backendpool. not adding anything", serviceName, wantLb)
 				foundBackendPool = true
 
+				if !az.useStandardLoadBalancer() || !az.EnableMultipleStandardLoadBalancers {
+					break
+				}
+
 				var backendIPConfigurationsToBeDeleted []network.InterfaceIPConfiguration
 				if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
 					for _, ipConf := range *bp.BackendIPConfigurations {


### PR DESCRIPTION
Attempt to bypass new code in Azure legacy-cloud-provider that deletes nodes from loadbalancer backend pools.