### PR TITLE
Bug 1959420: fix a 4.6 test flake

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -975,13 +975,16 @@ func (j *TestJig) checkExternalServiceReachability(svc *v1.Service, pod *v1.Pod)
 	svcName := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, framework.TestContext.ClusterDNSDomain)
 	// Service must resolve to IP
 	cmd := fmt.Sprintf("nslookup %s", svcName)
-	_, stderr, err := framework.RunHostCmdWithFullOutput(pod.Namespace, pod.Name, cmd)
-	// NOTE(claudiub): nslookup may return 0 on Windows, even though the DNS name was not found. In this case,
-	// we can check stderr for the error.
-	if err != nil || (framework.NodeOSDistroIs("windows") && strings.Contains(stderr, fmt.Sprintf("can't find %s", svcName))) {
-		return fmt.Errorf("ExternalName service %q must resolve to IP", pod.Namespace+"/"+pod.Name)
-	}
-	return nil
+	return wait.PollImmediate(framework.Poll, ServiceReachabilityShortPollTimeout, func() (done bool, err error) {
+		_, stderr, err := framework.RunHostCmdWithFullOutput(pod.Namespace, pod.Name, cmd)
+		// NOTE(claudiub): nslookup may return 0 on Windows, even though the DNS name was not found. In this case,
+		// we can check stderr for the error.
+		if err != nil || (framework.NodeOSDistroIs("windows") && strings.Contains(stderr, fmt.Sprintf("can't find %s", svcName))) {
+			framework.Logf("ExternalName service %q failed to resolve to IP", pod.Namespace+"/"+pod.Name)
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 // CheckServiceReachability ensures that request are served by the services. Only supports Services with type ClusterIP, NodePort and ExternalName.


### PR DESCRIPTION
This test used to be flaky and was eventually fixed. For some reason it doesn't fail much in our 4.6 e2e jobs, so we never bothered to cherry-pick the fix, but now it keeps tripping up third-party network plugin vendors trying to certify new versions of their plugins against 4.6 EUS, for some reason.