### PR TITLE
UPSTREAM: 102089: Bug 1961644: Add Node IP IPv6 formatting in NodeAuthenticator tests

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -19,6 +19,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +62,8 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		pod := createNodeAuthTestPod(f)
 		for _, nodeIP := range nodeIPs {
 			// Anonymous authentication is disabled by default
-			result := framework.RunHostCmdOrDie(ns, pod.Name, fmt.Sprintf("curl -sIk -o /dev/null -w '%s' https://%s:%v/metrics", "%{http_code}", nodeIP, ports.KubeletPort))
+			host := net.JoinHostPort(nodeIP, strconv.Itoa(ports.KubeletPort))
+			result := framework.RunHostCmdOrDie(ns, pod.Name, fmt.Sprintf("curl -sIk -o /dev/null -w '%s' https://%s/metrics", "%{http_code}", host))
 			gomega.Expect(result).To(gomega.Or(gomega.Equal("401"), gomega.Equal("403")), "the kubelet's main port 10250 should reject requests with no credentials")
 		}
 	})
@@ -81,12 +84,13 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		pod := createNodeAuthTestPod(f)
 
 		for _, nodeIP := range nodeIPs {
+			host := net.JoinHostPort(nodeIP, strconv.Itoa(ports.KubeletPort))
 			result := framework.RunHostCmdOrDie(ns,
 				pod.Name,
-				fmt.Sprintf("curl -sIk -o /dev/null -w '%s' --header \"Authorization: Bearer `%s`\" https://%s:%v/metrics",
+				fmt.Sprintf("curl -sIk -o /dev/null -w '%s' --header \"Authorization: Bearer `%s`\" https://%s/metrics",
 					"%{http_code}",
 					"cat /var/run/secrets/kubernetes.io/serviceaccount/token",
-					nodeIP, ports.KubeletPort))
+					host))
 			gomega.Expect(result).To(gomega.Or(gomega.Equal("401"), gomega.Equal("403")), "the kubelet can delegate ServiceAccount tokens to the API server")
 		}
 	})


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/102089 

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Enable `[Feature:Feature:NodeAuthenticator]` tests for IPv6 configuration.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Enclose node ip within `[]` when it is IPv6 for `[Feature:NodeAuthenticator]` tests. 
