### PR TITLE
Ratelimit proof

### DIFF
--- a/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
@@ -1,14 +1,24 @@
 package openshiftkubeapiserver
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"strings"
-
-	authenticationv1 "k8s.io/api/authentication/v1"
-	genericapiserver "k8s.io/apiserver/pkg/server"
+	"time"
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	"github.com/openshift/library-go/pkg/apiserver/httprequest"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 // TODO switch back to taking a kubeapiserver config.  For now make it obviously safe for 3.11
@@ -26,6 +36,9 @@ func BuildHandlerChain(consolePublicURL string, oauthMetadataFile string) (func(
 	return func(apiHandler http.Handler, genericConfig *genericapiserver.Config) http.Handler {
 			// well-known comes after the normal handling chain. This shows where to connect for oauth information
 			handler := withOAuthInfo(apiHandler, oAuthMetadata)
+
+			// we rate limit watches after building the regular handler chain so we have the context information
+			handler = withWatchRateLimit(handler)
 
 			// this is the normal kube handler chain
 			handler = genericapiserver.DefaultBuildHandlerChain(handler, genericConfig)
@@ -94,4 +107,126 @@ func translateLegacyScopeImpersonation(handler http.Handler) http.Handler {
 
 		handler.ServeHTTP(w, req)
 	})
+}
+
+type authorizerAttributesFunc func(ctx context.Context) (authorizer.Attributes, error)
+
+type watchRateLimit struct {
+	delegate http.Handler
+
+	earlyRateLimiter  flowcontrol.RateLimiter
+	middleRateLimiter flowcontrol.RateLimiter
+
+	authorizerAttributesFn authorizerAttributesFunc
+	clock                  clock.Clock
+	earlyEndTime           time.Time
+	middleEndTime          time.Time
+}
+
+// ServeHTTP rate limits the establishment of watches to keep kube-apiservers from crashing.
+// Rate limiting watches effectively creates an upper bound on secret and configmap mounts of 10*QPS because of a
+// ten minute watch timeout and kubelets use watches to get the content for the mount.
+// We will break the rate limiting into three timespans
+// 1. first ten minutes: this is the most restrictive 10000 total mounted secrets and configmaps, 1000 per minute.
+//    We're trying to break up the slug of kubelet traffic and
+//    we want to be sure that operators can make progress during this time if we need to recover a cluster in
+//    a bad state.
+// 2. second ten minutes: this is less restrictive  20000 total mounted secrets and configmaps, 2000 per minute.
+//    This lets us start to ramp up during a relative steady state.
+// 3. no limit.  We have this to handle cases of large clusters with more than 20000 mounted secrets and configmaps.
+//    I honestly don't know how common this is, but I don't want to break on it.
+// Recall that we observed more than the the 30,000 per minute observed during some disruptive events on a cluster.
+// In addition, we special case watches in the platform operator namespaces, cluster scope, and kube-system.
+// We have not observed large numbers of these and they are required in order to make progress when trying to correct
+// some kinds of cluster failures.
+func (h watchRateLimit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var effectiveRateLimiter flowcontrol.RateLimiter
+	now := h.clock.Now()
+	switch {
+	case now.After(h.middleEndTime):
+		// we are past our rate limiting time
+		h.delegate.ServeHTTP(w, req)
+		return
+	case now.After(h.earlyEndTime):
+		effectiveRateLimiter = h.middleRateLimiter
+	default:
+		effectiveRateLimiter = h.earlyRateLimiter
+	}
+
+	ctx := req.Context()
+
+	attributes, err := h.authorizerAttributesFn(ctx)
+	if err != nil {
+		// if we cannot get attributes, don't fail the request
+		h.delegate.ServeHTTP(w, req)
+		return
+	}
+	if attributes.GetUser() == nil {
+		// if we cannot get user, don't fail the request
+		h.delegate.ServeHTTP(w, req)
+		return
+	}
+	for _, group := range attributes.GetUser().GetGroups() {
+		if group == user.SystemPrivilegedGroup {
+			// system:masters always have the power!
+			h.delegate.ServeHTTP(w, req)
+			return
+		}
+	}
+
+	if attributes.GetVerb() != "watch" {
+		// only throttle watch establishment
+		h.delegate.ServeHTTP(w, req)
+		return
+	}
+	namespace := attributes.GetNamespace()
+	switch {
+	case len(namespace) == 0:
+		// don't rate limit cluster scoped watches because operators that need to make progress may use those
+		// if we have to restrict further we can
+		h.delegate.ServeHTTP(w, req)
+		return
+
+	case strings.HasPrefix("kube-", namespace):
+		// don't rate limit kube- because some operators use and we use this for delegated authn
+		h.delegate.ServeHTTP(w, req)
+		return
+
+	case strings.HasPrefix("openshift-", namespace):
+		// don't rate limit openshift- because we need operators to make progress, so we need openshift- mounts
+		// to succeed in order to progress
+		h.delegate.ServeHTTP(w, req)
+		return
+
+	}
+
+	// TODO Abu: Can I get some metrics help here?
+	if !effectiveRateLimiter.TryAccept() {
+		ae := request.AuditEventFrom(ctx)
+		audit.LogAnnotation(ae, "apiserver.openshift.io/watch-rate-limit", "rate-limited")
+		retryAfter := rand.Intn(15) + 5 // evenly weighted from 5-20 second wait
+		// Return a 429 status indicating "Too Many Requests", but make sure its recognizeable
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+		http.Error(w, "Too many WATCH requests, please try again later.", http.StatusTooManyRequests)
+		return
+	}
+	h.delegate.ServeHTTP(w, req)
+}
+
+func newWatchRateLimit(handler http.Handler, theClock clock.Clock) watchRateLimit {
+	startTime := theClock.Now()
+
+	return watchRateLimit{
+		delegate:               handler,
+		earlyRateLimiter:       flowcontrol.NewTokenBucketRateLimiterWithClock(16.6, 100, theClock),
+		middleRateLimiter:      flowcontrol.NewTokenBucketRateLimiterWithClock(33.3, 100, theClock),
+		authorizerAttributesFn: filters.GetAuthorizerAttributes,
+		clock:                  theClock,
+		earlyEndTime:           startTime.Add(10 * time.Minute),
+		middleEndTime:          startTime.Add(20 * time.Minute),
+	}
+}
+
+func withWatchRateLimit(handler http.Handler) http.Handler {
+	return newWatchRateLimit(handler, clock.RealClock{})
 }

--- a/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
@@ -218,7 +218,7 @@ func newWatchRateLimit(handler http.Handler, theClock clock.Clock) watchRateLimi
 
 	return watchRateLimit{
 		delegate:               handler,
-		earlyRateLimiter:       flowcontrol.NewTokenBucketRateLimiterWithClock(16.6, 100, theClock),
+		earlyRateLimiter:       flowcontrol.NewTokenBucketRateLimiterWithClock(0.5, 1, theClock),
 		middleRateLimiter:      flowcontrol.NewTokenBucketRateLimiterWithClock(33.3, 100, theClock),
 		authorizerAttributesFn: filters.GetAuthorizerAttributes,
 		clock:                  theClock,

--- a/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain_test.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain_test.go
@@ -1,0 +1,103 @@
+package openshiftkubeapiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func TestWatchRateLimit(t *testing.T) {
+	delegate := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	fakeClock := clock.NewFakeClock(time.Now())
+
+	watchRateLimiter := newWatchRateLimit(delegate, fakeClock)
+	watchRateLimiter.earlyRateLimiter = flowcontrol.NewTokenBucketRateLimiterWithClock(1, 1, fakeClock)
+	watchRateLimiter.middleRateLimiter = flowcontrol.NewTokenBucketRateLimiterWithClock(3, 3, fakeClock)
+	watchRateLimiter.authorizerAttributesFn = func(ctx context.Context) (authorizer.Attributes, error) {
+		return authorizer.AttributesRecord{
+			User: &user.DefaultInfo{
+				Name:   "",
+				UID:    "",
+				Groups: nil,
+				Extra:  nil,
+			},
+			Verb:            "watch",
+			Namespace:       "foo",
+			APIGroup:        "",
+			APIVersion:      "",
+			Resource:        "pods",
+			Subresource:     "",
+			Name:            "",
+			ResourceRequest: true,
+			Path:            "",
+		}, nil
+	}
+
+	testServer := httptest.NewServer(watchRateLimiter)
+	defer testServer.Close()
+
+	// fill the buckets
+	fakeClock.SetTime(fakeClock.Now().Add(1 * time.Minute))
+	expectOk(t, testServer)
+	expectRateLimit(t, testServer)
+
+	// refill early
+	fakeClock.SetTime(fakeClock.Now().Add(1 * time.Second))
+	expectOk(t, testServer)
+	expectRateLimit(t, testServer)
+
+	// move to the middle rate limiter
+	fakeClock.SetTime(fakeClock.Now().Add(10 * time.Minute))
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectRateLimit(t, testServer)
+
+	// refill middle
+	fakeClock.SetTime(fakeClock.Now().Add(1 * time.Second))
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectRateLimit(t, testServer)
+
+	// move to unlimited
+	fakeClock.SetTime(fakeClock.Now().Add(10 * time.Minute))
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+	expectOk(t, testServer)
+}
+
+func expectOk(t *testing.T, testServer *httptest.Server) {
+	t.Helper()
+
+	response, err := testServer.Client().Get(testServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatal(response.StatusCode)
+	}
+}
+
+func expectRateLimit(t *testing.T, testServer *httptest.Server) {
+	t.Helper()
+
+	response, err := testServer.Client().Get(testServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatal(response.StatusCode)
+	}
+}


### PR DESCRIPTION
make sure that https://github.com/openshift/kubernetes/pull/629 works

/hold

This sets the limit very low to be sure we see the information in the audit log.