### PR TITLE
Bug 1926484: UPSTREAM: <carry>: kube-apiserver: ignore SIGTERM/INT after the first one

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -178,7 +178,7 @@ cluster's shared state through which all other components interact.`,
 				return utilerrors.NewAggregate(errs)
 			}
 
-			return Run(completedOptions, genericapiserver.SetupSignalHandler())
+			return Run(completedOptions, genericapiserver.SetupSignalHandler(false))
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -126,7 +126,7 @@ controller, and serviceaccounts controller.`,
 				os.Exit(1)
 			}
 
-			stopCh := server.SetupSignalHandler()
+			stopCh := server.SetupSignalHandler(true)
 			if err := Run(c.Complete(), stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -124,7 +124,7 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		stopCh := server.SetupSignalHandler()
+		stopCh := server.SetupSignalHandler(true)
 		<-stopCh
 		cancel()
 	}()

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -261,7 +261,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			kubeletDeps.KubeletConfigController = kubeletConfigController
 
 			// set up signal context here in order to be reused by kubelet and docker shim
-			ctx := genericapiserver.SetupSignalContext()
+			ctx := genericapiserver.SetupSignalContext(true)
 
 			// run the kubelet
 			klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)

--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -31,7 +31,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	stopCh := genericapiserver.SetupSignalHandler()
+	stopCh := genericapiserver.SetupSignalHandler(true)
 	cmd := server.NewServerCommand(os.Stdout, os.Stderr, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/signal.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/signal.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"os"
 	"os/signal"
+
+	"k8s.io/klog/v2"
 )
 
 var onlyOneSignalHandler = make(chan struct{})
@@ -30,14 +32,14 @@ var shutdownHandler chan os.Signal
 // is terminated with exit code 1.
 // Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
 // be called once.
-func SetupSignalHandler() <-chan struct{} {
-	return SetupSignalContext().Done()
+func SetupSignalHandler(exitOnSecondSignal bool) <-chan struct{} {
+	return SetupSignalContext(exitOnSecondSignal).Done()
 }
 
 // SetupSignalContext is same as SetupSignalHandler, but a context.Context is returned.
 // Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
 // be called once.
-func SetupSignalContext() context.Context {
+func SetupSignalContext(exitOnSecondSignal bool) context.Context {
 	close(onlyOneSignalHandler) // panics when called twice
 
 	shutdownHandler = make(chan os.Signal, 2)
@@ -47,8 +49,15 @@ func SetupSignalContext() context.Context {
 	go func() {
 		<-shutdownHandler
 		cancel()
-		<-shutdownHandler
-		os.Exit(1) // second signal. Exit directly.
+		if exitOnSecondSignal {
+			<-shutdownHandler
+			os.Exit(1)
+		} else {
+			for {
+				<-shutdownHandler
+				klog.Infof("Termination signal has been received already. Ignoring signal.")
+			}
+		}
 	}()
 
 	return ctx

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -38,7 +38,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	stopCh := genericapiserver.SetupSignalHandler()
+	stopCh := genericapiserver.SetupSignalHandler(true)
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)
 	cmd := server.NewCommandStartAggregator(options, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
Normally kubelet sends SIGTERM to root process of container on graceful shutdown. But during node shutdown, systemd is the actor sending the signal instead. And systemd sends SIGTERM to *every* process. As we have the `watch-termination` wrapper, both systemd sends SIGTERM and `watch-termination` forwards => 2 SIGTERMs arrive at kube-apiserver, which makes it shutdown hard (`os.Exit(1)`).

This PR make kube-apiserver ignore a second SIGTERM.