### PR TITLE
Bug 1953127: UPSTREAM: <drop>: work around broken NetPol DNS rules

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -641,7 +641,7 @@ var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 						},
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},

--- a/test/e2e/network/netpol/policies.go
+++ b/test/e2e/network/netpol/policies.go
@@ -170,7 +170,7 @@ func GetAllowEgressByPort(name string, port *intstr.IntOrString) *networkingv1.N
 						{Port: port},
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},
@@ -208,7 +208,7 @@ func GetDenyAllWithEgressDNS() *networkingv1.NetworkPolicy {
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},
@@ -442,7 +442,7 @@ func GetAllowEgressByNamespaceAndPod(name string, targetLabels map[string]string
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},
@@ -511,7 +511,7 @@ func GetAllowEgressByCIDR(podname string, podserverCIDR string) *networkingv1.Ne
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},
@@ -550,7 +550,7 @@ func GetAllowEgressByCIDRExcept(podname string, podserverCIDR string, except []s
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: &protocolUDP,
-							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 5353},
 						},
 					},
 				},


### PR DESCRIPTION
The tests assume that the DNS pods listen on port 53, which they don't in OCP. Hack around this for now. https://github.com/kubernetes/kubernetes/issues/102286 should result in an eventual fix.

/cc @aojea