### PR TITLE
Bug 1949612: UPSTREAM: 101708: Fix log spam for du failure on pod etc-hosts metrics

### DIFF
--- a/pkg/kubelet/stats/host_stats_provider.go
+++ b/pkg/kubelet/stats/host_stats_provider.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
@@ -82,6 +83,10 @@ func (h hostStatsProvider) getPodEtcHostsStats(podUID types.UID, rootFsInfo *cad
 	// Runtimes may not support etc hosts file (Windows with docker)
 	podEtcHostsPath, isEtcHostsSupported := h.podEtcHostsPathFunc(podUID)
 	if !isEtcHostsSupported {
+		return nil, nil
+	}
+	// Some pods have an explicit /etc/hosts mount and the Kubelet will not create an etc-hosts file for them
+	if _, err := os.Stat(podEtcHostsPath); os.IsNotExist(err) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Pods which explicitly mount /etc/hosts do not create a pod-wide etc-hosts file, which results in the metrics provider spamming the kubelet logs with messages like the following:

```
"Unable to fetch pod etc hosts stats" err="failed to get stats failed command 'du' ($ nice -n 19 du -x -s -B 1) on path /var/lib/kubelet/pods/d451e557-9ff8-4cc6-91d3-6cfc21e7ea4f/etc-hosts with error exit status 1" pod="openshift-dns/node-resolver-tckq7"
```

#### Which issue(s) this PR fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1949612

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```