### PR TITLE
Add DOWNSTREAM_OWNERS as preparation for https://github.com/kubernetes/test-infra/pull/20482

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,31 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    reviewers:
+    - deads2k
+    - sttts
+    - soltysh
+    - mfojtik
+    - marun
+    - tnozicka
+
+    # approvers are limited to the team that manages rebases and pays the price for carries that are introduced
+    approvers:
+    - deads2k
+    - sttts
+    - soltysh
+    - mfojtik
+    - marun
+    - tnozicka
+
+  "^\\.go.(mod|sum)$":
+    labels:
+    - "vendor-update"
+  "^vendor/.*":
+    labels:
+    - "vendor-update"
+  "^staging/.*":
+    labels:
+    - "vendor-update"
+component: kube-apiserver

--- a/pkg/kubelet/DOWNSTREAM_OWNERS
+++ b/pkg/kubelet/DOWNSTREAM_OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - rphillips
+  - sjenning
+  - mrunalp
+
+# adding mrunalp and sjenning from the upstream Kubelet OWNERS file:
+#   https://github.com/kubernetes/kubernetes/blob/17bb2fc050ec786b60db7d8d6d4d3ac8eeac205b/pkg/kubelet/OWNERS#L10-L11
+# sub-package approvers for "UPSTREAM: <PR>: ..." changes that merged upstream
+# carry patches for "UPSTREAM: <carry>: ..." will be approved by the root level approvers
+approvers:
+  - sjenning
+  - mrunalp
+
+component: node


### PR DESCRIPTION
Instead of modifying upstream OWNERS files and to avoid possible conflicts, we will make use of https://github.com/kubernetes/test-infra/pull/20482 to point to DOWNSTREAM_OWNERS instead.

When we have enabled DOWNSTREAM_OWNERS in prow config, we will revert the modifications of OWNERS.

This needs a backport to 4.6, 4.5, 4.4.