### PR TITLE
Bug 1953555: UPSTREAM: <carry>: Skip GlusterFS tests

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -2525,7 +2525,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] Dynamic Provisioning DynamicProvisioner [Slow] should test that deleting a claim before the volume is provisioned deletes the volume.": "should test that deleting a claim before the volume is provisioned deletes the volume. [Suite:k8s]",
 
-	"[Top Level] [sig-storage] Dynamic Provisioning GlusterDynamicProvisioner should create and delete persistent volumes [fast]": "should create and delete persistent volumes [fast] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-storage] Dynamic Provisioning GlusterDynamicProvisioner should create and delete persistent volumes [fast]": "should create and delete persistent volumes [fast] [Disabled:Unsupported] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] Dynamic Provisioning Invalid AWS KMS key should report an error and create no PV": "should report an error and create no PV [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -11343,7 +11343,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] Volumes ConfigMap should be mountable": "should be mountable [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-storage] Volumes GlusterFS should be mountable": "should be mountable [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-storage] Volumes GlusterFS should be mountable": "should be mountable [Disabled:Unsupported] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] Volumes NFSv3 should be mountable for NFSv3": "should be mountable for NFSv3 [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -111,6 +111,8 @@ var (
 			`\[Driver: rbd\]`,               // OpenShift 4.x does not support Ceph RBD (use CSI instead)
 			`\[Driver: ceph\]`,              // OpenShift 4.x does not support CephFS (use CSI instead)
 			`\[Driver: gluster\]`,           // OpenShift 4.x does not support Gluster
+			`Volumes GlusterFS`,             // OpenShift 4.x does not support Gluster
+			`GlusterDynamicProvisioner`,     // OpenShift 4.x does not support Gluster
 			`\[Feature:PodSecurityPolicy\]`, // OpenShift 4.x does not enable PSP by default
 		},
 		// tests too slow to be part of conformance


### PR DESCRIPTION
The previous PR #647 left two GlusterFS test still running:

```
[sig-storage] Volumes GlusterFS should be mountable [Skipped:ibmcloud] [Suite:openshift/conformance/parallel] [Suite:k8s]
[sig-storage] Dynamic Provisioning GlusterDynamicProvisioner should create and delete persistent volumes
```
Skip it, we don't support Gluster and it does not work on ipv6
