### PR TITLE
Bug 1899941: Override termination grace period on annotation

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -608,6 +609,11 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 		gracePeriod = *pod.DeletionGracePeriodSeconds
 	case pod.Spec.TerminationGracePeriodSeconds != nil:
 		gracePeriod = *pod.Spec.TerminationGracePeriodSeconds
+		if annotationGracePeriod, found := pod.ObjectMeta.Annotations["unsupported.do-not-use.openshift.io/override-liveness-grace-period-seconds"]; found {
+			if val, err := strconv.ParseUint(annotationGracePeriod, 10, 64); err == nil && val > 0 {
+				gracePeriod = int64(val)
+			}
+		}
 	}
 
 	if len(message) == 0 {


### PR DESCRIPTION
I have tested this fix as follows:

- Applied patch against k/k
- Ran local-cluster-up with patch
- Created pod (spec in details) with annotation to shut down after 10s on liveness probe failure, and terminationGracePeriodSeconds = 500
- Watched for events demonstrating it was shut down within 10s
- Removed pod
- Recreated pod *without* annotation
- Watched for events demonstrating it was not shut down within 10s

This is my first OpenShift-only patch so I'm not 100% sure what to do with testing. The upstream unit tests for this file need a rewrite in order to cover for this case (they only check for deletion failures). I could write an e2e test similar to my manual test above.

/cc @mrunalp @rphillips @smarterclayton @derekwaynecarr 

Test pod spec:

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  annotations:
    "unsupported.do-not-use.openshift.io/override-liveness-grace-period-seconds": "10"
spec:
  terminationGracePeriodSeconds: 500
  containers:
    - name: test
      image: nginx
      command: [bash, -c, "sleep 100000000"]
      ports:
        - containerPort: 8080
      livenessProbe:
        httpGet:
          path: /healthz
          port: 8080
        failureThreshold: 1
        periodSeconds: 60
```

With annotation:
```
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  35s               default-scheduler  Successfully assigned default/test-pod to 127.0.0.1
  Normal   Pulled     32s               kubelet            Successfully pulled image "nginx" in 1.722675823s
  Warning  Unhealthy  14s               kubelet            Liveness probe failed: Get "http://172.17.0.3:8080/healthz": dial tcp 172.17.0.3:8080: connect: connection refused
  Normal   Killing    14s               kubelet            Container test failed liveness probe, will be restarted
  Normal   Pulling    3s (x2 over 34s)  kubelet            Pulling image "nginx"
  Normal   Created    2s (x2 over 32s)  kubelet            Created container test
  Normal   Pulled     2s                kubelet            Successfully pulled image "nginx" in 1.499383132s
  Normal   Started    1s (x2 over 32s)  kubelet            Started container test
```

With annotation commented out:
```
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  81s   default-scheduler  Successfully assigned default/test-pod to 127.0.0.1
  Normal   Pulling    80s   kubelet            Pulling image "nginx"
  Normal   Pulled     79s   kubelet            Successfully pulled image "nginx" in 1.592565474s
  Normal   Created    79s   kubelet            Created container test
  Normal   Started    79s   kubelet            Started container test
  Warning  Unhealthy  62s   kubelet            Liveness probe failed: Get "http://172.17.0.3:8080/healthz": dial tcp 172.17.0.3:8080: connect: connection refused
  Normal   Killing    62s   kubelet            Container test failed liveness probe, will be restarted
... (did not get killed within 10s, is waiting the full 500s)
```