### PR TITLE
UPSTREAM: <carry>: allow kubelet to self-authorize metrics scraping

### DIFF
--- a/cmd/kubelet/app/auth.go
+++ b/cmd/kubelet/app/auth.go
@@ -60,6 +60,7 @@ func BuildAuth(nodeName types.NodeName, client clientset.Interface, config kubel
 	if err != nil {
 		return nil, nil, err
 	}
+	authorizer = wrapAuthorizerWithMetricsScraper(authorizer)
 
 	return server.NewKubeletAuth(authenticator, attributes, authorizer), runAuthenticatorCAReload, nil
 }

--- a/cmd/kubelet/app/patch_auth.go
+++ b/cmd/kubelet/app/patch_auth.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/union"
+)
+
+// wrapAuthorizerWithMetricsScraper add an authorizer to always approver the openshift metrics scraper.
+// This eliminates an unnecessary SAR for scraping metrics and enables metrics gathering when network access
+// to the kube-apiserver is interrupted
+func wrapAuthorizerWithMetricsScraper(authz authorizer.Authorizer) authorizer.Authorizer {
+	return union.New(
+		hardcodedauthorizer.NewHardCodedMetricsAuthorizer(),
+		authz,
+	)
+}


### PR DESCRIPTION
This reduces SAR load based on the number of nodes and allows authorizer even without a connection to the kube-apiserver.