### PR TITLE
UPSTREAM: <carry>: kube-apiserver: ignore SIGTERM/INT after the first one

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -178,7 +178,7 @@ cluster's shared state through which all other components interact.`,
 				return utilerrors.NewAggregate(errs)
 			}
 
-			return Run(completedOptions, genericapiserver.SetupSignalHandler(false))
+			return Run(completedOptions, genericapiserver.SetupSignalHandlerIgnoringFurtherSignals())
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -126,7 +126,7 @@ controller, and serviceaccounts controller.`,
 				os.Exit(1)
 			}
 
-			stopCh := server.SetupSignalHandler(true)
+			stopCh := server.SetupSignalHandler()
 			if err := Run(c.Complete(), stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -124,7 +124,7 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		stopCh := server.SetupSignalHandler(true)
+		stopCh := server.SetupSignalHandler()
 		<-stopCh
 		cancel()
 	}()

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -261,7 +261,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			kubeletDeps.KubeletConfigController = kubeletConfigController
 
 			// set up signal context here in order to be reused by kubelet and docker shim
-			ctx := genericapiserver.SetupSignalContext(true)
+			ctx := genericapiserver.SetupSignalContext()
 
 			// run the kubelet
 			klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)

--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -31,7 +31,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	stopCh := genericapiserver.SetupSignalHandler(true)
+	stopCh := genericapiserver.SetupSignalHandler()
 	cmd := server.NewServerCommand(os.Stdout, os.Stderr, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/signal.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/signal.go
@@ -32,14 +32,30 @@ var shutdownHandler chan os.Signal
 // is terminated with exit code 1.
 // Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
 // be called once.
-func SetupSignalHandler(exitOnSecondSignal bool) <-chan struct{} {
-	return SetupSignalContext(exitOnSecondSignal).Done()
+func SetupSignalHandler() <-chan struct{} {
+	return SetupSignalContext().Done()
+}
+
+// SetupSignalHandlerIgnoringFurtherSignals is the same as SetupSignalContext, except
+// it ignores further exit signals after receiving the first one.
+func SetupSignalHandlerIgnoringFurtherSignals() <-chan struct{} {
+	return SetupSignalContextNotExiting().Done()
 }
 
 // SetupSignalContext is same as SetupSignalHandler, but a context.Context is returned.
 // Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
 // be called once.
-func SetupSignalContext(exitOnSecondSignal bool) context.Context {
+func SetupSignalContext() context.Context {
+	return setupSignalContext(true)
+}
+
+// SetupSignalContextNotExiting is the same as SetupSignalContext, except
+// it ignores further exit signals after receiving the first one.
+func SetupSignalContextNotExiting() context.Context {
+	return setupSignalContext(false)
+}
+
+func setupSignalContext(exitOnSecondSignal bool) context.Context {
 	close(onlyOneSignalHandler) // panics when called twice
 
 	shutdownHandler = make(chan os.Signal, 2)

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -38,7 +38,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	stopCh := genericapiserver.SetupSignalHandler(true)
+	stopCh := genericapiserver.SetupSignalHandler()
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)
 	cmd := server.NewCommandStartAggregator(options, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
This partially reverts some of the changes from https://github.com/openshift/kubernetes/pull/558 to provide the new functions for areas that need them, while keeping the old functions so as to not affect other repos that depend on them (like library-go, see https://github.com/openshift/library-go/pull/1008)