### PR TITLE
Bug 1912564: UPSTREAM: 97323: fix the deadlock in priority and fairness config controller

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/BUILD
@@ -78,6 +78,7 @@ go_test(
         "//staging/src/k8s.io/api/flowcontrol/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -21,12 +21,15 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
 	fcv1a1 "k8s.io/api/flowcontrol/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/util/flowcontrol/debug"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
@@ -305,6 +308,106 @@ func TestConfigConsumer(t *testing.T) {
 			cts.requestWG.Wait()
 		})
 	}
+}
+
+func TestAPFControllerWithGracefulShutdown(t *testing.T) {
+	const plName = "test-ps"
+	fs := &fcv1a1.FlowSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-fs",
+		},
+		Spec: fcv1a1.FlowSchemaSpec{
+			MatchingPrecedence: 100,
+			PriorityLevelConfiguration: fcv1a1.PriorityLevelConfigurationReference{
+				Name: plName,
+			},
+			DistinguisherMethod: &fcv1a1.FlowDistinguisherMethod{
+				Type: fcv1a1.FlowDistinguisherMethodByUserType,
+			},
+		},
+	}
+
+	pl := &fcv1a1.PriorityLevelConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: plName,
+		},
+		Spec: fcv1a1.PriorityLevelConfigurationSpec{
+			Type: fcv1a1.PriorityLevelEnablementLimited,
+			Limited: &fcv1a1.LimitedPriorityLevelConfiguration{
+				AssuredConcurrencyShares: 10,
+				LimitResponse: fcv1a1.LimitResponse{
+					Type: fcv1a1.LimitResponseTypeReject,
+				},
+			},
+		},
+	}
+
+	clientset := clientsetfake.NewSimpleClientset(fs, pl)
+	informerFactory := informers.NewSharedInformerFactory(clientset, time.Second)
+	flowcontrolClient := clientset.FlowcontrolV1alpha1()
+	cts := &ctlrTestState{t: t,
+		fcIfc:           flowcontrolClient,
+		existingFSs:     map[string]*fcv1a1.FlowSchema{},
+		existingPLs:     map[string]*fcv1a1.PriorityLevelConfiguration{},
+		heldRequestsMap: map[string][]heldRequest{},
+		queues:          map[string]*ctlrTestQueueSet{},
+	}
+	controller := newTestableController(
+		informerFactory,
+		flowcontrolClient,
+		100,
+		time.Minute,
+		metrics.PriorityLevelConcurrencyObserverPairGenerator,
+		cts,
+	)
+
+	stopCh, controllerCompletedCh := make(chan struct{}), make(chan struct{})
+	var controllerErr error
+
+	informerFactory.Start(stopCh)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	status := informerFactory.WaitForCacheSync(ctx.Done())
+	if names := unsynced(status); len(names) > 0 {
+		t.Fatalf("WaitForCacheSync did not successfully complete, resources=%#v", names)
+	}
+
+	go func() {
+		defer close(controllerCompletedCh)
+		controllerErr = controller.Run(stopCh)
+	}()
+
+	// ensure that the controller has run its first loop.
+	err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+		if controller.getPriorityLevelState(plName) == nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("expected the controller to reconcile the priority level configuration object: %s, error: %s", plName, err)
+	}
+
+	close(stopCh)
+	t.Log("waiting for the controller Run function to shutdown gracefully")
+	<-controllerCompletedCh
+
+	if controllerErr != nil {
+		t.Errorf("expected nil error from controller Run function, but got: %#v", controllerErr)
+	}
+}
+
+func unsynced(status map[reflect.Type]bool) []string {
+	names := make([]string, 0)
+
+	for objType, synced := range status {
+		if !synced {
+			names = append(names, objType.Name())
+		}
+	}
+
+	return names
 }
 
 func checkNewFS(cts *ctlrTestState, rng *rand.Rand, trialName string, ftr *fsTestingRecord, catchAlls map[bool]*fcv1a1.FlowSchema) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
- API Priority and Fairness controller, `configController.Run` has a race condition. `cfgCtlr.runWorker` runs in the same go routine as the `Run` function. `runWorker` is a long running function and returns when the underlying queue shuts down. So `runWorker`  waits for the queue shutdown and the `Run` function waits for `runWorker`  to finish, thus entering a deadlock.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

```docs

```