### PR TITLE
bug 1957502: UPSTREAM: <carry>: correct apirequestcount lock

### DIFF
--- a/openshift-kube-apiserver/filters/deprecatedapirequest/request_counts.go
+++ b/openshift-kube-apiserver/filters/deprecatedapirequest/request_counts.go
@@ -258,10 +258,10 @@ func (c *hourlyRequestCounts) User(user userKey) *userRequestCounts {
 	}
 
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	if _, ok := c.usersToRequestCounts[user]; !ok {
 		c.usersToRequestCounts[user] = newUserRequestCounts(user)
 	}
-	c.lock.Unlock()
 	return c.usersToRequestCounts[user]
 }
 
@@ -369,10 +369,10 @@ func (c *userRequestCounts) Verb(verb string) *verbRequestCount {
 	}
 
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	if _, ok := c.verbsToRequestCounts[verb]; !ok {
 		c.verbsToRequestCounts[verb] = &verbRequestCount{}
 	}
-	c.lock.Unlock()
 	return c.verbsToRequestCounts[verb]
 }
 


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial/1389928085503086592

```
E0505 14:38:27.582470      19 runtime.go:76] Observed a panic: runtime error: invalid memory address or nil pointer dereference
goroutine 8505117 [running]:
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1(0xc02e9f9260)
	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:102 +0x125
panic(0x49d9640, 0x83684f0)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1.1(0xc0290eac80, 0x5cc4378, 0xc031866d50, 0x7fb4276122c0, 0xc000eae900, 0xc000eae8a0, 0x1, 0x1, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:89 +0x216
panic(0x49d9640, 0x83684f0)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
type..eq.k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest.userKey(0xc01a0b20d0, 0xc00f8d6db8, 0xd673691f539063a9)
	<autogenerated>:1 +0x99
k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest.(*hourlyRequestCounts).User(0xc0451a19e0, 0xc0294d6100, 0x3b, 0xc046ef9f40, 0x1c, 0x0)
	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest/request_counts.go:265 +0x197
```

The race test didn't catch this before merge.  Sometimes that map must be realloc'd during expansion and the critical section didn't cover the return.