### PR TITLE
Bug 1956281: Update pause image to v3.5 

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -166,7 +166,7 @@ dependencies:
       match: TAG =
 
   - name: "k8s.gcr.io/pause: dependents"
-    version: 3.4.1
+    version: 3.5
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: PauseVersion\s+=
@@ -215,7 +215,7 @@ dependencies:
     - path: test/utils/runners.go
       match: k8s.gcr.io\/pause:\d+\.\d+
     - path: test/utils/image/manifest.go
-      match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+.\d+"}
+      match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+"}
 
   # metadata-concealment: bump this one first
   - name: "metadata-concealment"

--- a/build/pause/CHANGELOG.md
+++ b/build/pause/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 3.4.1
+# 3.5
+
+* Run the container image as non root user per default ([#97963](https://github.com/kubernetes/kubernetes/pull/97963))
+
+# 3.5
 
 * Support for Windows container images (OS Versions: 20H2) was added.([#97322](https://prs.k8s.io/97322), [@claudiubelu](https://github.com/claudiubelu))
 

--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -158,7 +158,7 @@ export WINDOWS_BOOTSTRAP_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubelet.bootstrap-k
 # Path for kube-proxy kubeconfig file on Windows nodes.
 export WINDOWS_KUBEPROXY_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubeproxy.kubeconfig"
 # Pause container image for Windows container.
-export WINDOWS_INFRA_CONTAINER="k8s.gcr.io/pause:3.4.1"
+export WINDOWS_INFRA_CONTAINER="k8s.gcr.io/pause:3.5"
 # Storage Path for csi-proxy. csi-proxy only needs to be installed for Windows.
 export CSI_PROXY_STORAGE_PATH="https://storage.googleapis.com/gke-release/csi-proxy"
 # Version for csi-proxy

--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -358,7 +358,7 @@ spec:
     spec:
       containers:
       - name: pause-win
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5
       nodeSelector:
         kubernetes.io/os: windows
       tolerations:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -400,7 +400,7 @@ const (
 	ModeNode string = "Node"
 
 	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "3.4.1"
+	PauseVersion = "3.5"
 )
 
 var (

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -119,11 +119,11 @@ func TestBuildKubeletArgMap(t *testing.T) {
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
 					CRISocket: "/var/run/dockershim.sock",
 				},
-				pauseImage: "gcr.io/pause:3.4.1",
+				pauseImage: "gcr.io/pause:3.5",
 			},
 			expected: map[string]string{
 				"network-plugin":            "cni",
-				"pod-infra-container-image": "gcr.io/pause:3.4.1",
+				"pod-infra-container-image": "gcr.io/pause:3.5",
 			},
 		},
 	}

--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	validTmpl    = "image: {{ .ImageRepository }}/pause:3.4.1"
-	validTmplOut = "image: k8s.gcr.io/pause:3.4.1"
-	doNothing    = "image: k8s.gcr.io/pause:3.4.1"
+	validTmpl    = "image: {{ .ImageRepository }}/pause:3.5"
+	validTmplOut = "image: k8s.gcr.io/pause:3.5"
+	doNothing    = "image: k8s.gcr.io/pause:3.5"
 	invalidTmpl1 = "{{ .baz }/d}"
 	invalidTmpl2 = "{{ !foobar }}"
 )

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -28,7 +28,7 @@ import (
 const (
 	// When these values are updated, also update test/utils/image/manifest.go
 	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
-	defaultPodSandboxImageVersion = "3.4.1"
+	defaultPodSandboxImageVersion = "3.5"
 )
 
 var (

--- a/hack/testdata/filter/pod-apply-selector.yaml
+++ b/hack/testdata/filter/pod-apply-selector.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/filter/pod-dont-apply.yaml
+++ b/hack/testdata/filter/pod-dont-apply.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/multi-resource-1.yaml
+++ b/hack/testdata/multi-resource-1.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5
 ---
 apiVersion: v1
 kind: Namespace

--- a/hack/testdata/multi-resource-3.yaml
+++ b/hack/testdata/multi-resource-3.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5
 ---
 apiVersion: v1
 kind: Pod
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5
 ---
 apiVersion: v1
 kind: Pod
@@ -26,5 +26,5 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5
 

--- a/hack/testdata/multi-resource-json-modify.json
+++ b/hack/testdata/multi-resource-json-modify.json
@@ -43,7 +43,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "k8s.gcr.io/pause:3.4.1",
+           "image": "k8s.gcr.io/pause:3.5",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-json.json
+++ b/hack/testdata/multi-resource-json.json
@@ -41,7 +41,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "k8s.gcr.io/pause:3.4.1",
+           "image": "k8s.gcr.io/pause:3.5",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-list-modify.json
+++ b/hack/testdata/multi-resource-list-modify.json
@@ -47,7 +47,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.4.1",
+                    "image": "k8s.gcr.io/pause:3.5",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-list.json
+++ b/hack/testdata/multi-resource-list.json
@@ -45,7 +45,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.4.1",
+                    "image": "k8s.gcr.io/pause:3.5",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist-modify.json
+++ b/hack/testdata/multi-resource-rclist-modify.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.4.1",
+                    "image": "k8s.gcr.io/pause:3.5",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "k8s.gcr.io/pause:3.4.1",
+                "image": "k8s.gcr.io/pause:3.5",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist.json
+++ b/hack/testdata/multi-resource-rclist.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "k8s.gcr.io/pause:3.4.1",
+                    "image": "k8s.gcr.io/pause:3.5",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "k8s.gcr.io/pause:3.4.1",
+                "image": "k8s.gcr.io/pause:3.5",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-yaml-modify.yaml
+++ b/hack/testdata/multi-resource-yaml-modify.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/multi-resource-yaml.yaml
+++ b/hack/testdata/multi-resource-yaml.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/pod-apply.yaml
+++ b/hack/testdata/pod-apply.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/pod-with-precision.json
+++ b/hack/testdata/pod-with-precision.json
@@ -9,7 +9,7 @@
     "containers": [
       {
         "name": "kubernetes-pause",
-        "image": "k8s.gcr.io/pause:3.4.1"
+        "image": "k8s.gcr.io/pause:3.5"
       }
     ],
     "restartPolicy": "Never",

--- a/hack/testdata/pod.yaml
+++ b/hack/testdata/pod.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/prune/a.yaml
+++ b/hack/testdata/prune/a.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/prune/b.yaml
+++ b/hack/testdata/prune/b.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/sorted-pods/sorted-pod1.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod1.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause2
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/sorted-pods/sorted-pod2.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod2.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause1
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/hack/testdata/sorted-pods/sorted-pod3.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod3.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause3
-    image: k8s.gcr.io/pause:3.4.1
+    image: k8s.gcr.io/pause:3.5

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "k8s.gcr.io/pause:3.4.1"
+	defaultSandboxImage = "k8s.gcr.io/pause:3.5"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2

--- a/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5

--- a/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -529,9 +529,9 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
-  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause:3.4.1"}]}}'
+  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause:3.5"}]}}'
   # Post-condition: valid-pod POD has expected image
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/pause:3.4.1:'
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/pause:3.5:'
 
   # pod has field for kubectl patch field manager
   output_message=$(kubectl get pod valid-pod -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)

--- a/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+++ b/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
@@ -76,6 +76,6 @@ spec:
         - name: root-mount
           mountPath: /root
       containers:
-      - image: "k8s.gcr.io/pause:3.4.1"
+      - image: "k8s.gcr.io/pause:3.5"
         name: pause
 

--- a/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5

--- a/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.4.1
+        image: k8s.gcr.io/pause:3.5

--- a/test/integration/benchmark-controller.json
+++ b/test/integration/benchmark-controller.json
@@ -17,7 +17,7 @@
        "spec": {
            "containers": [{
              "name": "test-container",
-             "image": "k8s.gcr.io/pause:3.4.1"
+             "image": "k8s.gcr.io/pause:3.5"
            }]
        }
     }

--- a/test/integration/scheduler_perf/config/churn/pod-default.yaml
+++ b/test/integration/scheduler_perf/config/churn/pod-default.yaml
@@ -4,5 +4,5 @@ metadata:
   generateName: pod-churn-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause

--- a/test/integration/scheduler_perf/config/pod-default.yaml
+++ b/test/integration/scheduler_perf/config/pod-default.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: pod-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-high-priority.yaml
+++ b/test/integration/scheduler_perf/config/pod-high-priority.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   priority: 10
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-large-cpu.yaml
+++ b/test/integration/scheduler_perf/config/pod-large-cpu.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: pod-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-low-priority.yaml
+++ b/test/integration/scheduler_perf/config/pod-low-priority.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-node-affinity.yaml
@@ -14,7 +14,7 @@ spec:
             - zone1
             - zone2
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: topology.kubernetes.io/zone
         namespaces: ["sched-test", "sched-setup"]
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-pod-anti-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: kubernetes.io/hostname
         namespaces: ["sched-test", "sched-setup"]
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-test", "sched-setup"]
           weight: 1
   containers:
-    - image: k8s.gcr.io/pause:3.4.1
+    - image: k8s.gcr.io/pause:3.5
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-pod-anti-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-test", "sched-setup"]
           weight: 1
   containers:
-    - image: k8s.gcr.io/pause:3.4.1
+    - image: k8s.gcr.io/pause:3.5
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-secret-volume.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: secret-volume-
 spec:
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: k8s.gcr.io/pause:3.4.1
+  - image: k8s.gcr.io/pause:3.5
     name: pause
     ports:
     - containerPort: 80

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -241,7 +241,7 @@ func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs[Nonewprivs] = Config{promoterE2eRegistry, "nonewprivs", "1.3"}
 	configs[NonRoot] = Config{promoterE2eRegistry, "nonroot", "1.1"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
-	configs[Pause] = Config{gcRegistry, "pause", "3.4.1"}
+	configs[Pause] = Config{gcRegistry, "pause", "3.5"}
 	configs[Perl] = Config{promoterE2eRegistry, "perl", "5.26"}
 	configs[PrometheusDummyExporter] = Config{gcRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{gcRegistry, "prometheus-to-sd", "v0.5.0"}

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1303,7 +1303,7 @@ func MakePodSpec() v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
 			Name:  "pause",
-			Image: "k8s.gcr.io/pause:3.4.1",
+			Image: "k8s.gcr.io/pause:3.5",
 			Ports: []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -1725,7 +1725,7 @@ type DaemonConfig struct {
 
 func (config *DaemonConfig) Run() error {
 	if config.Image == "" {
-		config.Image = "k8s.gcr.io/pause:3.4.1"
+		config.Image = "k8s.gcr.io/pause:3.5"
 	}
 	nameLabel := map[string]string{
 		"name": config.Name + "-daemon",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update dependencies and the test images to use pause 3.5. We also
provide a changelog entry for the new container image version.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/kubernetes/pull/97963
Upstream PR: https://github.com/kubernetes/kubernetes/pull/100292
#### Special notes for your reviewer:

Previous 3.4.1 update PR: https://github.com/kubernetes/kubernetes/pull/98205

#### Does this PR introduce a user-facing change?

```release-note
Updated pause image to version 3.5
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
