### PR TITLE
Bug 1941000:  get AZ of cinder volume from cinder and not from metadata

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -739,16 +739,16 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 		return nil, nil
 	}
 
-	// Get metadata
-	md, err := getMetadata(os.metadataOpts.SearchOrder)
+	// Get Volume
+	volume, err := os.getVolume(pv.Spec.Cinder.VolumeID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Construct Volume Labels
 	labels := make(map[string]string)
-	if md.AvailabilityZone != "" {
-		labels[v1.LabelFailureDomainBetaZone] = md.AvailabilityZone
+	if volume.AvailabilityZone != "" {
+		labels[v1.LabelFailureDomainBetaZone] = volume.AvailabilityZone
 	}
 	if os.region != "" {
 		labels[v1.LabelFailureDomainBetaRegion] = os.region


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1941000

and reverts https://github.com/openshift/origin/pull/23578/files
