### PR TITLE
Bug 1949452: UPSTREAM: 101162: Fix Client-Side Request Throttling Malformed Logs

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -602,7 +602,7 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	if latency > extraLongThrottleLatency {
 		// If the rate limiter latency is very high, the log message should be printed at a higher log level,
 		// but we use a throttled logger to prevent spamming.
-		globalThrottledLogger.Infof(message)
+		globalThrottledLogger.Infof("%s", message)
 	}
 	metrics.RateLimiterLatency.Observe(ctx, r.verb, r.finalURLTemplate(), latency)
 


### PR DESCRIPTION
When client-side requests are being throttled, the log messages that contain
URL-encoded strings are mistakenly interpreted as the format specifier (%),
causing the outputs to be malformed:

```
185:I0415 21:15:51.591419       1 request.go:668] Waited for 1.379057017s due to client-side throttling, not priority and fairness, request: GET:https://10.217.4.1:443/api/v1/namespaces/openshift-kube-apiserver/pods?labelSelector=apiserver%!D(MISSING)true
186:I0415 21:15:52.787904       1 request.go:668] Waited for 2.560841267s due to client-side throttling, not priority and fairness, request: GET:https://10.217.4.1:443/api/v1/namespaces/openshift-kube-apiserver/pods?labelSelector=apiserver%!D(MISSING)true
210:I0415 21:16:00.188633       1 request.go:668] Waited for 3.990309811s due to client-side throttling, not priority and fairness, request: GET:https://10.217.4.1:443/api/v1/namespaces/openshift-config-managed/secrets?labelSelector=encryption.apiserver.operator.openshift.io%!F(MISSING)component%!D(MISSING)openshift-kube-apiserver
```

This PR adds the %s format verb to ensure that the whole log message is
interpreted as a string.

Signed-off-by: Ivan Sim <isim@redhat.com>