### PR TITLE
Bug 1882750: UPSTREAM: 98103: kubelet: Delete static pod gracefully and fix mirrorPodTerminationMap leak

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1480,6 +1480,13 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 		return nil
 	}
 
+	// If the pod is a static pod and its mirror pod is still gracefully terminating,
+	// we do not want to start the new static pod until the old static pod is gracefully terminated.
+	podFullName := kubecontainer.GetPodFullName(pod)
+	if kl.podKiller.IsMirrorPodPendingTerminationByPodName(podFullName) {
+		return fmt.Errorf("pod %q is pending termination", podFullName)
+	}
+
 	// Latency measurements for the main workflow are relative to the
 	// first time the pod was seen by the API server.
 	var firstSeenTime time.Time
@@ -1615,7 +1622,6 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 
 	// Create Mirror Pod for Static Pod if it doesn't already exist
 	if kubetypes.IsStaticPod(pod) {
-		podFullName := kubecontainer.GetPodFullName(pod)
 		deleted := false
 		if mirrorPod != nil {
 			if mirrorPod.DeletionTimestamp != nil || !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {


### PR DESCRIPTION
Delete static pod gracefully and fix mirrorPodTerminationMap leak

upstream bug: https://github.com/kubernetes/kubernetes/issues/97722
upstream PR: https://github.com/kubernetes/kubernetes/pull/98103
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1882750

/cc @rphillips 