### PR TITLE
KS with preferred host support

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 
 	// LeaderElection is optional.
 	LeaderElection *leaderelection.LeaderElectionConfig
+
+	// OpenShiftContext is additional context that we need to launch the kube-scheduler for openshift
+	OpenShiftContext OpenShiftContext
 }
 
 type completedConfig struct {

--- a/cmd/kube-scheduler/app/config/patch.go
+++ b/cmd/kube-scheduler/app/config/patch.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"k8s.io/client-go/transport"
+
+	"github.com/openshift/library-go/pkg/monitor/health"
+)
+
+// OpenShiftContext is additional context that we need to launch the kube-scheduler for openshift.
+// Basically, this holds our additional config information.
+type OpenShiftContext struct {
+	UnsupportedKubeAPIOverPreferredHost bool
+	PreferredHostRoundTripperWrapperFn  transport.WrapperFunc
+	PreferredHostHealthMonitor          *health.Prober
+}

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -49,6 +49,8 @@ import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
 
 // Options has all the params needed to run a Scheduler
@@ -71,6 +73,9 @@ type Options struct {
 	WriteConfigTo string
 
 	Master string
+
+	// OpenShiftContext is additional context that we need to launch the kube-scheduler for openshift.
+	OpenShiftContext schedulerappconfig.OpenShiftContext
 }
 
 // NewOptions returns default scheduler app options.
@@ -156,6 +161,7 @@ func (o *Options) Flags() (nfs cliflag.NamedFlagSets) {
   --policy-configmap-namespace`)
 	fs.StringVar(&o.WriteConfigTo, "write-config-to", o.WriteConfigTo, "If set, write the configuration values to this file and exit.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.BoolVar(&o.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost, "unsupported-kube-api-over-localhost", false, "when set makes KS prefer talking to localhost kube-apiserver (when available) instead of an LB")
 
 	o.SecureServing.AddFlags(nfs.FlagSet("secure serving"))
 	o.CombinedInsecureServing.AddFlags(nfs.FlagSet("insecure serving"))
@@ -262,11 +268,17 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 	if err := o.ApplyTo(c); err != nil {
 		return nil, err
 	}
+	c.OpenShiftContext = o.OpenShiftContext
 
 	// Prepare kube config.
 	kubeConfig, err := createKubeConfig(c.ComponentConfig.ClientConnection, o.Master)
 	if err != nil {
 		return nil, err
+	}
+
+	if c.OpenShiftContext.PreferredHostRoundTripperWrapperFn != nil {
+		libgorestclient.DefaultServerName(kubeConfig)
+		kubeConfig.Wrap(c.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
 	}
 
 	// Prepare kube clients.

--- a/cmd/kube-scheduler/app/options/patch.go
+++ b/cmd/kube-scheduler/app/options/patch.go
@@ -1,0 +1,7 @@
+package options
+
+import kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+
+func LoadKubeSchedulerConfiguration(file string) (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {
+	return loadConfigFromFile(file)
+}

--- a/cmd/kube-scheduler/app/patch.go
+++ b/cmd/kube-scheduler/app/patch.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/monitor/health"
+)
+
+func setUpPreferredHostForOpenShift(kubeSchedulerOptions *options.Options) error {
+	if !kubeSchedulerOptions.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost {
+		return nil
+	}
+
+	master, kubeConfig := kubeSchedulerOptions.Master, kubeSchedulerOptions.ComponentConfig.ClientConnection.Kubeconfig
+
+	// this makes our patch small
+	// if there was no kubeconfig specified we won't be able to get cluster info.
+	// in that case try to load the configuration and read kubeconfig directly from it if it was provided.
+	if len(kubeConfig) == 0 && len(kubeSchedulerOptions.ConfigFile) > 0 {
+		cfg, err := options.LoadKubeSchedulerConfiguration(kubeSchedulerOptions.ConfigFile)
+		if err != nil {
+			return err
+		}
+		kubeConfig = cfg.ClientConnection.Kubeconfig
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeConfig)
+	if err != nil {
+		return err
+	}
+	libgorestclient.DefaultServerName(config)
+
+	targetProvider := health.StaticTargetProvider{"localhost:6443"}
+	kubeSchedulerOptions.OpenShiftContext.PreferredHostHealthMonitor, err = health.New(targetProvider, createRestConfigForHealthMonitor(config))
+	if err != nil {
+		return err
+	}
+	kubeSchedulerOptions.OpenShiftContext.PreferredHostHealthMonitor.
+		WithHealthyProbesThreshold(3).
+		WithUnHealthyProbesThreshold(5).
+		WithProbeInterval(5 * time.Second).
+		WithProbeResponseTimeout(2 * time.Second).
+		WithMetrics(health.Register(legacyregistry.MustRegister))
+
+	kubeSchedulerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn = libgorestclient.NewPreferredHostRoundTripper(func() string {
+		healthyTargets, _ := kubeSchedulerOptions.OpenShiftContext.PreferredHostHealthMonitor.Targets()
+		if len(healthyTargets) == 1 {
+			return healthyTargets[0]
+		}
+		return ""
+	})
+
+	kubeSchedulerOptions.Authentication.WithCustomRoundTripper(kubeSchedulerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	kubeSchedulerOptions.Authorization.WithCustomRoundTripper(kubeSchedulerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	return nil
+}
+
+func createRestConfigForHealthMonitor(restConfig *rest.Config) *rest.Config {
+	restConfigCopy := *restConfig
+	rest.AddUserAgent(&restConfigCopy, "kube-scheduler-health-monitor")
+
+	return &restConfigCopy
+}

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -129,6 +129,10 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 		cancel()
 	}()
 
+	if err := setUpPreferredHostForOpenShift(opts); err != nil {
+		return err
+	}
+
 	cc, sched, err := Setup(ctx, opts, registryOptions...)
 	if err != nil {
 		return err
@@ -141,6 +145,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *scheduler.Scheduler) error {
 	// To help debugging, immediately log version
 	klog.V(1).Infof("Starting Kubernetes Scheduler version %+v", version.Get())
+
+	// start the localhost health monitor early so that it can be used by the LE client
+	if cc.OpenShiftContext.PreferredHostHealthMonitor != nil {
+		go cc.OpenShiftContext.PreferredHostHealthMonitor.Run(ctx)
+	}
 
 	// Configz registration.
 	if cz, err := configz.New("componentconfig"); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/openshift/api v0.0.0-20210331193751-3acddb19d360
 	github.com/openshift/apiserver-library-go v0.0.0-20210401085424-478bd0360e43
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_model v0.2.0
@@ -398,7 +398,7 @@ replace (
 	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210401085424-478bd0360e43
 	github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pascaldekloe/goe => github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c
 	github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
 	github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -447,6 +447,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -487,8 +487,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
-	github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+	github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -485,8 +485,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,6 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
 )
 
 // DelegatingAuthorizationOptions provides an easy way for composing API servers to delegate their authorization to
@@ -70,6 +71,9 @@ type DelegatingAuthorizationOptions struct {
 	// This allows us to configure the sleep time at each iteration and the maximum number of retries allowed
 	// before we fail the webhook call in order to limit the fan out that ensues when the system is degraded.
 	WebhookRetryBackoff *wait.Backoff
+
+	// CustomRoundTripperFn allows for specifying a middleware function for custom HTTP behaviour for the authorization webhook client.
+	CustomRoundTripperFn transport.WrapperFunc
 }
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
@@ -110,6 +114,11 @@ func (s *DelegatingAuthorizationOptions) WithClientTimeout(timeout time.Duration
 // WithCustomRetryBackoff sets the custom backoff parameters for the authorization webhook retry logic.
 func (s *DelegatingAuthorizationOptions) WithCustomRetryBackoff(backoff wait.Backoff) {
 	s.WebhookRetryBackoff = &backoff
+}
+
+// WithCustomRoundTripper allows for specifying a middleware function for custom HTTP behaviour for the authorization webhook client.
+func (s *DelegatingAuthorizationOptions) WithCustomRoundTripper(rt transport.WrapperFunc) {
+	s.CustomRoundTripperFn = rt
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {
@@ -230,6 +239,9 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
 	clientConfig.Timeout = s.ClientTimeout
+	if s.CustomRoundTripperFn != nil {
+		clientConfig.Wrap(s.CustomRoundTripperFn)
+	}
 
 	// make the client use protobuf
 	protoConfig := rest.CopyConfig(clientConfig)

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -465,6 +465,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -488,8 +488,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/controller-manager/go.sum
+++ b/staging/src/k8s.io/controller-manager/go.sum
@@ -603,6 +603,7 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaR
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -489,8 +489,9 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/kube-controller-manager/go.sum
+++ b/staging/src/k8s.io/kube-controller-manager/go.sum
@@ -277,7 +277,7 @@ github.com/openshift/api v0.0.0-20210331193751-3acddb19d360/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -489,6 +489,7 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaR
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
 github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -324,7 +324,7 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -319,8 +319,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mo
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible h1:2qD1n/RAnycWMPjYS6MEAUzRmVoF0ql7ozk1ANv8dcM=
 github.com/openshift/ginkgo v4.7.0-origin.0+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 h1:DiyukCScFXVF8JFvvnWpSpHGFRt1EP4Rn4/9feevAdU=
-github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 h1:/6Xf107BJIzdfRe9xfuU4xnx7TUHQ7vzDMWiNYPmxfM=
+github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/metrics.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/metrics.go
@@ -1,0 +1,111 @@
+package health
+
+import (
+	compbasemetrics "k8s.io/component-base/metrics"
+)
+
+type registerables []compbasemetrics.Registerable
+
+var (
+	healthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_healthy_target_total",
+			Help:           "Number of healthy instances registered with the health monitor. Partitioned by targets.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	currentHealthyTargets = compbasemetrics.NewGauge(
+		&compbasemetrics.GaugeOpts{
+			Name:           "health_monitor_current_healthy_targets",
+			Help:           "Number of currently healthy instances observed by the health monitor",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+	)
+
+	unHealthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_unhealthy_target_total",
+			Help:           "Number of unhealthy instances registered with the health monitor. Partitioned by targets.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	readyzViolationRequestTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_readyz_violation_request_total",
+			Help:           "Number of HTTP requests partitioned by status code and target that violate the readyz protocol.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"code", "target"},
+	)
+
+	metrics = registerables{
+		healthyTargetsTotal,
+		currentHealthyTargets,
+		unHealthyTargetsTotal,
+		readyzViolationRequestTotal,
+	}
+)
+
+// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+func HealthyTargetsTotal(target string) {
+	healthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// CurrentHealthyTargets keeps track of the current number of healthy targets observed by the health monitor
+func CurrentHealthyTargets(count float64) {
+	currentHealthyTargets.Set(count)
+}
+
+// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+func UnHealthyTargetsTotal(target string) {
+	unHealthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+//
+// the "readyz" protocol defines the following HTTP status code:
+//   HTTP 200 - when the server operates normally
+//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+func ReadyzProtocolRequestTotal(code, target string) {
+	readyzViolationRequestTotal.WithLabelValues(code, target).Add(1)
+}
+
+// Metrics specifies a set of methods that are used to register various metrics
+type Metrics struct {
+	// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+	HealthyTargetsTotal func(target string)
+
+	// CurrentHealthyTargets keeps track of the current number of healthy targets observed by the health monitor
+	CurrentHealthyTargets func(count float64)
+
+	// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+	UnHealthyTargetsTotal func(target string)
+
+	// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+	//
+	// the "readyz" protocol defines the following HTTP status code:
+	//   HTTP 200 - when the server operates normally
+	//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+	ReadyzProtocolRequestTotal func(code, target string)
+}
+
+// Register is a way to register the health monitor related metrics in the provided store
+func Register(registerFn func(...compbasemetrics.Registerable)) *Metrics {
+	registerFn(metrics...)
+	return &Metrics{
+		HealthyTargetsTotal:        HealthyTargetsTotal,
+		CurrentHealthyTargets:      CurrentHealthyTargets,
+		UnHealthyTargetsTotal:      UnHealthyTargetsTotal,
+		ReadyzProtocolRequestTotal: ReadyzProtocolRequestTotal,
+	}
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) TargetsTotal(string)                 {}
+func (noopMetrics) TargetsGauge(float64)                {}
+func (noopMetrics) TargetsWithCodeTotal(string, string) {}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/options.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/options.go
@@ -1,0 +1,33 @@
+package health
+
+import "time"
+
+// WithUnHealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+func (sm *Prober) WithUnHealthyProbesThreshold(unhealthyProbesThreshold int) *Prober {
+	sm.unhealthyProbesThreshold = unhealthyProbesThreshold
+	return sm
+}
+
+// WithHealthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+func (sm *Prober) WithHealthyProbesThreshold(healthyProbesThreshold int) *Prober {
+	sm.healthyProbesThreshold = healthyProbesThreshold
+	return sm
+}
+
+// WithProbeResponseTimeout specifies a time limit for requests made by the HTTP client for the health check
+func (sm *Prober) WithProbeResponseTimeout(probeResponseTimeout time.Duration) *Prober {
+	sm.client.Timeout = probeResponseTimeout
+	return sm
+}
+
+// WithProbeInterval specifies a time interval at which health checks are send
+func (sm *Prober) WithProbeInterval(probeInterval time.Duration) *Prober {
+	sm.probeInterval = probeInterval
+	return sm
+}
+
+// WithMetrics specifies a set of methods that are used to register various metrics
+func (sm *Prober) WithMetrics(metrics *Metrics) *Prober {
+	sm.metrics = metrics
+	return sm
+}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/prober.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/prober.go
@@ -1,0 +1,377 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
+)
+
+var (
+	defaultProbeResponseTimeout = 1 * time.Second
+	defaultProbeInterval        = 2 * time.Second
+
+	defaultUnhealthyProbesThreshold = 3
+	defaultHealthyProbesThreshold   = 5
+)
+
+type Prober struct {
+	// targetProvider provides a list of targets to monitor
+	// it also can schedule refreshing the list by simply calling Enqueue method
+	targetProvider TargetProvider
+
+	// client is an HTTP client that is used to probe health checks for targets
+	client *http.Client
+
+	// probeInterval specifies a time interval at which health checks are send
+	probeInterval time.Duration
+
+	// unhealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+	unhealthyProbesThreshold int
+
+	// healthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+	healthyProbesThreshold int
+
+	healthyTargets   []string
+	unhealthyTargets []string
+	targetsToMonitor []string
+
+	consecutiveSuccessfulProbes map[string]int
+	consecutiveFailedProbes     map[string][]error
+
+	refreshTargetsLock sync.Mutex
+	refreshTargets     bool
+
+	// exportedHealthyTargets holds a copy of healthyTargets
+	exportedHealthyTargets atomic.Value
+
+	// exportedUnhealthyTargets holds a copy of unhealthyTargets
+	exportedUnhealthyTargets atomic.Value
+
+	// listeners holds a list of interested parties to be notified when the list of healthy targets changes
+	listeners []Listener
+
+	// metrics specifies a set of methods that are used to register various metrics
+	metrics *Metrics
+}
+
+var _ Listener = &Prober{}
+var _ Notifier = &Prober{}
+
+// New creates a health monitor that periodically sends requests to the provided targets to check their health.
+//
+// The following methods allows you to configure behaviour of the monitor after creation.
+//
+//   WithUnHealthyProbesThreshold - that specifies consecutive failed health checks after which a target is considered unhealthy
+//                                  the default value is: 3
+//
+//   WithHealthyProbesThreshold   - that specifies consecutive successful health checks after which a target is considered healthy
+//                                  the default value is: 5
+//
+//   WithProbeResponseTimeout     - that specifies a time limit for requests made by the HTTP client for the health check
+//                                  the default value is: 1 second
+//
+//   WithProbeInterval            - that specifies a time interval at which health checks are send
+//                                  the default value is: 2 seconds
+//
+//   WithMetrics                  - that specifies a set of methods that are used to register various metrics
+//                                  the default value is: no metrics
+//
+//
+// Additionally the monitor implements Listener and Notifier interfaces.
+//
+// The health monitor automatically registers for notification if the target provided also implements the Notifier interface.
+// It is implicit so that the provider can provide a static or a dynamic list of targets.
+//
+// Interested parties can register a listener for notifications about healthy/unhealthy targets changes via AddListener.
+// TODO: instead of restConfig we could accept transport so that it is reused instead of creating a new connection to targets
+//       reusing the transport has the advantage of using the same connection as other clients
+func New(targetProvider TargetProvider, restConfig *rest.Config) (*Prober, error) {
+	client, err := createHealthCheckHTTPClient(defaultProbeResponseTimeout, restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	hm := &Prober{
+		client:                   client,
+		targetProvider:           targetProvider,
+		targetsToMonitor:         targetProvider.CurrentTargetsList(),
+		probeInterval:            defaultProbeInterval,
+		unhealthyProbesThreshold: defaultUnhealthyProbesThreshold,
+		healthyProbesThreshold:   defaultHealthyProbesThreshold,
+
+		consecutiveSuccessfulProbes: map[string]int{},
+		consecutiveFailedProbes:     map[string][]error{},
+
+		metrics: &Metrics{
+			HealthyTargetsTotal:        noopMetrics{}.TargetsTotal,
+			CurrentHealthyTargets:      noopMetrics{}.TargetsGauge,
+			UnHealthyTargetsTotal:      noopMetrics{}.TargetsTotal,
+			ReadyzProtocolRequestTotal: noopMetrics{}.TargetsWithCodeTotal,
+		},
+	}
+	hm.exportedHealthyTargets.Store([]string{})
+	hm.exportedUnhealthyTargets.Store([]string{})
+
+	if notifier, ok := targetProvider.(Notifier); ok {
+		notifier.AddListener(hm)
+	}
+
+	return hm, nil
+}
+
+// Run starts monitoring the provided targets until stop channel is closed
+// This method is blocking and it is meant to be launched in a separate goroutine
+func (sm *Prober) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting the health monitor with Interval = %v, Timeout = %v, HealthyThreshold = %v, UnhealthyThreshold = %v ", sm.probeInterval, sm.client.Timeout, sm.healthyProbesThreshold, sm.unhealthyProbesThreshold)
+	defer klog.Info("Shutting down the health monitor")
+
+	wait.Until(sm.healthCheckRegisteredTargets, sm.probeInterval, ctx.Done())
+}
+
+// Enqueue schedules refreshing the target list on the next probeInterval
+// This method is used by the TargetProvider to notify that the list has changed
+func (sm *Prober) Enqueue() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	sm.refreshTargets = true
+}
+
+// Targets returns a list of healthy and unhealthy targets
+func (sm *Prober) Targets() ([]string, []string) {
+	return sm.exportedHealthyTargets.Load().([]string), sm.exportedUnhealthyTargets.Load().([]string)
+}
+
+// AddListener adds a listener to be notified when the list of healthy targets changes
+//
+// Note:
+// this method is not thread safe and mustn't be called after calling StartMonitoring() method
+func (sm *Prober) AddListener(listener Listener) {
+	sm.listeners = append(sm.listeners, listener)
+}
+
+type targetErrTuple struct {
+	target string
+	err    error
+}
+
+// refreshTargetsLocked updates the internal targets list to monitor if it was requested (via the Enqueue method)
+func (sm *Prober) refreshTargetsLocked() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	if !sm.refreshTargets {
+		return
+	}
+
+	sm.refreshTargets = false
+	freshTargets := sm.targetProvider.CurrentTargetsList()
+	freshTargetSet := sets.NewString(freshTargets...)
+
+	currentTargetsSet := sets.NewString(sm.targetsToMonitor...)
+	newTargetsToMonitorSet := freshTargetSet.Difference(currentTargetsSet)
+	if newTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor observed new targets = %v", newTargetsToMonitorSet.List())
+	}
+
+	removedTargetsToMonitorSet := currentTargetsSet.Difference(freshTargetSet)
+	if removedTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor will stop checking the following targets targets = %v", removedTargetsToMonitorSet.List())
+		for targetToRemove := range removedTargetsToMonitorSet {
+			delete(sm.consecutiveSuccessfulProbes, targetToRemove)
+			delete(sm.consecutiveFailedProbes, targetToRemove)
+		}
+
+		healthyTargetsSet := sets.NewString(sm.healthyTargets...)
+		healthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.healthyTargets = healthyTargetsSet.List()
+
+		unhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+		unhealthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.unhealthyTargets = unhealthyTargetsSet.List()
+	}
+
+	sm.targetsToMonitor = freshTargets
+}
+
+func (sm *Prober) healthCheckRegisteredTargets() {
+	sm.refreshTargetsLocked()
+	var wg sync.WaitGroup
+	resTargetErrTupleCh := make(chan targetErrTuple, len(sm.targetsToMonitor))
+
+	for i := 0; i < len(sm.targetsToMonitor); i++ {
+		wg.Add(1)
+		go func(target string) {
+			defer wg.Done()
+			err := sm.healthCheckSingleTarget(target)
+			resTargetErrTupleCh <- targetErrTuple{target, err}
+		}(sm.targetsToMonitor[i])
+	}
+	wg.Wait()
+	close(resTargetErrTupleCh)
+
+	currentHealthCheckProbes := make([]targetErrTuple, 0, len(sm.targetsToMonitor))
+	for svrErrTuple := range resTargetErrTupleCh {
+		currentHealthCheckProbes = append(currentHealthCheckProbes, svrErrTuple)
+	}
+
+	sm.updateHealthChecksFor(currentHealthCheckProbes)
+}
+
+// updateHealthChecksFor examines the health of targets based on the provided probes and the current configuration.
+// It also notifies interested parties about changes in the health condition.
+// Interested parties can be registered by calling AddListener method.
+func (sm *Prober) updateHealthChecksFor(currentHealthCheckProbes []targetErrTuple) {
+	newUnhealthyTargets := []string{}
+	newHealthyTargets := []string{}
+
+	for _, svrErrTuple := range currentHealthCheckProbes {
+		if svrErrTuple.err != nil {
+			delete(sm.consecutiveSuccessfulProbes, svrErrTuple.target)
+
+			unhealthyProbesSlice := sm.consecutiveFailedProbes[svrErrTuple.target]
+			if len(unhealthyProbesSlice) < sm.unhealthyProbesThreshold {
+				unhealthyProbesSlice = append(unhealthyProbesSlice, svrErrTuple.err)
+				sm.consecutiveFailedProbes[svrErrTuple.target] = unhealthyProbesSlice
+				if len(unhealthyProbesSlice) == sm.unhealthyProbesThreshold {
+					newUnhealthyTargets = append(newUnhealthyTargets, svrErrTuple.target)
+				}
+			}
+			continue
+		}
+
+		delete(sm.consecutiveFailedProbes, svrErrTuple.target)
+
+		healthyProbesCounter := sm.consecutiveSuccessfulProbes[svrErrTuple.target]
+		if healthyProbesCounter < sm.healthyProbesThreshold {
+			healthyProbesCounter++
+			sm.consecutiveSuccessfulProbes[svrErrTuple.target] = healthyProbesCounter
+			if healthyProbesCounter == sm.healthyProbesThreshold {
+				newHealthyTargets = append(newHealthyTargets, svrErrTuple.target)
+			}
+		}
+	}
+
+	newUnhealthyTargetsSet := sets.NewString(newUnhealthyTargets...)
+	newHealthyTargetsSet := sets.NewString(newHealthyTargets...)
+	notifyListeners := false
+
+	// detect unhealthy targets
+	previouslyUnhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+	currentlyUnhealthyTargetsSet := previouslyUnhealthyTargetsSet.Union(newUnhealthyTargetsSet)
+	currentlyUnhealthyTargetsSet.Delete(newHealthyTargetsSet.List()...)
+	if !currentlyUnhealthyTargetsSet.Equal(previouslyUnhealthyTargetsSet) {
+		sm.unhealthyTargets = currentlyUnhealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following unhealthy targets %v", sm.unhealthyTargets)
+		logUnhealthyTargets(sm.unhealthyTargets, currentHealthCheckProbes)
+
+		exportedUnhealthyTargets := make([]string, len(sm.unhealthyTargets))
+		for index, unhealthyTarget := range sm.unhealthyTargets {
+			exportedUnhealthyTargets[index] = unhealthyTarget
+			sm.metrics.UnHealthyTargetsTotal(unhealthyTarget)
+		}
+		sm.exportedUnhealthyTargets.Store(exportedUnhealthyTargets)
+		notifyListeners = true
+	}
+
+	// detect healthy targets
+	previouslyHealthyTargetsSet := sets.NewString(sm.healthyTargets...)
+	currentlyHealthyTargetsSet := previouslyHealthyTargetsSet.Union(newHealthyTargetsSet)
+	currentlyHealthyTargetsSet.Delete(newUnhealthyTargetsSet.List()...)
+	if !currentlyHealthyTargetsSet.Equal(previouslyHealthyTargetsSet) {
+		sm.healthyTargets = currentlyHealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following healthy targets %v", sm.healthyTargets)
+
+		exportedHealthyTargets := make([]string, len(sm.healthyTargets))
+		for index, healthyTarget := range sm.healthyTargets {
+			exportedHealthyTargets[index] = healthyTarget
+			sm.metrics.HealthyTargetsTotal(healthyTarget)
+		}
+		sm.exportedHealthyTargets.Store(exportedHealthyTargets)
+		notifyListeners = true
+	}
+
+	if notifyListeners {
+		// something has changed update the currently healthy targets metric
+		sm.metrics.CurrentHealthyTargets(float64(len(sm.healthyTargets)))
+
+		// notify listeners about the new healthy/unhealthy targets
+		for _, listener := range sm.listeners {
+			listener.Enqueue()
+		}
+	}
+}
+
+func (sm *Prober) healthCheckSingleTarget(target string) error {
+	// TODO: make the protocol, port and the path configurable
+	targetURL, err := url.Parse(fmt.Sprintf("https://%s/%s", target, "readyz"))
+	if err != nil {
+		return err
+	}
+	newReq, err := http.NewRequest("GET", targetURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := sm.client.Do(newReq)
+	if err != nil {
+		sm.metrics.ReadyzProtocolRequestTotal("<error>", target)
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusInternalServerError {
+			sm.metrics.ReadyzProtocolRequestTotal(strconv.Itoa(resp.StatusCode), target)
+		}
+		return fmt.Errorf("bad status from %v: %v, expected HTTP 200", targetURL.String(), resp.StatusCode)
+	}
+
+	return err
+}
+
+func createHealthCheckHTTPClient(responseTimeout time.Duration, restConfig *rest.Config) (*http.Client, error) {
+	transportConfig, err := restConfig.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: utilnet.SetTransportDefaults(&http.Transport{
+			TLSClientConfig: tlsConfig,
+		}),
+		Timeout: responseTimeout,
+	}
+
+	return client, nil
+}
+
+func logUnhealthyTargets(unhealthyTargets []string, currentHealthCheckProbes []targetErrTuple) {
+	for _, unhealthyTarget := range unhealthyTargets {
+		errorsForUnhealthyTarget := []error{}
+		for _, svrErrTuple := range currentHealthCheckProbes {
+			if svrErrTuple.target == unhealthyTarget {
+				errorsForUnhealthyTarget = append(errorsForUnhealthyTarget, svrErrTuple.err)
+			}
+		}
+		klog.V(2).Infof("the following target %v became unhealthy due to %v", unhealthyTarget, utilerrors.NewAggregate(errorsForUnhealthyTarget).Error())
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/monitor/health/target_resolver.go
+++ b/vendor/github.com/openshift/library-go/pkg/monitor/health/target_resolver.go
@@ -1,0 +1,28 @@
+package health
+
+// Listener is an interface to use to notify interested parties of a change.
+type Listener interface {
+	// Enqueue should be called when an input may have changed
+	Enqueue()
+}
+
+// Notifier is a way to add listeners
+type Notifier interface {
+	// AddListener is adds a listener to be notified of potential input changes
+	AddListener(listener Listener)
+}
+
+// TargetProviders is an interface to use to get a list of targets to monitor
+type TargetProvider interface {
+	// CurrentTargetsList returns a precomputed list of targets
+	CurrentTargetsList() []string
+}
+
+// StaticTargetProvider implements TargetProvider and provides a static list of targets
+type StaticTargetProvider []string
+
+var _ TargetProvider = StaticTargetProvider{}
+
+func (sp StaticTargetProvider) CurrentTargetsList() []string {
+	return sp
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1064,9 +1064,9 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52 => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+# github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427 => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 ## explicit
-# github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210331235027-66936e2fcc52
+# github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210407092538-7021fda6f427
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig
 github.com/openshift/library-go/pkg/apiserver/admission/admissiontimeout
@@ -1084,6 +1084,7 @@ github.com/openshift/library-go/pkg/image/imageutil
 github.com/openshift/library-go/pkg/image/internal/digest
 github.com/openshift/library-go/pkg/image/internal/reference
 github.com/openshift/library-go/pkg/image/reference
+github.com/openshift/library-go/pkg/monitor/health
 github.com/openshift/library-go/pkg/network
 github.com/openshift/library-go/pkg/oauth/oauthdiscovery
 github.com/openshift/library-go/pkg/quota/clusterquotamapping


### PR DESCRIPTION
to switch KS to use a preferred host (for now only `localhost` is supported) the following `unsupported-kube-api-over-localhost` must be set to `true`

```
unsupportedConfigOverrides:
  arguments:
    unsupported-kube-api-over-localhost:
      - "true"
```


The preferred host is the primary host to which KS will be sending all requests. There is a health monitor that is constantly monitoring it. When the new host is unavailable all requests will be directed to the old host (from kubeconfig)