### PR TITLE
Bug 1896558: Skip multiaz e2e

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -1359,9 +1359,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs": "should schedule pods in the same zones as statically provisioned PVs [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones": "should spread the pods of a replication controller across zones [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones": "should spread the pods of a replication controller across zones [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones": "should spread the pods of a service across zones [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones": "should spread the pods of a service across zones [Disabled:Broken] [Serial] [Suite:k8s]",
 
 	"[Top Level] [sig-scheduling] SchedulerPredicates [Serial] PodTopologySpread Filtering validates 4 pods with MaxSkew=1 are evenly distributed into 2 nodes": "validates 4 pods with MaxSkew=1 are evenly distributed into 2 nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -77,9 +77,6 @@ var (
 			"should reject a Pod requesting a RuntimeClass with conflicting node selector",
 			"should run a Pod requesting a RuntimeClass with scheduling",
 
-			// A fix is in progress: https://github.com/openshift/origin/pull/24709
-			`Multi-AZ Clusters should spread the pods of a replication controller across zones`,
-
 			// NFS umount is broken in kernels 5.7+
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1854379
 			`\[sig-storage\].*\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\].*subPath should be able to unmount after the subpath directory is deleted`,

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -77,6 +77,9 @@ var (
 			"should reject a Pod requesting a RuntimeClass with conflicting node selector",
 			"should run a Pod requesting a RuntimeClass with scheduling",
 
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1896558
+			`Multi-AZ Clusters should spread the pods of a service across zones`,
+
 			// NFS umount is broken in kernels 5.7+
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1854379
 			`\[sig-storage\].*\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\].*subPath should be able to unmount after the subpath directory is deleted`,


### PR DESCRIPTION
The serial multiaz test is known flakey (fix tracked by https://bugzilla.redhat.com/show_bug.cgi?id=1896558) and frequently fails the serial e2e job. 

The other multiaz skip is tentatively removed because https://bugzilla.redhat.com/show_bug.cgi?id=1806594 suggests the issue has been resolved. More likely the skip resulted in the QA thinking the problem was fixed but really the test just wasn't running. Will unskip and update to point to the bz if that's the case.