### PR TITLE
Bug 1963079: KCM with preferred host support

### DIFF
--- a/cmd/kube-controller-manager/app/config/patch.go
+++ b/cmd/kube-controller-manager/app/config/patch.go
@@ -1,9 +1,18 @@
 package config
 
+import (
+	"k8s.io/client-go/transport"
+
+	"github.com/openshift/library-go/pkg/monitor/health"
+)
+
 // OpenShiftContext is additional context that we need to launch the kube-controller-manager for openshift.
 // Basically, this holds our additional config information.
 type OpenShiftContext struct {
 	OpenShiftConfig                     string
 	OpenShiftDefaultProjectNodeSelector string
 	KubeDefaultProjectNodeSelector      string
+	UnsupportedKubeAPIOverPreferredHost bool
+	PreferredHostRoundTripperWrapperFn  transport.WrapperFunc
+	PreferredHostHealthMonitor          *health.Prober
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -68,6 +68,8 @@ import (
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
 
 const (
@@ -113,6 +115,11 @@ controller, and serviceaccounts controller.`,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			verflag.PrintAndExitIfRequested()
+
+			if err := SetUpPreferredHostForOpenShift(s); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
 
 			c, err := s.Config(KnownControllers(), ControllersDisabledByDefault.List())
 			if err != nil {
@@ -183,6 +190,17 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		cfgz.Set(c.ComponentConfig)
 	} else {
 		klog.Errorf("unable to register configz: %v", err)
+	}
+
+	// start the localhost health monitor early so that it can be used by the LE client
+	if c.OpenShiftContext.PreferredHostHealthMonitor != nil {
+		hmCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-stopCh
+			cancel()
+		}()
+		go c.OpenShiftContext.PreferredHostHealthMonitor.Run(hmCtx)
 	}
 
 	// Setup any healthz checks we will want to use.
@@ -691,7 +709,7 @@ func createClientBuilders(c *config.CompletedConfig) (clientBuilder clientbuilde
 		}
 
 		clientBuilder = clientbuilder.NewDynamicClientBuilder(
-			restclient.AnonymousClientConfig(c.Kubeconfig),
+			libgorestclient.AnonymousClientConfigWithWrapTransport(c.Kubeconfig),
 			c.Client.CoreV1(),
 			metav1.NamespaceSystem)
 	} else {

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -47,6 +47,8 @@ import (
 
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
 
 const (
@@ -271,6 +273,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fs.StringVar(&dummy, "insecure-experimental-approve-all-kubelet-csrs-for-group", "", "This flag does nothing.")
 	fs.StringVar(&s.OpenShiftContext.OpenShiftConfig, "openshift-config", s.OpenShiftContext.OpenShiftConfig, "indicates that this process should be compatible with openshift start master")
 	fs.MarkHidden("openshift-config")
+	fs.BoolVar(&s.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost, "unsupported-kube-api-over-localhost", false, "when set makes KCM prefer talking to localhost kube-apiserver (when available) instead of LB")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("generic"))
 
 	return fss
@@ -442,6 +445,11 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
 	kubeconfig.QPS = s.Generic.ClientConnection.QPS
 	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)
+
+	if s.OpenShiftContext.PreferredHostRoundTripperWrapperFn != nil {
+		libgorestclient.DefaultServerName(kubeconfig)
+		kubeconfig.Wrap(s.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	}
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {

--- a/cmd/kube-controller-manager/app/patch.go
+++ b/cmd/kube-controller-manager/app/patch.go
@@ -1,17 +1,61 @@
 package app
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/json"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+
+	libgorestclient "github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/monitor/health"
 )
 
 var InformerFactoryOverride informers.SharedInformerFactory
+
+func SetUpPreferredHostForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions) error {
+	if !controllerManagerOptions.OpenShiftContext.UnsupportedKubeAPIOverPreferredHost {
+		return nil
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags(controllerManagerOptions.Master, controllerManagerOptions.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	libgorestclient.DefaultServerName(config)
+
+	targetProvider := health.StaticTargetProvider{"localhost:6443"}
+	controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor, err = health.New(targetProvider, createRestConfigForHealthMonitor(config))
+	if err != nil {
+		return err
+	}
+	controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor.
+		WithHealthyProbesThreshold(3).
+		WithUnHealthyProbesThreshold(5).
+		WithProbeInterval(5 * time.Second).
+		WithProbeResponseTimeout(2 * time.Second).
+		WithMetrics(health.Register(legacyregistry.MustRegister))
+
+	controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn = libgorestclient.NewPreferredHostRoundTripper(func() string {
+		healthyTargets, _ := controllerManagerOptions.OpenShiftContext.PreferredHostHealthMonitor.Targets()
+		if len(healthyTargets) == 1 {
+			return healthyTargets[0]
+		}
+		return ""
+	})
+
+	controllerManagerOptions.Authentication.WithCustomRoundTripper(controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	controllerManagerOptions.Authorization.WithCustomRoundTripper(controllerManagerOptions.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
+	return nil
+}
 
 func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config) error {
 	if len(controllerManager.OpenShiftContext.OpenShiftConfig) == 0 {
@@ -81,4 +125,11 @@ func applyOpenShiftConfigDefaultProjectSelector(controllerManagerOptions *option
 	controllerManagerOptions.OpenShiftContext.OpenShiftDefaultProjectNodeSelector = defaultNodeSelector.(string)
 
 	return nil
+}
+
+func createRestConfigForHealthMonitor(restConfig *rest.Config) *rest.Config {
+	restConfigCopy := *restConfig
+	rest.AddUserAgent(&restConfigCopy, fmt.Sprintf("%s-health-monitor", options.KubeControllerManagerUserAgent))
+
+	return &restConfigCopy
 }

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -116,7 +116,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 
 	rt, ok := t.roundTripperFuncMap[saName]
 	if ok {
-		configCopy.WrapTransport = rt
+		configCopy.Wrap(rt)
 	} else {
 		cachedTokenSource := transport.NewCachedTokenSource(&tokenSourceImpl{
 			namespace:          t.Namespace,
@@ -125,7 +125,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 			expirationSeconds:  t.expirationSeconds,
 			leewayPercent:      t.leewayPercent,
 		})
-		configCopy.WrapTransport = transport.ResettableTokenSourceWrapTransport(cachedTokenSource)
+		configCopy.Wrap(transport.ResettableTokenSourceWrapTransport(cachedTokenSource))
 		t.roundTripperFuncMap[saName] = configCopy.WrapTransport
 	}
 

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -235,7 +235,11 @@ func (ts *tokenSourceImpl) Token() (*oauth2.Token, error) {
 
 func constructClient(saNamespace, saName string, config *restclient.Config) restclient.Config {
 	username := apiserverserviceaccount.MakeUsername(saNamespace, saName)
-	ret := *restclient.AnonymousClientConfig(config)
+	// make a shallow copy
+	// the caller already castrated the config during creation
+	// this allows for potential extensions in the future
+	// for example it preserve HTTP wrappers for custom behavior per request
+	ret := *config
 	restclient.AddUserAgent(&ret, username)
 	return ret
 }


### PR DESCRIPTION
to switch KMC to use a preferred host (for now only `localhost` is supported) the following `unsupported-kube-api-over-localhost` must be set to `true`

```
unsupportedConfigOverrides:
  extendedArguments:
    unsupported-kube-api-over-localhost:
      - "true"
```


The preferred host is the primary host to which KCM will be sending all requests. There is a health monitor that is constantly monitoring it. When the new host is unavailable all requests will be directed to the old host (from kubeconfig)