### PR TITLE
UPSTREAM: 101067: Bug 1946459: fix nfs storage ipv6 add square brackets

### DIFF
--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -96,7 +96,7 @@ func TestRecycler(t *testing.T) {
 	}
 }
 
-func doTestPlugin(t *testing.T, spec *volume.Spec) {
+func doTestPlugin(t *testing.T, spec *volume.Spec, expectedDevice string) {
 	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
@@ -135,6 +135,20 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	if mounter.(*nfsMounter).readOnly {
 		t.Errorf("The volume source should not be read-only and it is.")
+	}
+	mntDevs, err := fake.List()
+	if err != nil {
+		t.Errorf("fakeMounter.List() failed: %v", err)
+	}
+	if len(mntDevs) != 1 {
+		t.Errorf("unexpected number of mounted devices. expected: %v, got %v", 1, len(mntDevs))
+	} else {
+		if mntDevs[0].Type != "nfs" {
+			t.Errorf("unexpected type of mounted devices. expected: %v, got %v", "nfs", mntDevs[0].Type)
+		}
+		if mntDevs[0].Device != expectedDevice {
+			t.Errorf("unexpected nfs device, expected %q, got: %q", expectedDevice, mntDevs[0].Device)
+		}
 	}
 	log := fake.GetLog()
 	if len(log) != 1 {
@@ -178,7 +192,23 @@ func TestPluginVolume(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "localhost", Path: "/somepath", ReadOnly: false}},
 	}
-	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "localhost:/somepath")
+}
+
+func TestIPV6VolumeSource(t *testing.T) {
+	vol := &v1.Volume{
+		Name:         "vol1",
+		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "0:0:0:0:0:0:0:1", Path: "/somepath", ReadOnly: false}},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "[0:0:0:0:0:0:0:1]:/somepath")
+}
+
+func TestIPV4VolumeSource(t *testing.T) {
+	vol := &v1.Volume{
+		Name:         "vol1",
+		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "127.0.0.1", Path: "/somepath", ReadOnly: false}},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "127.0.0.1:/somepath")
 }
 
 func TestPluginPersistentVolume(t *testing.T) {
@@ -193,7 +223,7 @@ func TestPluginPersistentVolume(t *testing.T) {
 		},
 	}
 
-	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false))
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false), "localhost:/somepath")
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/101067

#### What type of PR is this?

/kind bug
/kind storage
/label nfs
/label ipv6

#### What this PR does / why we need it:

Fix mounting `nfs` volumes in `ipv6` environment. 

#### Which issue(s) this PR fixes:

Fixes #101066 

#### Special notes for your reviewer:
Enclose only ipv6 within `[ ]`.

```release-note
Fixed mounting of NFS volumes when IPv6 address is used as a server.
```
