### PR TITLE
add failure details for SCC not  used.

### DIFF
--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -217,6 +217,14 @@ loop:
 	for i, provider = range providers {
 		if !allowedForUserOrSA(provider) {
 			denied = append(denied, provider.GetSCCName())
+			// this will cause every security context constraint attempted, in order, to the failure
+			validationErrs = append(validationErrs,
+				field.Forbidden(
+					field.NewPath(fmt.Sprintf("provider %q: ", provider.GetSCCName())),
+					"not usable by user or serviceaccount",
+				),
+			)
+
 			continue
 		}
 


### PR DESCRIPTION
https://github.com/openshift/kubernetes/pull/391 isn't showing the results we expect.

fake bump of https://github.com/openshift/apiserver-library-go/pull/43

If we can trip the error in this PR, we can see which SCCs are apparently not usable.