### PR TITLE
Bug 1965039: UPSTREAM: 101652: add jitter to lease controller

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
@@ -95,7 +95,7 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 		klog.Infof("lease controller has nil lease client, will not claim or renew leases")
 		return
 	}
-	wait.Until(c.sync, c.renewInterval, stopCh)
+	wait.JitterUntil(c.sync, c.renewInterval, 0.04, true, stopCh)
 }
 
 func (c *controller) sync() {


### PR DESCRIPTION
backport upstream: https://github.com/kubernetes/kubernetes/pull/101652