### PR TITLE
Bug 1913096: UPSTREAM: 97006: kubelet: Fix cadvisor machine metrics

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -551,6 +551,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if err != nil {
 		return nil, err
 	}
+	// Avoid collector collects it as a timestamped metric
+	// See PR #95210 and #97006 for more details.
+	machineInfo.Timestamp = time.Time{}
 	klet.setCachedMachineInfo(machineInfo)
 
 	imageBackOff := flowcontrol.NewBackOff(backOffPeriod, MaxContainerBackOff)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -367,6 +367,7 @@ func (s *Server) InstallDefaultHandlers(enableCAdvisorJSONEndpoints bool) {
 		Recursive: true,
 	}
 	r.RawMustRegister(metrics.NewPrometheusCollector(prometheusHostAdapter{s.host}, containerPrometheusLabelsFunc(s.host), includedMetrics, clock.RealClock{}, cadvisorOpts))
+	r.RawMustRegister(metrics.NewPrometheusMachineCollector(prometheusHostAdapter{s.host}, includedMetrics))
 	s.restfulCont.Handle(cadvisorMetricsPath,
 		compbasemetrics.HandlerFor(r, compbasemetrics.HandlerOpts{ErrorHandling: compbasemetrics.ContinueOnError}),
 	)


### PR DESCRIPTION
Restores cadvisor machine metrics that were accidentally removed in 1.19.

Upstream bug: https://github.com/kubernetes/kubernetes/issues/95204
Upstream PR: https://github.com/kubernetes/kubernetes/pull/97006
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1913096

/cc @rphillips 