### PR TITLE
openshift.spec: remove Source0 TODO

### DIFF
--- a/openshift.spec
+++ b/openshift.spec
@@ -51,7 +51,6 @@ ExclusiveArch:  %{go_arches}
 ExclusiveArch:  x86_64 aarch64 ppc64le s390x
 %endif
 
-# TODO(marun) tar archives are no longer published for 4.x. Should this value be removed?
 Source0:        https://%{import_path}/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildRequires:  systemd
 BuildRequires:  bsdtar


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes comment proposing removing `Source0`. `Source0` placeholder is replaced with source tarball in dist-git, so we still need this downstream. It would be fine if it were more evidently a placeholder/dummy though.

/cc @marun 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
