### PR TITLE
Bug 1953478: UPSTREAM: 101582: Fix invalid AWS KMS key test flake

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -825,6 +825,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		ginkgo.It("should report an error and create no PV", func() {
 			e2eskipper.SkipUnlessProviderIs("aws")
 			test := testsuites.StorageClassTest{
+				Client:      c,
 				Name:        "AWS EBS with invalid KMS key",
 				Provisioner: "kubernetes.io/aws-ebs",
 				Timeouts:    f.Timeouts,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
The "Dynamic Provisioning Invalid AWS KMS key should report an error and create no PV" storage test is failing due to a small oversight in the code: there is a missing API client in the test initialization.

#### Which issue(s) this PR fixes:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953478

```release-note
NONE
```