### PR TITLE
watch-termination: Do not forward signals to child process

### DIFF
--- a/cmd/watch-termination/main.go
+++ b/cmd/watch-termination/main.go
@@ -173,9 +173,7 @@ func run() int {
 				close(termCh)
 			}
 
-			klog.Infof("Received signal %s. Forwarding to sub-process %q.", s, args[0])
-
-			cmd.Process.Signal(s)
+			klog.Infof("Received signal %s", s)
 		}
 	}()
 


### PR DESCRIPTION
**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:
We rely on systemd to stop the containers running in scopes
during node shutdown or reboot. The signal forwarding results
in 2 SIGTERMs being sent to apiserver and it exits immediately
when that happens.

**Which issue(s) this PR fixes**:

This can be remove once https://bugzilla.redhat.com/show_bug.cgi?id=1925623 is fixed.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Do not forward signals to child processes
```


