### PR TITLE
bug 1954638: UPSTREAM: <carry>: apirequest count with empty .status.removedInRelease

### DIFF
--- a/openshift-kube-apiserver/filters/deprecatedapirequest/apiaccess_count_controller_test.go
+++ b/openshift-kube-apiserver/filters/deprecatedapirequest/apiaccess_count_controller_test.go
@@ -617,11 +617,6 @@ func setRequestCountTotals(status *apiv1.APIRequestCountStatus) {
 		totalForCurrentHour += status.CurrentHour.ByNode[nodeIndex].RequestCount
 	}
 	status.CurrentHour.RequestCount = totalForCurrentHour
-
-	// set the default value until we fix the validator
-	if len(status.RemovedInRelease) == 0 {
-		status.RemovedInRelease = "2.0"
-	}
 }
 
 func deprecatedAPIRequestStatus(options ...func(*apiv1.APIRequestCountStatus)) *apiv1.APIRequestCountStatus {

--- a/openshift-kube-apiserver/filters/deprecatedapirequest/deprecated.go
+++ b/openshift-kube-apiserver/filters/deprecatedapirequest/deprecated.go
@@ -18,10 +18,5 @@ var deprecatedApiRemovedRelease = map[schema.GroupVersionResource]string{
 
 // removedRelease of a specified resource.version.group.
 func removedRelease(resource schema.GroupVersionResource) string {
-	ret, ok := deprecatedApiRemovedRelease[resource]
-	if ok {
-		return ret
-	}
-	// return a non-empty default to get past validation for now.  Nothing is guaranteed for 2.0.
-	return "2.0"
+	return deprecatedApiRemovedRelease[resource]
 }


### PR DESCRIPTION
We fixed the validation bug, so empty removedInRelease is now allowed and more proper.