### PR TITLE
UPSTREAM: <carry>: Disable CSI migration on OpenStack Cinder

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -801,7 +801,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIMigrationvSphere:                            {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires vSphere CSI driver)
 	CSIMigrationvSphereComplete:                    {Default: false, PreRelease: featuregate.Beta}, // remove in 1.22
 	InTreePluginvSphereUnregister:                  {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationOpenStack:                          {Default: true, PreRelease: featuregate.Beta},
+	CSIMigrationOpenStack:                          {Default: false, PreRelease: featuregate.Beta}, // OCP(storage team): force off by default, requires explicit opt-in via FeatureGate CR. Please <carry> until it's GA. https://github.com/openshift/enhancements/pull/549
 	InTreePluginOpenStackUnregister:                {Default: false, PreRelease: featuregate.Alpha},
 	VolumeSubpath:                                  {Default: true, PreRelease: featuregate.GA},
 	ConfigurableFSGroupPolicy:                      {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
This is a tech preview feature that must be explicitly enabled by setting FeatureGate CR (https://github.com/openshift/api/pull/880).

For 4.8, we want AWS EBS and Cinder as tech preview for CSI migration. Both are Beta upstream, AWS EBS migration is off by default, Cinder is enabled by default (so we need to disable it in OCP in this PR).

This carry patch is to be carried until the CSI migration gets GA (~1.24?).

@openshift/storage 