### PR TITLE
 Bug 1945856: 99729:Only system-node-critical pods should be OOM Killed last

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -38,8 +38,8 @@ const (
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
 func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) int {
-	if types.IsCriticalPod(pod) {
-		// Critical pods should be the last to get killed.
+	if types.IsNodeCriticalPod(pod) {
+		// Only node critical pod should be the last to get killed.
 		return guaranteedOOMScoreAdj
 	}
 

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -139,9 +139,24 @@ var (
 
 	systemCritical = scheduling.SystemCriticalPriority
 
-	critical = v1.Pod{
+	clusterCritical = v1.Pod{
 		Spec: v1.PodSpec{
-			Priority: &systemCritical,
+			PriorityClassName: scheduling.SystemClusterCritical,
+			Priority:          &systemCritical,
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+	}
+
+	systemNodeCritical = scheduling.SystemCriticalPriority + 1000
+
+	nodeCritical = v1.Pod{
+		Spec: v1.PodSpec{
+			PriorityClassName: scheduling.SystemNodeCritical,
+			Priority:          &systemNodeCritical,
 			Containers: []v1.Container{
 				{
 					Resources: v1.ResourceRequirements{},
@@ -203,7 +218,13 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 			highOOMScoreAdj: 3,
 		},
 		{
-			pod:             &critical,
+			pod:             &clusterCritical,
+			memoryCapacity:  4000000000,
+			lowOOMScoreAdj:  1000,
+			highOOMScoreAdj: 1000,
+		},
+		{
+			pod:             &nodeCritical,
 			memoryCapacity:  4000000000,
 			lowOOMScoreAdj:  -997,
 			highOOMScoreAdj: -997,

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -179,3 +179,8 @@ func Preemptable(preemptor, preemptee *v1.Pod) bool {
 func IsCriticalPodBasedOnPriority(priority int32) bool {
 	return priority >= scheduling.SystemCriticalPriority
 }
+
+// IsNodeCriticalPod checks if the given pod is a system-node-critical
+func IsNodeCriticalPod(pod *v1.Pod) bool {
+	return IsCriticalPod(pod) && (pod.Spec.PriorityClassName == scheduling.SystemNodeCritical)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
Backport of https://github.com/openshift/kubernetes/pull/641/commits/d201f2f905bc5785d377723f2000b798faec15ae which will go to master.

This will help in having appropriate priority classes for components like monitoring

cc @bparees @smarterclayton @rphillips 