### PR TITLE
decrease the default ResponseWriter buffer to 512K

### DIFF
--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -54,7 +54,7 @@ import (
 const (
 	prefaceTimeout         = 10 * time.Second
 	firstSettingsTimeout   = 2 * time.Second // should be in-flight with preface anyway
-	handlerChunkWriteSize  = 4 << 10
+	handlerChunkWriteSize  = 512
 	defaultMaxStreams      = 250 // TODO: make this 100 as the GFE seems to?
 	maxQueuedControlFrames = 10000
 )


### PR DESCRIPTION
The default `ResponseWriter.Write` (https://golang.org/pkg/net/http/#ResponseWriter) method's buffer is 4096 K. That means that most of the time `Write` method won't return any error because it will write to memory instead of sending data over the network to a client. 

Unfortunately, that means that the audit subsystem can contain misleading entries suggesting that data was successfully sent to a client whereas due to a network error sending might have failed.