### PR TITLE
Ensure multi-az test is run in the serial job

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -1365,9 +1365,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs": "should schedule pods in the same zones as statically provisioned PVs [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones": "should spread the pods of a replication controller across zones [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones [Serial]": "should spread the pods of a replication controller across zones [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones": "should spread the pods of a service across zones [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones [Serial]": "should spread the pods of a service across zones [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
 	"[Top Level] [sig-scheduling] SchedulerPredicates [Serial] PodTopologySpread Filtering validates 4 pods with MaxSkew=1 are evenly distributed into 2 nodes": "validates 4 pods with MaxSkew=1 are evenly distributed into 2 nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -121,8 +121,6 @@ var (
 			`Clean up pods on node`,     // schedules up to max pods per node
 			`DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume`, // test is very disruptive to other tests
 
-			`Multi-AZ Clusters should spread the pods of a service across zones`, // spreading is a priority, not a predicate, and if the node is temporarily full the priority will be ignored
-
 			`Should be able to support the 1\.7 Sample API Server using the current Aggregator`, // down apiservices break other clients today https://bugzilla.redhat.com/show_bug.cgi?id=1623195
 
 			`\[Feature:HPA\] Horizontal pod autoscaling \(scale resource: CPU\) \[sig-autoscaling\] ReplicationController light Should scale from 1 pod to 2 pods`,

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -69,11 +69,11 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 			cleanUp()
 		}
 	})
-	ginkgo.It("should spread the pods of a service across zones", func() {
+	ginkgo.It("should spread the pods of a service across zones [Serial]", func() {
 		SpreadServiceOrFail(f, 5*zoneCount, imageutils.GetPauseImageName())
 	})
 
-	ginkgo.It("should spread the pods of a replication controller across zones", func() {
+	ginkgo.It("should spread the pods of a replication controller across zones [Serial]", func() {
 		SpreadRCOrFail(f, int32(5*zoneCount), framework.ServeHostnameImage, []string{"serve-hostname"})
 	})
 })


### PR DESCRIPTION
Upstream PR: https://github.com/kubernetes/kubernetes/pull/100378

This change is necessary to allow the disruptive quorum restore test to successfully pass conformance after restore.

/cc  @smarterclayton  @hexfusion 