### PR TITLE
<carry>: enable CSI migration gates in Attach/Detach controller

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -184,7 +184,7 @@ func NewAttachDetachController(
 
 	csiTranslator := csitrans.New()
 	adc.intreeToCSITranslator = csiTranslator
-	adc.csiMigratedPluginManager = csimigration.NewPluginManager(csiTranslator, utilfeature.DefaultFeatureGate)
+	adc.csiMigratedPluginManager = csimigration.NewADCPluginManager(csiTranslator, utilfeature.DefaultFeatureGate)
 
 	adc.desiredStateOfWorldPopulator = populator.NewDesiredStateOfWorldPopulator(
 		timerConfig.DesiredStateOfWorldPopulatorLoopSleepPeriod,

--- a/pkg/features/patch_kube_features.go
+++ b/pkg/features/patch_kube_features.go
@@ -1,0 +1,30 @@
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+	// owner: @jsafrane
+	// alpha: v1.21
+	//
+	// Enables the AWS EBS CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationAWS featuregate.Feature = "ADC_CSIMigrationAWS"
+
+	// owner: @jsafrane
+	// alpha: v1.21
+	//
+	// Enables the Cinder CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationCinder featuregate.Feature = "ADC_CSIMigrationCinder"
+)
+
+var ocpDefaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	ADCCSIMigrationAWS:    {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationCinder: {Default: true, PreRelease: featuregate.Beta},
+}
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(ocpDefaultKubernetesFeatureGates))
+}

--- a/pkg/volume/csimigration/patch_adc_plugin_manager.go
+++ b/pkg/volume/csimigration/patch_adc_plugin_manager.go
@@ -1,0 +1,44 @@
+package csimigration
+
+import (
+	"k8s.io/component-base/featuregate"
+	csilibplugins "k8s.io/csi-translation-lib/plugins"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// NewADCPluginManager returns a new PluginManager instance for the Attach Detach controller which uses different
+// featuregates in openshift to control enablement/disablement which *DO NOT MATCH* the featuregates for the rest of the
+// cluster.
+func NewADCPluginManager(m PluginNameMapper, featureGate featuregate.FeatureGate) PluginManager {
+	ret := NewPluginManager(m, featureGate)
+	ret.useADCPluginManagerFeatureGates = true
+	return ret
+}
+
+// adcIsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
+// for a particular storage plugin in Attach/Detach controller.
+func (pm PluginManager) adcIsMigrationEnabledForPlugin(pluginName string) bool {
+	// CSIMigration feature should be enabled along with the plugin-specific one
+	if !pm.featureGate.Enabled(features.CSIMigration) {
+		return false
+	}
+
+	switch pluginName {
+	case csilibplugins.AWSEBSInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationAWS)
+	case csilibplugins.CinderInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationCinder)
+	default:
+		return pm.isMigrationEnabledForPlugin(pluginName)
+	}
+}
+
+// IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
+// for a particular storage plugin
+func (pm PluginManager) IsMigrationEnabledForPlugin(pluginName string) bool {
+	if pm.useADCPluginManagerFeatureGates {
+		return pm.adcIsMigrationEnabledForPlugin(pluginName)
+	}
+
+	return pm.isMigrationEnabledForPlugin(pluginName)
+}

--- a/pkg/volume/csimigration/plugin_manager.go
+++ b/pkg/volume/csimigration/plugin_manager.go
@@ -38,6 +38,8 @@ type PluginNameMapper interface {
 type PluginManager struct {
 	PluginNameMapper
 	featureGate featuregate.FeatureGate
+
+	useADCPluginManagerFeatureGates bool
 }
 
 // NewPluginManager returns a new PluginManager instance
@@ -77,9 +79,7 @@ func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
 	}
 }
 
-// IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
-// for a particular storage plugin
-func (pm PluginManager) IsMigrationEnabledForPlugin(pluginName string) bool {
+func (pm PluginManager) isMigrationEnabledForPlugin(pluginName string) bool {
 	// CSIMigration feature should be enabled along with the plugin-specific one
 	if !pm.featureGate.Enabled(features.CSIMigration) {
 		return false


### PR DESCRIPTION
Run A/D controller with CSI migration feature flags force-enabled.

There are two commits.:
1. `UPSTREAM: 99942` is already in Kubernetes 1.21 and we'll get it through rebase.
2. very minimal `<carry>` patch that forcefully sets CSI migration gates *only* in A/D controller. We will need it as `<carry>` patch until CSI migration of all volume plugins reaches GA (1.23-1.24?)

See https://github.com/openshift/enhancements/pull/549 for details.

The patch works around two issues we have in OCP:

* CVO downgrades Kubernetes components in wrong order: kube-controller-manager (A/D controller) is downgraded first and then it downgrades kubelets. This is not supported Kubernetes version skew, kubelet cannot be newer than KCM. A/D controller breaks in this case.

* FeatureGates are applied in random order. Without this PR, we need to enable CSI migration flag in A/D controller first, then kubelets. With this PR, the order does not matter.

With this PR, A/D controller knows about CSI migration and will attach volumes to nodes either "in-tree style" or "CSI style", depending what the node actually wants. In a default 4.8 cluster, it will be in-tree style, as CSI migration is disabled everywhere else, so there should be no visible change in A/D controller processing. It becomes useful as the CSI migration becomes enabled on nodes (either during upgrade to 4.9 or downgrade 4.9->4.8), or when user opts-in for CSI migration as tech preview in 4.8 via FeatureGates CR.