### PR TITLE
Bug 1908389: UPSTREAM: 97635: Cherry pick 443 and 448 from cloud provider azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -317,7 +317,7 @@ func (az *Cloud) cleanBackendpoolForPrimarySLB(primarySLB *network.LoadBalancer,
 						return nil, err
 					}
 					primaryVMSetName := az.VMSet.GetPrimaryVMSetName()
-					if !strings.EqualFold(primaryVMSetName, vmSetName) {
+					if !strings.EqualFold(primaryVMSetName, vmSetName) && vmSetName != "" {
 						klog.V(2).Infof("cleanBackendpoolForPrimarySLB: found unwanted vmSet %s, decouple it from the LB", vmSetName)
 						// construct a backendPool that only contains the IP config of the node to be deleted
 						interfaceIPConfigToBeDeleted := network.InterfaceIPConfiguration{
@@ -1132,6 +1132,10 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						nodeName, _, err := az.VMSet.GetNodeNameByIPConfigurationID(ipConfID)
 						if err != nil {
 							return nil, err
+						}
+						if nodeName == "" {
+							// VM may under deletion
+							continue
 						}
 						// If a node is not supposed to be included in the LB, it
 						// would not be in the `nodes` slice. We need to check the nodes that


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test
/kind regression

**What this PR does / why we need it**:

It fixes configuring service load balancers on Azure.

**Which issue(s) this PR fixes**:

Fixes BZ#1908389.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

This is a cherry pick of upstream https://github.com/kubernetes/kubernetes/pull/97635, which unblocks our azure CI as seen in https://github.com/openshift/kubernetes/pull/499. 

