### PR TITLE
WIP: Fix RBAC of generic ephemeral volumes controller

### DIFF
--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -21,8 +21,6 @@ var (
 
 			`\[Feature:CrossNamespacePodAffinity\]`,
 
-			`\[Feature:GenericEphemeralVolume\]`,
-
 			`\[Feature:DaemonSetUpdateSurge\]`,
 
 			`\[Feature:StorageVersionAPI\]`,

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -198,6 +198,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "ephemeral-volume-controller"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch", "create").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 				eventsRule(),
 			},


### PR DESCRIPTION
The controller must be able to "update" finalizers of all pods. Garbage
collector does not allow PVC to be owner by a Pod otherwise.

WIP: only for testing, do not merge.