### PR TITLE
WIP: BoundServiceAccountTokenVolume + service-ca.crt experiment

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -786,7 +786,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA},
 	SupportPodPidsLimit:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	SupportNodePidsLimit:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	BoundServiceAccountTokenVolume:                 {Default: false, PreRelease: featuregate.Beta},                   // TODO(auth): investigate the impact of enabling this feature (https://bugzilla.redhat.com/show_bug.cgi?id=1946479)
+	BoundServiceAccountTokenVolume:                 {Default: true, PreRelease: featuregate.Beta},
 	ServiceAccountIssuerDiscovery:                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	CRIContainerLogRotation:                        {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	CSIMigration:                                   {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/security/podsecuritypolicy/provider_test.go
+++ b/pkg/security/podsecuritypolicy/provider_test.go
@@ -1444,7 +1444,7 @@ func TestValidateProjectedVolume(t *testing.T) {
 		{
 			desc:                  "deny if secret is not allowed",
 			allowedFSTypes:        []policy.FSType{policy.EmptyDir},
-			projectedVolumeSource: serviceaccount.TokenVolumeSource(),
+			projectedVolumeSource: serviceaccount.TokenVolumeSource("service-account-token-secret"),
 			wantAllow:             false,
 		},
 		{
@@ -1471,7 +1471,7 @@ func TestValidateProjectedVolume(t *testing.T) {
 		{
 			desc:                  "allow if secret is allowed and the projected volume sources equals to the ones injected by service account admission plugin",
 			allowedFSTypes:        []policy.FSType{policy.Secret},
-			projectedVolumeSource: serviceaccount.TokenVolumeSource(),
+			projectedVolumeSource: serviceaccount.TokenVolumeSource("service-account-token-secret"),
 			wantAllow:             true,
 		},
 	}


### PR DESCRIPTION
I don’t really know what I’m doing, mostly curious to see how this fails.

Even if this works, it further cements down the use of long-term service account secrets. (I guess hypothetically we could continue to generate them, but only with the `service-ca.crt` component.)

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Re-enable BoundServiceAccountTokenVolume ; to preserve the `service-ca.crt` file that was previously included in the mounted secret, just add a reference to the old secret in the created projected volume — the token controller generating the secrets with `service-ca.crt` included is still running and generating secrets in the right namespace.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
