### PR TITLE
UPSTREAM: 97371: fix sctp hostPort test

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3813,6 +3813,7 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 		podName := "hostport"
 		ports := []v1.ContainerPort{{Protocol: v1.ProtocolSCTP, ContainerPort: 5060, HostPort: 5060}}
 		podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, ports)
+		podSpec.Spec.NodeName = node.Name
 
 		ginkgo.By(fmt.Sprintf("Launching the pod on node %v", node.Name))
 		f.PodClient().CreateSync(podSpec)


### PR DESCRIPTION
The test create a pod with a hostPort to expose an SCTP port, then
it checks if the iptables rules were installed correctly in the host.

The iptables rules MUST be checked in the same host where the pod
is running :)

https://bugzilla.redhat.com/show_bug.cgi?id=1908677