### PR TITLE
improves the apiserver graceful shutdown procedure

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -848,6 +849,9 @@ var _ genericapiserver.EventSink = eventRegistrySink{}
 
 func (s eventRegistrySink) Create(v1event *corev1.Event) (*corev1.Event, error) {
 	ctx := request.WithNamespace(request.WithRequestInfo(request.NewContext(), &request.RequestInfo{APIVersion: "v1"}), v1event.Namespace)
+	// since we are bypassing the API set a hard timeout for the storage layer
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 
 	var event core.Event
 	if err := v1.Convert_v1_Event_To_core_Event(v1event, &event, nil); err != nil {


### PR DESCRIPTION
It fixes two potential issues that were found during investigating https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp/1367261143931817984

`1`: it makes recording termination events a non-blocking operation.
previously closing `delayedStopCh` might have been delayed on preserving data in the storage.
the `delayedStopCh` is important as it signals the HTTP server to start the shutdown procedure.

`2`: it also sets a hard timeout of 3 seconds for the storage layer since we are bypassing the API layer.

