### PR TITLE
UPSTREAM: <carry>: openshift KCM volume plugin manager uses a disjoint set of featuregates

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -385,7 +385,7 @@ func startVolumeExpandController(ctx ControllerContext) (http.Handler, bool, err
 			ctx.Cloud,
 			plugins,
 			csiTranslator,
-			csimigration.NewPluginManager(csiTranslator),
+			csimigration.NewKCMPluginManager(csiTranslator),
 			filteredDialOptions,
 		)
 

--- a/pkg/features/patch_kube_features.go
+++ b/pkg/features/patch_kube_features.go
@@ -1,0 +1,22 @@
+package features
+
+import "k8s.io/component-base/featuregate"
+
+var (
+	// owner: @jsafrane
+	// alpha: v1.21
+	//
+	// Disables the AWS EBS in-tree driver for the KCM only.
+	KCMInTreePluginAWSUnregister featuregate.Feature = "KCM_InTreePluginAWSUnregister"
+
+	// owner: @jsafrane
+	// alpha: v1.21
+	//
+	// Disables the GCE PD in-tree driver for the KCM only.
+	KCMInTreePluginGCEUnregister featuregate.Feature = "KCM_InTreePluginGCEUnregister"
+)
+
+func init() {
+	defaultKubernetesFeatureGates[KCMInTreePluginAWSUnregister] = featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}
+	defaultKubernetesFeatureGates[KCMInTreePluginGCEUnregister] = featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}
+}

--- a/pkg/volume/csimigration/patch_kcm_plugin_manager.go
+++ b/pkg/volume/csimigration/patch_kcm_plugin_manager.go
@@ -14,6 +14,26 @@ func NewKCMPluginManager(m PluginNameMapper, featureGate featuregate.FeatureGate
 }
 
 // IsMigrationCompleteForPlugin indicates whether CSI migration has been completed
+// for a particular storage plugin
+func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
+	if pm.useKCMPluginManagerFeatureGates {
+		return pm.kcmIsMigrationCompleteForPlugin(pluginName)
+	}
+
+	return pm.isMigrationCompleteForPlugin(pluginName)
+}
+
+// IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
+// for a particular storage plugin
+func (pm PluginManager) IsMigrationEnabledForPlugin(pluginName string) bool {
+	if pm.useKCMPluginManagerFeatureGates {
+		return pm.kcmIsMigrationEnabledForPlugin(pluginName)
+	}
+
+	return pm.isMigrationEnabledForPlugin(pluginName)
+}
+
+// IsMigrationCompleteForPlugin indicates whether CSI migration has been completed
 // for a particular storage plugin. A complete migration will need to:
 // 1. Enable CSIMigrationXX for the plugin
 // 2. Unregister the in-tree plugin by setting the InTreePluginXXUnregister feature gate
@@ -30,7 +50,7 @@ func (pm PluginManager) kcmIsMigrationCompleteForPlugin(pluginName string) bool 
 		return pm.featureGate.Enabled(features.KCMInTreePluginAWSUnregister)
 	default:
 		// default to the normal path
-		return pm.IsMigrationCompleteForPlugin(pluginName)
+		return pm.isMigrationCompleteForPlugin(pluginName)
 	}
 }
 
@@ -48,6 +68,6 @@ func (pm PluginManager) kcmIsMigrationEnabledForPlugin(pluginName string) bool {
 		return pm.featureGate.Enabled(features.KCMCSIMigrationAWS)
 	default:
 		// default to the normal path
-		return pm.IsMigrationEnabledForPlugin(pluginName)
+		return pm.isMigrationEnabledForPlugin(pluginName)
 	}
 }

--- a/pkg/volume/csimigration/patch_kcm_plugin_manager.go
+++ b/pkg/volume/csimigration/patch_kcm_plugin_manager.go
@@ -1,0 +1,53 @@
+package csimigration
+
+import (
+	"k8s.io/component-base/featuregate"
+	csilibplugins "k8s.io/csi-translation-lib/plugins"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// NewKCMPluginManager returns a new PluginManager instance for the KCM which uses different featuregates in openshift
+// to control enablement/disablement which *DO NOT MATCH* the featuregates for the rest of the cluster.
+func NewKCMPluginManager(m PluginNameMapper, featureGate featuregate.FeatureGate) PluginManager {
+	ret := NewPluginManager(m, featureGate)
+	ret.useKCMPluginManagerFeatureGates = true
+}
+
+// IsMigrationCompleteForPlugin indicates whether CSI migration has been completed
+// for a particular storage plugin. A complete migration will need to:
+// 1. Enable CSIMigrationXX for the plugin
+// 2. Unregister the in-tree plugin by setting the InTreePluginXXUnregister feature gate
+func (pm PluginManager) kcmIsMigrationCompleteForPlugin(pluginName string) bool {
+	// CSIMigration feature and plugin specific InTreePluginUnregister feature flags should
+	// be enabled for plugin specific migration completion to be take effect
+	if !pm.IsMigrationEnabledForPlugin(pluginName) {
+		return false
+	}
+
+	// only list your special cases here
+	switch pluginName {
+	case csilibplugins.AWSEBSInTreePluginName:
+		return pm.featureGate.Enabled(features.KCMInTreePluginAWSUnregister)
+	default:
+		// default to the normal path
+		return pm.IsMigrationCompleteForPlugin(pluginName)
+	}
+}
+
+// IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
+// for a particular storage plugin
+func (pm PluginManager) kcmIsMigrationEnabledForPlugin(pluginName string) bool {
+	// CSIMigration feature should be enabled along with the plugin-specific one
+	if !pm.featureGate.Enabled(features.CSIMigration) {
+		return false
+	}
+
+	// only list your special cases here
+	switch pluginName {
+	case csilibplugins.AWSEBSInTreePluginName:
+		return pm.featureGate.Enabled(features.KCMCSIMigrationAWS)
+	default:
+		// default to the normal path
+		return pm.IsMigrationEnabledForPlugin(pluginName)
+	}
+}

--- a/pkg/volume/csimigration/plugin_manager.go
+++ b/pkg/volume/csimigration/plugin_manager.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
@@ -38,6 +38,8 @@ type PluginNameMapper interface {
 // PluginManager keeps track of migrated state of in-tree plugins
 type PluginManager struct {
 	PluginNameMapper
+
+	useKCMPluginManagerFeatureGates bool
 }
 
 // NewPluginManager returns a new PluginManager instance
@@ -50,6 +52,10 @@ func NewPluginManager(m PluginNameMapper) PluginManager {
 // IsMigrationCompleteForPlugin indicates whether CSI migration has been completed
 // for a particular storage plugin
 func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
+	if pm.useKCMPluginManagerFeatureGates {
+		return pm.kcmIsMigrationCompleteForPlugin(pluginName)
+	}
+
 	// CSIMigration feature and plugin specific migration feature flags should
 	// be enabled for plugin specific migration completion feature flags to be
 	// take effect
@@ -78,6 +84,10 @@ func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
 // IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
 // for a particular storage plugin
 func (pm PluginManager) IsMigrationEnabledForPlugin(pluginName string) bool {
+	if pm.useKCMPluginManagerFeatureGates {
+		return pm.kcmIsMigrationEnabledForPlugin(pluginName)
+	}
+
 	// CSIMigration feature should be enabled along with the plugin-specific one
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
 		return false

--- a/pkg/volume/csimigration/plugin_manager.go
+++ b/pkg/volume/csimigration/plugin_manager.go
@@ -49,13 +49,7 @@ func NewPluginManager(m PluginNameMapper) PluginManager {
 	}
 }
 
-// IsMigrationCompleteForPlugin indicates whether CSI migration has been completed
-// for a particular storage plugin
-func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
-	if pm.useKCMPluginManagerFeatureGates {
-		return pm.kcmIsMigrationCompleteForPlugin(pluginName)
-	}
-
+func (pm PluginManager) isMigrationCompleteForPlugin(pluginName string) bool {
 	// CSIMigration feature and plugin specific migration feature flags should
 	// be enabled for plugin specific migration completion feature flags to be
 	// take effect
@@ -81,13 +75,7 @@ func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
 	}
 }
 
-// IsMigrationEnabledForPlugin indicates whether CSI migration has been enabled
-// for a particular storage plugin
-func (pm PluginManager) IsMigrationEnabledForPlugin(pluginName string) bool {
-	if pm.useKCMPluginManagerFeatureGates {
-		return pm.kcmIsMigrationEnabledForPlugin(pluginName)
-	}
-
+func (pm PluginManager) isMigrationEnabledForPlugin(pluginName string) bool {
 	// CSIMigration feature should be enabled along with the plugin-specific one
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
 		return false


### PR DESCRIPTION
The volume plugin manager for openshfit's kube-controller-manager uses a set of featuregates that are NOT the same as the the kube-controller-manager and not the same as the kubelet.

This means these featuregates (if we kept the old names) would be inconsistent inside of a single binary.  There are now separate featuregates for the volumepluginmanger when running in teh kubecontrollermanager to reflect this distintion.