### PR TITLE
UPSTREAM: 97295: Fix staticcheck in test/integration/{examples,framework}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -3,8 +3,6 @@ pkg/controller/replicaset
 pkg/kubelet/dockershim
 pkg/volume/testing
 test/e2e/autoscaling
-test/integration/examples
-test/integration/framework
 test/integration/garbagecollector
 test/integration/scheduler_perf
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -90,7 +90,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 			"--kubeconfig", wardleToKASKubeConfigFile,
 		})
 		if err := wardleCmd.Execute(); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 	directWardleClientConfig, err := waitForWardleRunning(t, kubeClientConfig, wardleCertDir, wardlePort)
@@ -131,7 +131,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 	// wait for the unavailable API service to be processed with updated status
 	err = wait.Poll(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
-		_, err = kubeClient.Discovery().ServerResources()
+		_, _, err = kubeClient.Discovery().ServerGroupsAndResources()
 		hasExpectedError := checkWardleUnavailableDiscoveryError(t, err)
 		return hasExpectedError, nil
 	})

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -100,7 +100,7 @@ func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn fun
 	// TODO: Check for valid etcd version.
 	etcdPath, err := getEtcdPath()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, installEtcd)
+		fmt.Fprint(os.Stderr, installEtcd)
 		return "", nil, fmt.Errorf("could not find etcd in PATH: %v", err)
 	}
 	etcdPort, err := getAvailablePort()

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -127,7 +127,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	}
 	go func() {
 		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(stopCh); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 


### PR DESCRIPTION
Backports 97295 to fix make vet

Ref https://github.com/kubernetes/kubernetes/pull/97295/files