### PR TITLE
Bug 1900241: UPSTREAM: <carry>: 4.6 disable nfs subpath

### DIFF
--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -89,6 +89,10 @@ var (
 
 			// A fix is in progress: https://github.com/openshift/origin/pull/24709
 			`Multi-AZ Clusters should spread the pods of a replication controller across zones`,
+
+			// NFS umount is broken in kernels 5.7+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1854379
+			`\[sig-storage\].*\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\].*subPath should be able to unmount after the subpath directory is deleted`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
NFS umount is broken in kernels 5.7+, see https://bugzilla.redhat.com/show_bug.cgi?id=1854379, disable corresponding test.

This has been already merged into master/4.7 as https://github.com/openshift/kubernetes/pull/450