### PR TITLE
Bug 1951585: Addresses build error pause

### DIFF
--- a/build/pause/Dockerfile.Rhel
+++ b/build/pause/Dockerfile.Rhel
@@ -2,6 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:ubi8.art AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes/build/pause
 COPY . .
 RUN dnf install -y gcc glibc-static && \
+    mkdir -p bin && \
     gcc -Os -Wall -Werror -static -o bin/pause ./linux/pause.c
 
 FROM scratch


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Follow-up of https://github.com/openshift/kubernetes/pull/633. Related: https://github.com/openshift/ocp-build-data/pull/898. 

Ensuring the target directory exists before writing a file to it, and fixes build failure:
```
 /usr/bin/ld: cannot open output file bin/pause: No such file or directory
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
