### PR TITLE
Limit public-info-viewer cluster role to oauth-authorization-server only

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -223,7 +223,7 @@ func clusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:openshift:public-info-viewer"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
-					"/.well-known", "/.well-known/*",
+					"/.well-known", "/.well-known/oauth-authorization-server",
 				).RuleOrDie(),
 			},
 		},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1162,7 +1162,7 @@ items:
   rules:
   - nonResourceURLs:
     - /.well-known
-    - /.well-known/*
+    - /.well-known/oauth-authorization-server
     verbs:
     - get
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Upstream started leveraging .well-known endpoints and does not allow
accessing them by unauthenticated groups by default. Only limit
unauthenticated access to the `/.well-known/oauth-authorization-server`
endpoint that is needed for authentication into OpenShift.

----

cc @sttts @deads2k 