### PR TITLE
bump IPv6DualStack to beta (early merge from 1.21)

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -229,10 +229,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"of type NodePort, using this as the value of the port. If zero, the Kubernetes master "+
 		"service will be of type ClusterIP.")
 
-	// TODO (khenidak) change documentation as we move IPv6DualStack feature from ALPHA to BETA
 	fs.StringVar(&s.ServiceClusterIPRanges, "service-cluster-ip-range", s.ServiceClusterIPRanges, ""+
 		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+
-		"overlap with any IP ranges assigned to nodes or pods.")
+		"overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.")
 
 	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
 		"A port range to reserve for services with NodePort visibility. "+

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -1897,6 +1897,11 @@ func TestSetDefaultIPFamilies(t *testing.T) {
 			}
 		})
 
+		// TODO: @khenidak
+		// with BETA feature is always on. This ensure we test for gate on/off scenarios
+		// as we move to stable this entire test will need to be folded into one test
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, false)()
+
 		// run without gate (families should not change)
 		t.Run(fmt.Sprintf("without-gate:%s", test.name), func(t *testing.T) {
 			obj2 := roundTrip(t, runtime.Object(&test.svc))
@@ -2039,6 +2044,10 @@ func TestSetDefaultServiceIPFamilyPolicy(t *testing.T) {
 
 		// without gate. IPFamilyPolicy should never change
 		t.Run(test.name, func(t *testing.T) {
+			//TODO: @khenidak
+			// BETA feature. gate is on. when we go stable fold the test into one scenario
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, false)()
+
 			obj2 := roundTrip(t, runtime.Object(&test.svc))
 			svc2 := obj2.(*v1.Service)
 

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -104,11 +104,6 @@ func NewNodeIpamController(
 			klog.Fatal("Controller: Must specify --cluster-cidr if --allocate-node-cidrs is set")
 		}
 
-		// TODO: (khenidak) IPv6DualStack beta:
-		// - modify mask to allow flexible masks for IPv4 and IPv6
-		// - for alpha status they are the same
-
-		// for each cidr, node mask size must be <= cidr mask
 		for idx, cidr := range clusterCIDRs {
 			mask := cidr.Mask
 			if maskSize, _ := mask.Size(); maskSize > nodeCIDRMaskSizes[idx] {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -511,6 +511,7 @@ const (
 
 	// owner: @khenidak
 	// alpha: v1.15
+	// beta: v1.21
 	//
 	// Enables ipv6 dual stack
 	IPv6DualStack featuregate.Feature = "IPv6DualStack"
@@ -797,7 +798,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NonPreemptingPriority:                          {Default: true, PreRelease: featuregate.Beta},
 	VolumePVCDataSource:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
 	PodOverhead:                                    {Default: true, PreRelease: featuregate.Beta},
-	IPv6DualStack:                                  {Default: false, PreRelease: featuregate.Alpha},
+	IPv6DualStack:                                  {Default: true, PreRelease: featuregate.Beta},
 	EndpointSlice:                                  {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceProxying:                          {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceTerminatingCondition:              {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -183,6 +183,15 @@ func TestCNIPlugin(t *testing.T) {
 				},
 			}, cmd, args...)
 		},
+		func(cmd string, args ...string) exec.Cmd {
+			return fakeexec.InitFakeCmd(&fakeexec.FakeCmd{
+				CombinedOutputScript: []fakeexec.FakeAction{
+					func() ([]byte, []byte, error) {
+						return []byte(podIPOutput), nil, nil
+					},
+				},
+			}, cmd, args...)
+		},
 	}
 
 	fexec := &fakeexec.FakeExec{


### PR DESCRIPTION
Pull in the IPv6DualStack alpha->beta migration now, so we can test dual stack in master without needing to override feature gates.

I skimmed for other post-1.20 dual-stack related commits and found:
- improved e2e testing
- ipvs fixes
- cloud/Azure fixes
- fixes to error handling when the user creates invalid dual-stack services
- fixes for single-stack clusters where IPv6 is disabled in the kernel
 
none of which seems _immediately_ necessary (though we may end up merging a few more bits before the eventual 1.21 rebase...)

cc @aojea 