### PR TITLE
KCM with preferred host support

### DIFF
--- a/cmd/kube-controller-manager/app/config/patch.go
+++ b/cmd/kube-controller-manager/app/config/patch.go
@@ -1,9 +1,18 @@
 package config
 
+import (
+	"k8s.io/client-go/transport"
+
+	"github.com/openshift/library-go/pkg/monitor/health"
+)
+
 // OpenShiftContext is additional context that we need to launch the kube-controller-manager for openshift.
 // Basically, this holds our additional config information.
 type OpenShiftContext struct {
 	OpenShiftConfig                     string
 	OpenShiftDefaultProjectNodeSelector string
 	KubeDefaultProjectNodeSelector      string
+	UnsupportedKubeAPIOverPreferredHost bool
+	PreferredHostRoundTripperWrapperFn  transport.WrapperFunc
+	PreferredHostHealthMonitor          *health.Prober
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -68,6 +68,8 @@ import (
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
 
 const (
@@ -113,6 +115,11 @@ controller, and serviceaccounts controller.`,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			verflag.PrintAndExitIfRequested()
+
+			if err := SetUpPreferredHostForOpenShift(s); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
 
 			c, err := s.Config(KnownControllers(), ControllersDisabledByDefault.List())
 			if err != nil {
@@ -183,6 +190,17 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		cfgz.Set(c.ComponentConfig)
 	} else {
 		klog.Errorf("unable to register configz: %v", err)
+	}
+
+	// start the localhost health monitor early so that it can be used by the LE client
+	if c.OpenShiftContext.PreferredHostHealthMonitor != nil {
+		hmCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-stopCh
+			cancel()
+		}()
+		go c.OpenShiftContext.PreferredHostHealthMonitor.Run(hmCtx)
 	}
 
 	// Setup any healthz checks we will want to use.
@@ -691,7 +709,7 @@ func createClientBuilders(c *config.CompletedConfig) (clientBuilder clientbuilde
 		}
 
 		clientBuilder = clientbuilder.NewDynamicClientBuilder(
-			restclient.AnonymousClientConfig(c.Kubeconfig),
+			libgorestclient.AnonymousClientConfigWithWrapTransport(c.Kubeconfig),
 			c.Client.CoreV1(),
 			metav1.NamespaceSystem)
 	} else {

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -47,6 +47,8 @@ import (
 
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
 
 const (
@@ -271,6 +273,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fs.StringVar(&dummy, "insecure-experimental-approve-all-kubelet-csrs-for-group", "", "This flag does nothing.")
 	fs.StringVar(&s.OpenShiftContext.OpenShiftConfig, "openshift-config", s.OpenShiftContext.OpenShiftConfig, "indicates that this process should be compatible with openshift start master")
 	fs.MarkHidden("openshift-config")
+	fs.BoolVar(&s.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost, "unsupported-kube-api-over-localhost", false, "when set makes KCM prefer talking to localhost kube-apiserver (when available) instead of LB")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("generic"))
 
 	return fss
@@ -442,6 +445,11 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
 	kubeconfig.QPS = s.Generic.ClientConnection.QPS
 	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)
+
+	if s.OpenShiftContext.PreferredHostRoundTripperWrapperFn != nil {
+		libgorestclient.DefaultServerName(kubeconfig)
+		kubeconfig.Wrap(s.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	}
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {

--- a/cmd/kube-controller-manager/app/patch.go
+++ b/cmd/kube-controller-manager/app/patch.go
@@ -1,17 +1,61 @@
 package app
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/json"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/monitor/health"
 )
 
 var InformerFactoryOverride informers.SharedInformerFactory
+
+func SetUpPreferredHostForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions) error {
+	if !controllerManagerOptions.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost {
+		return nil
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags(controllerManagerOptions.Master, controllerManagerOptions.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	libgorestclient.DefaultServerName(config)
+
+	targetProvider := health.StaticTargetProvider{"localhost:6443"}
+	controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor, err = health.New(targetProvider, createRestConfigForHealthMonitor(config))
+	if err != nil {
+		return err
+	}
+	controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor.
+		WithHealthyProbesThreshold(3).
+		WithUnHealthyProbesThreshold(5).
+		WithProbeInterval(5 * time.Second).
+		WithProbeResponseTimeout(2 * time.Second).
+		WithMetrics(health.Register(legacyregistry.MustRegister))
+
+	controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn = libgorestclient.NewPreferredHostRoundTripper(func() string {
+		healthyTargets, _ := controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor.Targets()
+		if len(healthyTargets) == 1 {
+			return healthyTargets[0]
+		}
+		return ""
+	})
+
+	controllerManagerOptions.Authentication.WithCustomRoundTripper(controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	controllerManagerOptions.Authorization.WithCustomRoundTripper(controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	return nil
+}
 
 func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config) error {
 	if len(controllerManager.OpenShiftContext.OpenShiftConfig) == 0 {
@@ -81,4 +125,11 @@ func applyOpenShiftConfigDefaultProjectSelector(controllerManagerOptions *option
 	controllerManagerOptions.OpenShiftContext.OpenShiftDefaultProjectNodeSelector = defaultNodeSelector.(string)
 
 	return nil
+}
+
+func createRestConfigForHealthMonitor(restConfig *rest.Config) *rest.Config {
+	restConfigCopy := *restConfig
+	rest.AddUserAgent(&restConfigCopy, fmt.Sprintf("%s-health-monitor", options.KubeControllerManagerUserAgent))
+
+	return &restConfigCopy
 }

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/openshift/api v0.0.0-20210331193751-3acddb19d360
 	github.com/openshift/apiserver-library-go v0.0.0-20210401085424-478bd0360e43
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_model v0.2.0
@@ -398,7 +398,7 @@ replace (
 	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210401085424-478bd0360e43
 	github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pascaldekloe/goe => github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c
 	github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
 	github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -447,6 +447,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -487,8 +487,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
-	github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -485,8 +485,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,6 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
 )
 
 // DelegatingAuthorizationOptions provides an easy way for composing API servers to delegate their authorization to
@@ -70,6 +71,9 @@ type DelegatingAuthorizationOptions struct {
 	// This allows us to configure the sleep time at each iteration and the maximum number of retries allowed
 	// before we fail the webhook call in order to limit the fan out that ensues when the system is degraded.
 	WebhookRetryBackoff *wait.Backoff
+
+	// CustomRoundTripperFn allows for specifying a middleware function for custom HTTP behaviour for the authorization webhook client.
+	CustomRoundTripperFn transport.WrapperFunc
 }
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
@@ -110,6 +114,11 @@ func (s *DelegatingAuthorizationOptions) WithClientTimeout(timeout time.Duration
 // WithCustomRetryBackoff sets the custom backoff parameters for the authorization webhook retry logic.
 func (s *DelegatingAuthorizationOptions) WithCustomRetryBackoff(backoff wait.Backoff) {
 	s.WebhookRetryBackoff = &backoff
+}
+
+// WithCustomRoundTripper allows for specifying a middleware function for custom HTTP behaviour for the authorization webhook client.
+func (s *DelegatingAuthorizationOptions) WithCustomRoundTripper(rt transport.WrapperFunc) {
+	s.CustomRoundTripperFn = rt
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {
@@ -230,6 +239,9 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
 	clientConfig.Timeout = s.ClientTimeout
+	if s.CustomRoundTripperFn != nil {
+		clientConfig.Wrap(s.CustomRoundTripperFn)
+	}
 
 	// make the client use protobuf
 	protoConfig := rest.CopyConfig(clientConfig)

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -465,6 +465,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -488,8 +488,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/controller-manager/go.sum
+++ b/staging/src/k8s.io/controller-manager/go.sum
@@ -603,6 +603,7 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaR
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -116,7 +116,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 
 	rt, ok := t.roundTripperFuncMap[saName]
 	if ok {
-		configCopy.WrapTransport = rt
+		configCopy.Wrap(rt)
 	} else {
 		cachedTokenSource := transport.NewCachedTokenSource(&tokenSourceImpl{
 			namespace:          t.Namespace,
@@ -125,7 +125,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 			expirationSeconds:  t.expirationSeconds,
 			leewayPercent:      t.leewayPercent,
 		})
-		configCopy.WrapTransport = transport.ResettableTokenSourceWrapTransport(cachedTokenSource)
+		configCopy.Wrap(transport.ResettableTokenSourceWrapTransport(cachedTokenSource))
 		t.roundTripperFuncMap[saName] = configCopy.WrapTransport
 	}
 

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -235,7 +235,11 @@ func (ts *tokenSourceImpl) Token() (*oauth2.Token, error) {
 
 func constructClient(saNamespace, saName string, config *restclient.Config) restclient.Config {
 	username := apiserverserviceaccount.MakeUsername(saNamespace, saName)
-	ret := *restclient.AnonymousClientConfig(config)
+	// make a shallow copy
+	// the caller already castrated the config during creation
+	// this allows for potential extensions in the future
+	// for example it preserve HTTP wrappers for custom behavior per request
+	ret := *config
 	restclient.AddUserAgent(&ret, username)
 	return ret
 }

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -489,8 +489,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/kube-controller-manager/go.sum
+++ b/staging/src/k8s.io/kube-controller-manager/go.sum
@@ -277,7 +277,7 @@ github.com/openshift/api v0.0.0-20210331193751-3acddb19d360/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -489,6 +489,7 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaR
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -324,7 +324,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -319,8 +319,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/metrics.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/metrics.go
@@ -1,0 +1,111 @@
+package health
+
+import (
+	compbasemetrics "k8s.io/component-base/metrics"
+)
+
+type registerables []compbasemetrics.Registerable
+
+var (
+	healthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_healthy_target_total",
+			Help:           "Number of healthy instances registered with the health monitor. Partitioned by targets.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	currentHealthyTargets = compbasemetrics.NewGauge(
+		&compbasemetrics.GaugeOpts{
+			Name:           "health_monitor_current_healthy_targets",
+			Help:           "Number of currently healthy instances observed by the health monitor",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+	)
+
+	unHealthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_unhealthy_target_total",
+			Help:           "Number of unhealthy instances registered with the health monitor. Partitioned by targets.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	readyzViolationRequestTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_readyz_violation_request_total",
+			Help:           "Number of HTTP requests partitioned by status code and target that violate the readyz protocol.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"code", "target"},
+	)
+
+	metrics = registerables{
+		healthyTargetsTotal,
+		currentHealthyTargets,
+		unHealthyTargetsTotal,
+		readyzViolationRequestTotal,
+	}
+)
+
+// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+func HealthyTargetsTotal(target string) {
+	healthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// CurrentHealthyTargets keeps track of the current number of healthy targets observed by the health monitor
+func CurrentHealthyTargets(count float64) {
+	currentHealthyTargets.Set(count)
+}
+
+// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+func UnHealthyTargetsTotal(target string) {
+	unHealthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+//
+// the "readyz" protocol defines the following HTTP status code:
+//   HTTP 200 - when the server operates normally
+//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+func ReadyzProtocolRequestTotal(code, target string) {
+	readyzViolationRequestTotal.WithLabelValues(code, target).Add(1)
+}
+
+// Metrics specifies a set of methods that are used to register various metrics
+type Metrics struct {
+	// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+	HealthyTargetsTotal func(target string)
+
+	// CurrentHealthyTargets keeps track of the current number of healthy targets observed by the health monitor
+	CurrentHealthyTargets func(count float64)
+
+	// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+	UnHealthyTargetsTotal func(target string)
+
+	// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+	//
+	// the "readyz" protocol defines the following HTTP status code:
+	//   HTTP 200 - when the server operates normally
+	//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+	ReadyzProtocolRequestTotal func(code, target string)
+}
+
+// Register is a way to register the health monitor related metrics in the provided store
+func Register(registerFn func(...compbasemetrics.Registerable)) *Metrics {
+	registerFn(metrics...)
+	return &Metrics{
+		HealthyTargetsTotal:        HealthyTargetsTotal,
+		CurrentHealthyTargets:      CurrentHealthyTargets,
+		UnHealthyTargetsTotal:      UnHealthyTargetsTotal,
+		ReadyzProtocolRequestTotal: ReadyzProtocolRequestTotal,
+	}
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) TargetsTotal(string)                 {}
+func (noopMetrics) TargetsGauge(float64)                {}
+func (noopMetrics) TargetsWithCodeTotal(string, string) {}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/options.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/options.go
@@ -1,0 +1,33 @@
+package health
+
+import "time"
+
+// WithUnHealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+func (sm *Prober) WithUnHealthyProbesThreshold(unhealthyProbesThreshold int) *Prober {
+	sm.unhealthyProbesThreshold = unhealthyProbesThreshold
+	return sm
+}
+
+// WithHealthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+func (sm *Prober) WithHealthyProbesThreshold(healthyProbesThreshold int) *Prober {
+	sm.healthyProbesThreshold = healthyProbesThreshold
+	return sm
+}
+
+// WithProbeResponseTimeout specifies a time limit for requests made by the HTTP client for the health check
+func (sm *Prober) WithProbeResponseTimeout(probeResponseTimeout time.Duration) *Prober {
+	sm.client.Timeout = probeResponseTimeout
+	return sm
+}
+
+// WithProbeInterval specifies a time interval at which health checks are send
+func (sm *Prober) WithProbeInterval(probeInterval time.Duration) *Prober {
+	sm.probeInterval = probeInterval
+	return sm
+}
+
+// WithMetrics specifies a set of methods that are used to register various metrics
+func (sm *Prober) WithMetrics(metrics *Metrics) *Prober {
+	sm.metrics = metrics
+	return sm
+}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/prober.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/prober.go
@@ -1,0 +1,377 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
+)
+
+var (
+	defaultProbeResponseTimeout = 1 * time.Second
+	defaultProbeInterval        = 2 * time.Second
+
+	defaultUnhealthyProbesThreshold = 3
+	defaultHealthyProbesThreshold   = 5
+)
+
+type Prober struct {
+	// targetProvider provides a list of targets to monitor
+	// it also can schedule refreshing the list by simply calling Enqueue method
+	targetProvider TargetProvider
+
+	// client is an HTTP client that is used to probe health checks for targets
+	client *http.Client
+
+	// probeInterval specifies a time interval at which health checks are send
+	probeInterval time.Duration
+
+	// unhealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+	unhealthyProbesThreshold int
+
+	// healthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+	healthyProbesThreshold int
+
+	healthyTargets   []string
+	unhealthyTargets []string
+	targetsToMonitor []string
+
+	consecutiveSuccessfulProbes map[string]int
+	consecutiveFailedProbes     map[string][]error
+
+	refreshTargetsLock sync.Mutex
+	refreshTargets     bool
+
+	// exportedHealthyTargets holds a copy of healthyTargets
+	exportedHealthyTargets atomic.Value
+
+	// exportedUnhealthyTargets holds a copy of unhealthyTargets
+	exportedUnhealthyTargets atomic.Value
+
+	// listeners holds a list of interested parties to be notified when the list of healthy targets changes
+	listeners []Listener
+
+	// metrics specifies a set of methods that are used to register various metrics
+	metrics *Metrics
+}
+
+var _ Listener = &Prober{}
+var _ Notifier = &Prober{}
+
+// New creates a health monitor that periodically sends requests to the provided targets to check their health.
+//
+// The following methods allows you to configure behaviour of the monitor after creation.
+//
+//   WithUnHealthyProbesThreshold - that specifies consecutive failed health checks after which a target is considered unhealthy
+//                                  the default value is: 3
+//
+//   WithHealthyProbesThreshold   - that specifies consecutive successful health checks after which a target is considered healthy
+//                                  the default value is: 5
+//
+//   WithProbeResponseTimeout     - that specifies a time limit for requests made by the HTTP client for the health check
+//                                  the default value is: 1 second
+//
+//   WithProbeInterval            - that specifies a time interval at which health checks are send
+//                                  the default value is: 2 seconds
+//
+//   WithMetrics                  - that specifies a set of methods that are used to register various metrics
+//                                  the default value is: no metrics
+//
+//
+// Additionally the monitor implements Listener and Notifier interfaces.
+//
+// The health monitor automatically registers for notification if the target provided also implements the Notifier interface.
+// It is implicit so that the provider can provide a static or a dynamic list of targets.
+//
+// Interested parties can register a listener for notifications about healthy/unhealthy targets changes via AddListener.
+// TODO: instead of restConfig we could accept transport so that it is reused instead of creating a new connection to targets
+//       reusing the transport has the advantage of using the same connection as other clients
+func New(targetProvider TargetProvider, restConfig *rest.Config) (*Prober, error) {
+	client, err := createHealthCheckHTTPClient(defaultProbeResponseTimeout, restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	hm := &Prober{
+		client:                   client,
+		targetProvider:           targetProvider,
+		targetsToMonitor:         targetProvider.CurrentTargetsList(),
+		probeInterval:            defaultProbeInterval,
+		unhealthyProbesThreshold: defaultUnhealthyProbesThreshold,
+		healthyProbesThreshold:   defaultHealthyProbesThreshold,
+
+		consecutiveSuccessfulProbes: map[string]int{},
+		consecutiveFailedProbes:     map[string][]error{},
+
+		metrics: &Metrics{
+			HealthyTargetsTotal:        noopMetrics{}.TargetsTotal,
+			CurrentHealthyTargets:      noopMetrics{}.TargetsGauge,
+			UnHealthyTargetsTotal:      noopMetrics{}.TargetsTotal,
+			ReadyzProtocolRequestTotal: noopMetrics{}.TargetsWithCodeTotal,
+		},
+	}
+	hm.exportedHealthyTargets.Store([]string{})
+	hm.exportedUnhealthyTargets.Store([]string{})
+
+	if notifier, ok := targetProvider.(Notifier); ok {
+		notifier.AddListener(hm)
+	}
+
+	return hm, nil
+}
+
+// Run starts monitoring the provided targets until stop channel is closed
+// This method is blocking and it is meant to be launched in a separate goroutine
+func (sm *Prober) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting the health monitor with Interval = %v, Timeout = %v, HealthyThreshold = %v, UnhealthyThreshold = %v ", sm.probeInterval, sm.client.Timeout, sm.healthyProbesThreshold, sm.unhealthyProbesThreshold)
+	defer klog.Info("Shutting down the health monitor")
+
+	wait.Until(sm.healthCheckRegisteredTargets, sm.probeInterval, ctx.Done())
+}
+
+// Enqueue schedules refreshing the target list on the next probeInterval
+// This method is used by the TargetProvider to notify that the list has changed
+func (sm *Prober) Enqueue() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	sm.refreshTargets = true
+}
+
+// Targets returns a list of healthy and unhealthy targets
+func (sm *Prober) Targets() ([]string, []string) {
+	return sm.exportedHealthyTargets.Load().([]string), sm.exportedUnhealthyTargets.Load().([]string)
+}
+
+// AddListener adds a listener to be notified when the list of healthy targets changes
+//
+// Note:
+// this method is not thread safe and mustn't be called after calling StartMonitoring() method
+func (sm *Prober) AddListener(listener Listener) {
+	sm.listeners = append(sm.listeners, listener)
+}
+
+type targetErrTuple struct {
+	target string
+	err    error
+}
+
+// refreshTargetsLocked updates the internal targets list to monitor if it was requested (via the Enqueue method)
+func (sm *Prober) refreshTargetsLocked() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	if !sm.refreshTargets {
+		return
+	}
+
+	sm.refreshTargets = false
+	freshTargets := sm.targetProvider.CurrentTargetsList()
+	freshTargetSet := sets.NewString(freshTargets...)
+
+	currentTargetsSet := sets.NewString(sm.targetsToMonitor...)
+	newTargetsToMonitorSet := freshTargetSet.Difference(currentTargetsSet)
+	if newTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor observed new targets = %v", newTargetsToMonitorSet.List())
+	}
+
+	removedTargetsToMonitorSet := currentTargetsSet.Difference(freshTargetSet)
+	if removedTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor will stop checking the following targets targets = %v", removedTargetsToMonitorSet.List())
+		for targetToRemove := range removedTargetsToMonitorSet {
+			delete(sm.consecutiveSuccessfulProbes, targetToRemove)
+			delete(sm.consecutiveFailedProbes, targetToRemove)
+		}
+
+		healthyTargetsSet := sets.NewString(sm.healthyTargets...)
+		healthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.healthyTargets = healthyTargetsSet.List()
+
+		unhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+		unhealthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.unhealthyTargets = unhealthyTargetsSet.List()
+	}
+
+	sm.targetsToMonitor = freshTargets
+}
+
+func (sm *Prober) healthCheckRegisteredTargets() {
+	sm.refreshTargetsLocked()
+	var wg sync.WaitGroup
+	resTargetErrTupleCh := make(chan targetErrTuple, len(sm.targetsToMonitor))
+
+	for i := 0; i < len(sm.targetsToMonitor); i++ {
+		wg.Add(1)
+		go func(target string) {
+			defer wg.Done()
+			err := sm.healthCheckSingleTarget(target)
+			resTargetErrTupleCh <- targetErrTuple{target, err}
+		}(sm.targetsToMonitor[i])
+	}
+	wg.Wait()
+	close(resTargetErrTupleCh)
+
+	currentHealthCheckProbes := make([]targetErrTuple, 0, len(sm.targetsToMonitor))
+	for svrErrTuple := range resTargetErrTupleCh {
+		currentHealthCheckProbes = append(currentHealthCheckProbes, svrErrTuple)
+	}
+
+	sm.updateHealthChecksFor(currentHealthCheckProbes)
+}
+
+// updateHealthChecksFor examines the health of targets based on the provided probes and the current configuration.
+// It also notifies interested parties about changes in the health condition.
+// Interested parties can be registered by calling AddListener method.
+func (sm *Prober) updateHealthChecksFor(currentHealthCheckProbes []targetErrTuple) {
+	newUnhealthyTargets := []string{}
+	newHealthyTargets := []string{}
+
+	for _, svrErrTuple := range currentHealthCheckProbes {
+		if svrErrTuple.err != nil {
+			delete(sm.consecutiveSuccessfulProbes, svrErrTuple.target)
+
+			unhealthyProbesSlice := sm.consecutiveFailedProbes[svrErrTuple.target]
+			if len(unhealthyProbesSlice) < sm.unhealthyProbesThreshold {
+				unhealthyProbesSlice = append(unhealthyProbesSlice, svrErrTuple.err)
+				sm.consecutiveFailedProbes[svrErrTuple.target] = unhealthyProbesSlice
+				if len(unhealthyProbesSlice) == sm.unhealthyProbesThreshold {
+					newUnhealthyTargets = append(newUnhealthyTargets, svrErrTuple.target)
+				}
+			}
+			continue
+		}
+
+		delete(sm.consecutiveFailedProbes, svrErrTuple.target)
+
+		healthyProbesCounter := sm.consecutiveSuccessfulProbes[svrErrTuple.target]
+		if healthyProbesCounter < sm.healthyProbesThreshold {
+			healthyProbesCounter++
+			sm.consecutiveSuccessfulProbes[svrErrTuple.target] = healthyProbesCounter
+			if healthyProbesCounter == sm.healthyProbesThreshold {
+				newHealthyTargets = append(newHealthyTargets, svrErrTuple.target)
+			}
+		}
+	}
+
+	newUnhealthyTargetsSet := sets.NewString(newUnhealthyTargets...)
+	newHealthyTargetsSet := sets.NewString(newHealthyTargets...)
+	notifyListeners := false
+
+	// detect unhealthy targets
+	previouslyUnhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+	currentlyUnhealthyTargetsSet := previouslyUnhealthyTargetsSet.Union(newUnhealthyTargetsSet)
+	currentlyUnhealthyTargetsSet.Delete(newHealthyTargetsSet.List()...)
+	if !currentlyUnhealthyTargetsSet.Equal(previouslyUnhealthyTargetsSet) {
+		sm.unhealthyTargets = currentlyUnhealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following unhealthy targets %v", sm.unhealthyTargets)
+		logUnhealthyTargets(sm.unhealthyTargets, currentHealthCheckProbes)
+
+		exportedUnhealthyTargets := make([]string, len(sm.unhealthyTargets))
+		for index, unhealthyTarget := range sm.unhealthyTargets {
+			exportedUnhealthyTargets[index] = unhealthyTarget
+			sm.metrics.UnHealthyTargetsTotal(unhealthyTarget)
+		}
+		sm.exportedUnhealthyTargets.Store(exportedUnhealthyTargets)
+		notifyListeners = true
+	}
+
+	// detect healthy targets
+	previouslyHealthyTargetsSet := sets.NewString(sm.healthyTargets...)
+	currentlyHealthyTargetsSet := previouslyHealthyTargetsSet.Union(newHealthyTargetsSet)
+	currentlyHealthyTargetsSet.Delete(newUnhealthyTargetsSet.List()...)
+	if !currentlyHealthyTargetsSet.Equal(previouslyHealthyTargetsSet) {
+		sm.healthyTargets = currentlyHealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following healthy targets %v", sm.healthyTargets)
+
+		exportedHealthyTargets := make([]string, len(sm.healthyTargets))
+		for index, healthyTarget := range sm.healthyTargets {
+			exportedHealthyTargets[index] = healthyTarget
+			sm.metrics.HealthyTargetsTotal(healthyTarget)
+		}
+		sm.exportedHealthyTargets.Store(exportedHealthyTargets)
+		notifyListeners = true
+	}
+
+	if notifyListeners {
+		// something has changed update the currently healthy targets metric
+		sm.metrics.CurrentHealthyTargets(float64(len(sm.healthyTargets)))
+
+		// notify listeners about the new healthy/unhealthy targets
+		for _, listener := range sm.listeners {
+			listener.Enqueue()
+		}
+	}
+}
+
+func (sm *Prober) healthCheckSingleTarget(target string) error {
+	// TODO: make the protocol, port and the path configurable
+	targetURL, err := url.Parse(fmt.Sprintf("https://%s/%s", target, "readyz"))
+	if err != nil {
+		return err
+	}
+	newReq, err := http.NewRequest("GET", targetURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := sm.client.Do(newReq)
+	if err != nil {
+		sm.metrics.ReadyzProtocolRequestTotal("<error>", target)
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusInternalServerError {
+			sm.metrics.ReadyzProtocolRequestTotal(strconv.Itoa(resp.StatusCode), target)
+		}
+		return fmt.Errorf("bad status from %v: %v, expected HTTP 200", targetURL.String(), resp.StatusCode)
+	}
+
+	return err
+}
+
+func createHealthCheckHTTPClient(responseTimeout time.Duration, restConfig *rest.Config) (*http.Client, error) {
+	transportConfig, err := restConfig.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: utilnet.SetTransportDefaults(&http.Transport{
+			TLSClientConfig: tlsConfig,
+		}),
+		Timeout: responseTimeout,
+	}
+
+	return client, nil
+}
+
+func logUnhealthyTargets(unhealthyTargets []string, currentHealthCheckProbes []targetErrTuple) {
+	for _, unhealthyTarget := range unhealthyTargets {
+		errorsForUnhealthyTarget := []error{}
+		for _, svrErrTuple := range currentHealthCheckProbes {
+			if svrErrTuple.target == unhealthyTarget {
+				errorsForUnhealthyTarget = append(errorsForUnhealthyTarget, svrErrTuple.err)
+			}
+		}
+		klog.V(2).Infof("the following target %v became unhealthy due to %v", unhealthyTarget, utilerrors.NewAggregate(errorsForUnhealthyTarget).Error())
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/target_resolver.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/target_resolver.go
@@ -1,0 +1,28 @@
+package health
+
+// Listener is an interface to use to notify interested parties of a change.
+type Listener interface {
+	// Enqueue should be called when an input may have changed
+	Enqueue()
+}
+
+// Notifier is a way to add listeners
+type Notifier interface {
+	// AddListener is adds a listener to be notified of potential input changes
+	AddListener(listener Listener)
+}
+
+// TargetProviders is an interface to use to get a list of targets to monitor
+type TargetProvider interface {
+	// CurrentTargetsList returns a precomputed list of targets
+	CurrentTargetsList() []string
+}
+
+// StaticTargetProvider implements TargetProvider and provides a static list of targets
+type StaticTargetProvider []string
+
+var _ TargetProvider = StaticTargetProvider{}
+
+func (sp StaticTargetProvider) CurrentTargetsList() []string {
+	return sp
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1064,9 +1064,9 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+# github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 ## explicit
-# github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+# github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig
 github.com/openshift/library-go/pkg/apiserver/admission/admissiontimeout
@@ -1084,6 +1084,7 @@ github.com/openshift/library-go/pkg/image/imageutil
 github.com/openshift/library-go/pkg/image/internal/digest
 github.com/openshift/library-go/pkg/image/internal/reference
 github.com/openshift/library-go/pkg/image/reference
+github.com/openshift/library-go/pkg/monitor/health
 github.com/openshift/library-go/pkg/network
 github.com/openshift/library-go/pkg/oauth/oauthdiscovery
 github.com/openshift/library-go/pkg/quota/clusterquotamapping


### PR DESCRIPTION
to switch KMC to use a preferred host (for now only `localhost` is supported) the following `unsupported-kube-api-over-localhost` must be set to `true`

```
unsupportedConfigOverrides:
  extendedArguments:
    unsupported-kube-api-over-localhost:
      - "true"
```


The preferred host is the primary host to which KCM will be sending all requests. There is a health monitor that is constantly monitoring it. When the new host is unavailable all requests will be directed to the old host (from kubeconfig)