### PR TITLE
Bug 1949721: UPSTREAM: 99237: Use the audit ID of a request for better correlation

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -253,7 +253,8 @@ func buildHandlerChain(handler http.Handler, authn authenticator.Request, authz 
 	handler = genericapifilters.WithAuthentication(handler, authn, failedHandler, nil)
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver, nil)
+	handler = genericfilters.WithHTTPLogging(handler, nil)
+	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
 
 	return handler
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -195,10 +195,6 @@ type auditResponseWriter struct {
 	omitStages []auditinternal.Stage
 }
 
-func (a *auditResponseWriter) setHttpHeader() {
-	a.ResponseWriter.Header().Set(auditinternal.HeaderAuditID, string(a.event.AuditID))
-}
-
 func (a *auditResponseWriter) processCode(code int) {
 	a.once.Do(func() {
 		if a.event.ResponseStatus == nil {
@@ -216,13 +212,11 @@ func (a *auditResponseWriter) processCode(code int) {
 func (a *auditResponseWriter) Write(bs []byte) (int, error) {
 	// the Go library calls WriteHeader internally if no code was written yet. But this will go unnoticed for us
 	a.processCode(http.StatusOK)
-	a.setHttpHeader()
 	return a.ResponseWriter.Write(bs)
 }
 
 func (a *auditResponseWriter) WriteHeader(code int) {
 	a.processCode(code)
-	a.setHttpHeader()
 	a.ResponseWriter.WriteHeader(code)
 }
 
@@ -244,12 +238,6 @@ func (f *fancyResponseWriterDelegator) Flush() {
 func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	// fake a response status before protocol switch happens
 	f.processCode(http.StatusSwitchingProtocols)
-
-	// This will be ignored if WriteHeader() function has already been called.
-	// It's not guaranteed Audit-ID http header is sent for all requests.
-	// For example, when user run "kubectl exec", apiserver uses a proxy handler
-	// to deal with the request, users can only get http headers returned by kubelet node.
-	f.setHttpHeader()
 
 	return f.ResponseWriter.(http.Hijacker).Hijack()
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/with_auditid.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/with_auditid.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/types"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/google/uuid"
+)
+
+// WithAuditID attaches the Audit-ID associated with a request to the context.
+//
+// a. If the caller does not specify a value for Audit-ID in the request header, we generate a new audit ID
+// b. We echo the Audit-ID value to the caller via the response Header 'Audit-ID'.
+func WithAuditID(handler http.Handler) http.Handler {
+	return withAuditID(handler, func() string {
+		return uuid.New().String()
+	})
+}
+
+func withAuditID(handler http.Handler, newAuditIDFunc func() string) http.Handler {
+	if newAuditIDFunc == nil {
+		return handler
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		auditID := r.Header.Get(auditinternal.HeaderAuditID)
+		if len(auditID) == 0 {
+			auditID = newAuditIDFunc()
+		}
+
+		// Note: we save the user specified value of the Audit-ID header as is, no truncation is performed.
+		r = r.WithContext(request.WithAuditID(ctx, types.UID(auditID)))
+
+		// We echo the Audit-ID in to the response header.
+		// It's not guaranteed Audit-ID http header is sent for all requests.
+		// For example, when user run "kubectl exec", apiserver uses a proxy handler
+		// to deal with the request, users can only get http headers returned by kubelet node.
+		//
+		// This filter will also be used by other aggregated api server(s). For an aggregated API
+		// we don't want to see the same audit ID appearing more than once.
+		if value := w.Header().Get(auditinternal.HeaderAuditID); len(value) == 0 {
+			w.Header().Set(auditinternal.HeaderAuditID, auditID)
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/with_auditid_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/with_auditid_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestWithAuditID(t *testing.T) {
+	largeAuditID := fmt.Sprintf("%s-%s", uuid.New().String(), uuid.New().String())
+	tests := []struct {
+		name             string
+		newAuditIDFunc   func() string
+		auditIDSpecified string
+		auditIDExpected  string
+	}{
+		{
+			name:             "user specifies a value for Audit-ID in the request header",
+			auditIDSpecified: "foo-bar-baz",
+			auditIDExpected:  "foo-bar-baz",
+		},
+		{
+			name: "user does not specify a value for Audit-ID in the request header",
+			newAuditIDFunc: func() string {
+				return "foo-bar-baz"
+			},
+			auditIDExpected: "foo-bar-baz",
+		},
+		{
+			name:             "the value in Audit-ID request header is too large, should not be truncated",
+			auditIDSpecified: largeAuditID,
+			auditIDExpected:  largeAuditID,
+		},
+		{
+			name: "the generated Audit-ID is too large, should not be truncated",
+			newAuditIDFunc: func() string {
+				return largeAuditID
+			},
+			auditIDExpected: largeAuditID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const auditKey = "Audit-ID"
+			var (
+				innerHandlerCallCount int
+				auditIDGot            string
+				found                 bool
+			)
+			handler := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				innerHandlerCallCount++
+
+				// does the inner handler see the audit ID?
+				v, ok := request.AuditIDFrom(req.Context())
+
+				found = ok
+				auditIDGot = string(v)
+			})
+
+			wrapped := WithAuditID(handler)
+			if test.newAuditIDFunc != nil {
+				wrapped = withAuditID(handler, test.newAuditIDFunc)
+			}
+
+			testRequest, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if len(test.auditIDSpecified) > 0 {
+				testRequest.Header.Set(auditKey, test.auditIDSpecified)
+			}
+
+			w := httptest.NewRecorder()
+			wrapped.ServeHTTP(w, testRequest)
+
+			if innerHandlerCallCount != 1 {
+				t.Errorf("WithAuditID: expected the inner handler to be invoked once, but was invoked %d times", innerHandlerCallCount)
+			}
+			if !found {
+				t.Error("WithAuditID: expected request.AuditIDFrom to return true, but got false")
+			}
+			if test.auditIDExpected != auditIDGot {
+				t.Errorf("WithAuditID: expected the request context to have: %q, but got=%q", test.auditIDExpected, auditIDGot)
+			}
+
+			auditIDEchoed := w.Header().Get(auditKey)
+			if test.auditIDExpected != auditIDEchoed {
+				t.Errorf("WithAuditID: expected Audit-ID response header: %q, but got: %q", test.auditIDExpected, auditIDEchoed)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 const (
@@ -69,6 +70,20 @@ func (lazy *lazyAccept) String() string {
 	if lazy.req != nil {
 		accept := lazy.req.Header.Get("Accept")
 		return accept
+	}
+
+	return "unknown"
+}
+
+// lazyAuditID implements Stringer interface to lazily retrieve
+// the audit ID associated with the request.
+type lazyAuditID struct {
+	req *http.Request
+}
+
+func (lazy *lazyAuditID) String() string {
+	if lazy.req != nil {
+		return request.GetAuditIDTruncated(lazy.req)
 	}
 
 	return "unknown"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/trace_util.go
@@ -26,6 +26,7 @@ func traceFields(req *http.Request) []utiltrace.Field {
 	return []utiltrace.Field{
 		{Key: "url", Value: req.URL.Path},
 		{Key: "user-agent", Value: &lazyTruncatedUserAgent{req: req}},
+		{Key: "audit-id", Value: &lazyAuditID{req: req}},
 		{Key: "client", Value: &lazyClientIP{req: req}},
 		{Key: "accept", Value: &lazyAccept{req: req}},
 		{Key: "protocol", Value: req.Proto}}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/auditid.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/auditid.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type auditIDKeyType int
+
+// auditIDKey is the key to associate the Audit-ID value of a request.
+const auditIDKey auditIDKeyType = iota
+
+// WithAuditID returns a copy of the parent context into which the Audit-ID
+// associated with the request is set.
+//
+// If the specified auditID is empty, no value is set and the parent context is returned as is.
+func WithAuditID(parent context.Context, auditID types.UID) context.Context {
+	if auditID == "" {
+		return parent
+	}
+	return WithValue(parent, auditIDKey, auditID)
+}
+
+// AuditIDFrom returns the value of the audit ID from the request context.
+func AuditIDFrom(ctx context.Context) (types.UID, bool) {
+	auditID, ok := ctx.Value(auditIDKey).(types.UID)
+	return auditID, ok
+}
+
+// GetAuditIDTruncated returns the audit ID (truncated) associated with a request.
+// If the length of the Audit-ID value exceeds the limit, we truncate it to keep
+// the first N (maxAuditIDLength) characters.
+// This is intended to be used in logging only.
+func GetAuditIDTruncated(req *http.Request) string {
+	auditID, ok := AuditIDFrom(req.Context())
+	if !ok {
+		return ""
+	}
+
+	// if the user has specified a very long audit ID then we will use the first N characters
+	// Note: assuming Audit-ID header is in ASCII
+	const maxAuditIDLength = 64
+	if len(auditID) > maxAuditIDLength {
+		auditID = auditID[0:maxAuditIDLength]
+	}
+
+	return string(auditID)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/auditid_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/auditid_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestAuditIDFrom(t *testing.T) {
+	tests := []struct {
+		name            string
+		auditID         string
+		auditIDExpected string
+		expected        bool
+	}{
+		{
+			name:            "empty audit ID",
+			auditID:         "",
+			auditIDExpected: "",
+			expected:        false,
+		},
+		{
+			name:            "non empty audit ID",
+			auditID:         "foo-bar-baz",
+			auditIDExpected: "foo-bar-baz",
+			expected:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parent := context.TODO()
+			ctx := WithAuditID(parent, types.UID(test.auditID))
+
+			// for an empty audit ID we don't expect a copy of the parent context.
+			if len(test.auditID) == 0 && parent != ctx {
+				t.Error("expected no copy of the parent context with an empty audit ID")
+			}
+
+			value, ok := AuditIDFrom(ctx)
+			if test.expected != ok {
+				t.Errorf("expected AuditIDFrom to return: %t, but got: %t", test.expected, ok)
+			}
+
+			auditIDGot := string(value)
+			if test.auditIDExpected != auditIDGot {
+				t.Errorf("expected audit ID: %q, but got: %q", test.auditIDExpected, auditIDGot)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -851,8 +851,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithWarningRecorder(handler)
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithHSTS(handler, c.HSTSDirectives)
+	handler = genericfilters.WithHTTPLogging(handler, c.IsTerminating)
 	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
-	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver, c.IsTerminating)
+	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
 	return handler
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -854,6 +854,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericfilters.WithHTTPLogging(handler, c.IsTerminating)
 	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
 	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
+	handler = genericapifilters.WithAuditID(handler)
 	return handler
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -853,7 +853,8 @@ func newHandlerChain(t *testing.T, handler http.Handler, filter utilflowcontrol.
 	// we don't have any request with invalid timeout, so leaving audit policy and sink nil.
 	handler = apifilters.WithRequestDeadline(handler, nil, nil, longRunningRequestCheck, nil, requestTimeout)
 	handler = apifilters.WithRequestInfo(handler, requestInfoFactory)
-	handler = WithPanicRecovery(handler, requestInfoFactory, nil)
+	handler = WithPanicRecovery(handler, requestInfoFactory)
+	handler = apifilters.WithAuditID(handler)
 	return handler
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -108,7 +108,7 @@ func TestTimeout(t *testing.T) {
 		}), func(w http.ResponseWriter, req *http.Request, err interface{}) {
 			gotPanic <- err
 			http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)
-		}, nil),
+		}),
 	))
 	defer ts.Close()
 
@@ -250,7 +250,7 @@ func TestErrConnKilled(t *testing.T) {
 		GrouplessAPIPrefixes: sets.NewString("api"),
 	}
 
-	ts := httptest.NewServer(WithPanicRecovery(handler, resolver, nil))
+	ts := httptest.NewServer(WithPanicRecovery(handler, resolver))
 	defer ts.Close()
 
 	_, err = http.Get(ts.URL)
@@ -263,7 +263,7 @@ func TestErrConnKilled(t *testing.T) {
 	if strings.Count(capturedOutput, "\n") != 1 {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
-	if !strings.Contains(capturedOutput, `timeout or abort while handling: GET "/"`) {
+	if !strings.Contains(capturedOutput, `timeout or abort while handling: method=GET URI="/" audit-ID=""`) {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
 }
@@ -308,7 +308,7 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 	}
 
 	// test server
-	ts := httptest.NewUnstartedServer(WithPanicRecovery(handler, resolver, nil))
+	ts := httptest.NewUnstartedServer(WithPanicRecovery(handler, resolver))
 	tsCert, err := tls.X509KeyPair(tsCrt, tsKey)
 	if err != nil {
 		t.Fatalf("backend: invalid x509/key pair: %v", err)
@@ -353,7 +353,7 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 	if strings.Count(capturedOutput, "\n") != 1 {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
-	if !strings.Contains(capturedOutput, `timeout or abort while handling: GET "/"`) {
+	if !strings.Contains(capturedOutput, `timeout or abort while handling: method=GET URI="/" audit-ID=""`) {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -51,11 +51,11 @@ func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolve
 			// This call can have different handlers, but the default chain rate limits. Call it after the metrics are updated
 			// in case the rate limit delays it.  If you outrun the rate for this one timed out requests, something has gone
 			// seriously wrong with your server, but generally having a logging signal for timeouts is useful.
-			runtime.HandleError(fmt.Errorf("timeout or abort while handling: %v %q", req.Method, req.URL.Path))
+			runtime.HandleError(fmt.Errorf("timeout or abort while handling: method=%v URI=%q audit-ID=%q", req.Method, req.RequestURI, request.GetAuditIDTruncated(req)))
 			return
 		}
 		http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)
-		klog.Errorf("apiserver panic'd on %v %v", req.Method, req.RequestURI)
+		klog.ErrorS(nil, "apiserver panic'd", "method", req.Method, "URI", req.RequestURI, "audit-ID", request.GetAuditIDTruncated(req))
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -28,7 +28,7 @@ import (
 )
 
 // WithPanicRecovery wraps an http Handler to recover and log panics (except in the special case of http.ErrAbortHandler panics, which suppress logging).
-func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolver, isTerminating func() bool) http.Handler {
+func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolver) http.Handler {
 	return withPanicRecovery(handler, func(w http.ResponseWriter, req *http.Request, err interface{}) {
 		if err == http.ErrAbortHandler {
 			// Honor the http.ErrAbortHandler sentinel panic value
@@ -56,11 +56,15 @@ func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolve
 		}
 		http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)
 		klog.Errorf("apiserver panic'd on %v %v", req.Method, req.RequestURI)
-	}, isTerminating)
+	})
 }
 
-func withPanicRecovery(handler http.Handler, crashHandler func(http.ResponseWriter, *http.Request, interface{}), isTerminating func() bool) http.Handler {
-	handler = httplog.WithLogging(handler, httplog.DefaultStacktracePred, isTerminating)
+// WithHTTPLogging enables logging of incoming requests.
+func WithHTTPLogging(handler http.Handler, isTerminating func() bool) http.Handler {
+	return httplog.WithLogging(handler, httplog.DefaultStacktracePred, isTerminating)
+}
+
+func withPanicRecovery(handler http.Handler, crashHandler func(http.ResponseWriter, *http.Request, interface{})) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer runtime.HandleCrash(func(err interface{}) {
 			crashHandler(w, req, err)

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -188,12 +188,14 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 
 func (rl *respLogger) LogArgs() []interface{} {
 	latency := time.Since(rl.startTime)
+	auditID := request.GetAuditIDTruncated(rl.req)
 	if rl.hijacked {
 		return []interface{}{
 			"verb", rl.req.Method,
 			"URI", rl.req.RequestURI,
 			"latency", latency,
 			"userAgent", rl.req.UserAgent(),
+			"audit-ID", auditID,
 			"srcIP", rl.req.RemoteAddr,
 			"hijacked", true,
 		}
@@ -203,6 +205,7 @@ func (rl *respLogger) LogArgs() []interface{} {
 		"URI", rl.req.RequestURI,
 		"latency", latency,
 		"userAgent", rl.req.UserAgent(),
+		"audit-ID", auditID,
 		"srcIP", rl.req.RemoteAddr,
 		"resp", rl.status,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"time"
 
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
 
@@ -87,7 +88,13 @@ func WithLogging(handler http.Handler, pred StacktracePred, isTerminatingFn func
 		if isTerminatingFn != nil {
 			isTerminating = isTerminatingFn()
 		}
-		rl := newLogged(req, w).StacktraceWhen(pred).IsTerminating(isTerminating)
+
+		startTime := time.Now()
+		if receivedTimestamp, ok := request.ReceivedTimestampFrom(ctx); ok {
+			startTime = receivedTimestamp
+		}
+
+		rl := newLoggedWithStartTime(req, w, startTime).StacktraceWhen(pred).IsTerminating(isTerminating)
 		req = req.WithContext(context.WithValue(ctx, respLoggerContextKey, rl))
 
 		if klog.V(3).Enabled() || (rl.isTerminating && klog.V(1).Enabled()) {
@@ -107,14 +114,18 @@ func respLoggerFromContext(req *http.Request) *respLogger {
 	return nil
 }
 
-// newLogged turns a normal response writer into a logged response writer.
-func newLogged(req *http.Request, w http.ResponseWriter) *respLogger {
+func newLoggedWithStartTime(req *http.Request, w http.ResponseWriter, startTime time.Time) *respLogger {
 	return &respLogger{
-		startTime:         time.Now(),
+		startTime:         startTime,
 		req:               req,
 		w:                 w,
 		logStacktracePred: DefaultStacktracePred,
 	}
+}
+
+// newLogged turns a normal response writer into a logged response writer.
+func newLogged(req *http.Request, w http.ResponseWriter) *respLogger {
+	return newLoggedWithStartTime(req, w, time.Now())
 }
 
 // LogOf returns the logger hiding in w. If there is not an existing logger

--- a/staging/src/k8s.io/controller-manager/app/serve.go
+++ b/staging/src/k8s.io/controller-manager/app/serve.go
@@ -48,7 +48,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 	}
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver, nil)
+	handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
 
 	return handler
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	endpointmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -209,6 +210,12 @@ func newRequestForProxy(location *url.URL, req *http.Request) (*http.Request, co
 	newReq.Header = utilnet.CloneHeader(req.Header)
 	newReq.URL = location
 	newReq.Host = location.Host
+
+	// If the original request has an audit ID, let's make sure we propagate this
+	// to the aggregated server.
+	if auditID, found := genericapirequest.AuditIDFrom(req.Context()); found {
+		newReq.Header.Set(auditinternal.HeaderAuditID, string(auditID))
+	}
 
 	return newReq, cancelFn
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Use the audit ID of a request for better correlation:
- If an audit ID is not provided by the caller, generate one when we receive the request. This audit ID will be used to audit the request. 
- When we forward the request to the aggregated server, set the audit ID in the new request header. This allows audit logs from aggregated apiservers to be correlated with the kube-apiserver
- Use the audit ID in the current `tracer` we have
- Use the audit ID in `httplog`
- When a request panics, log an error with the audit ID.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
