### PR TITLE
Bug 1944631: openshift authenticator: don't allow old-style tokens

### DIFF
--- a/openshift-kube-apiserver/authentication/oauth/bootstrapauthenticator.go
+++ b/openshift-kube-apiserver/authentication/oauth/bootstrapauthenticator.go
@@ -39,11 +39,13 @@ func NewBootstrapAuthenticator(tokens oauthclient.OAuthAccessTokenInterface, get
 func (a *bootstrapAuthenticator) AuthenticateToken(ctx context.Context, name string) (*kauthenticator.Response, bool, error) {
 	// hash token for new-style sha256~ prefixed token
 	// TODO: reject non-sha256 prefix tokens in 4.7+
-	if strings.HasPrefix(name, sha256Prefix) {
-		withoutPrefix := strings.TrimPrefix(name, sha256Prefix)
-		h := sha256.Sum256([]byte(withoutPrefix))
-		name = sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
+	if !strings.HasPrefix(name, sha256Prefix) {
+		return nil, false, errOldFormat
 	}
+
+	withoutPrefix := strings.TrimPrefix(name, sha256Prefix)
+	h := sha256.Sum256([]byte(withoutPrefix))
+	name = sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
 
 	token, err := a.tokens.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {

--- a/openshift-kube-apiserver/authentication/oauth/expirationvalidator_test.go
+++ b/openshift-kube-apiserver/authentication/oauth/expirationvalidator_test.go
@@ -2,6 +2,10 @@ package oauth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	mathrand "math/rand"
 	"testing"
 	"time"
 
@@ -14,16 +18,18 @@ import (
 )
 
 func TestAuthenticateTokenExpired(t *testing.T) {
+	token1, token1Hash := generateOAuthTokenPair()
+	token2, token2Hash := generateOAuthTokenPair()
 	fakeOAuthClient := oauthfake.NewSimpleClientset(
 		// expired token that had a lifetime of 10 minutes
 		&oauthv1.OAuthAccessToken{
-			ObjectMeta: metav1.ObjectMeta{Name: "token1", CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)}},
+			ObjectMeta: metav1.ObjectMeta{Name: token1Hash, CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)}},
 			ExpiresIn:  600,
 			UserName:   "foo",
 		},
 		// non-expired token that has a lifetime of 10 minutes, but has a non-nil deletion timestamp
 		&oauthv1.OAuthAccessToken{
-			ObjectMeta: metav1.ObjectMeta{Name: "token2", CreationTimestamp: metav1.Time{Time: time.Now()}, DeletionTimestamp: &metav1.Time{}},
+			ObjectMeta: metav1.ObjectMeta{Name: token2Hash, CreationTimestamp: metav1.Time{Time: time.Now()}, DeletionTimestamp: &metav1.Time{}},
 			ExpiresIn:  600,
 			UserName:   "foo",
 		},
@@ -32,7 +38,7 @@ func TestAuthenticateTokenExpired(t *testing.T) {
 
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, NewExpirationValidator())
 
-	for _, tokenName := range []string{"token1", "token2"} {
+	for _, tokenName := range []string{token1, token2} {
 		userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), tokenName)
 		if found {
 			t.Error("Found token, but it should be missing!")
@@ -47,9 +53,10 @@ func TestAuthenticateTokenExpired(t *testing.T) {
 }
 
 func TestAuthenticateTokenValidated(t *testing.T) {
+	token, tokenHash := generateOAuthTokenPair()
 	fakeOAuthClient := oauthfake.NewSimpleClientset(
 		&oauthv1.OAuthAccessToken{
-			ObjectMeta: metav1.ObjectMeta{Name: "token", CreationTimestamp: metav1.Time{Time: time.Now()}},
+			ObjectMeta: metav1.ObjectMeta{Name: tokenHash, CreationTimestamp: metav1.Time{Time: time.Now()}},
 			ExpiresIn:  600, // 10 minutes
 			UserName:   "foo",
 			UserUID:    string("bar"),
@@ -59,7 +66,7 @@ func TestAuthenticateTokenValidated(t *testing.T) {
 
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, NewExpirationValidator(), NewUIDValidator())
 
-	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
+	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), token)
 	if !found {
 		t.Error("Did not find a token!")
 	}
@@ -69,4 +76,15 @@ func TestAuthenticateTokenValidated(t *testing.T) {
 	if userInfo == nil {
 		t.Error("Did not get a user!")
 	}
+}
+
+// generateOAuthTokenPair returns two tokens to use with OpenShift OAuth-based authentication.
+// The first token is a private token meant to be used as a Bearer token to send
+// queries to the API, the second token is a hashed token meant to be stored in
+// the database.
+func generateOAuthTokenPair() (privToken, pubToken string) {
+	const sha256Prefix = "sha256~"
+	randomToken := []byte(fmt.Sprintf("nottoorandom%d", mathrand.Int()))
+	hashed := sha256.Sum256([]byte(randomToken))
+	return sha256Prefix + string(randomToken), sha256Prefix + base64.RawURLEncoding.EncodeToString(hashed[:])
 }

--- a/openshift-kube-apiserver/authentication/oauth/tokenauthenticator.go
+++ b/openshift-kube-apiserver/authentication/oauth/tokenauthenticator.go
@@ -17,7 +17,10 @@ import (
 	userclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 )
 
-var errLookup = errors.New("token lookup failed")
+var (
+	errLookup    = errors.New("token lookup failed")
+	errOldFormat = errors.New("old, insecure token format")
+)
 
 type tokenAuthenticator struct {
 	tokens       oauthclient.OAuthAccessTokenInterface
@@ -42,11 +45,13 @@ const sha256Prefix = "sha256~"
 func (a *tokenAuthenticator) AuthenticateToken(ctx context.Context, name string) (*kauthenticator.Response, bool, error) {
 	// hash token for new-style sha256~ prefixed token
 	// TODO: reject non-sha256 prefix tokens in 4.7+
-	if strings.HasPrefix(name, sha256Prefix) {
-		withoutPrefix := strings.TrimPrefix(name, sha256Prefix)
-		h := sha256.Sum256([]byte(withoutPrefix))
-		name = sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
+	if !strings.HasPrefix(name, sha256Prefix) {
+		return nil, false, errOldFormat
 	}
+
+	withoutPrefix := strings.TrimPrefix(name, sha256Prefix)
+	h := sha256.Sum256([]byte(withoutPrefix))
+	name = sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
 
 	token, err := a.tokens.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
4.8 is going to be using the authenticator in the oauth-apiserver but we should make the best effort in making sure the old-styled tokens should not be usable anywhere.

/assign @sttts 