### PR TITLE
Bug 1966126: UPSTREAM: 102523: rootca controller: cleanup metrics for deleted name…

### DIFF
--- a/pkg/controller/certificates/rootcacertpublisher/metrics.go
+++ b/pkg/controller/certificates/rootcacertpublisher/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rootcacertpublisher
 
 import (
+	"net/http"
 	"strconv"
 	"sync"
 	"time"
@@ -60,6 +61,14 @@ func recordMetrics(start time.Time, ns string, err error) {
 	}
 	syncLatency.WithLabelValues(ns, code).Observe(time.Since(start).Seconds())
 	syncCounter.WithLabelValues(ns, code).Inc()
+}
+
+func cleanupMetrics(ns string) {
+	for code := http.StatusContinue; code <= http.StatusNetworkAuthenticationRequired; code++ {
+		codeStr := strconv.Itoa(code)
+		syncLatency.DeleteLabelValues(ns, codeStr)
+		syncCounter.DeleteLabelValues(ns, codeStr)
+	}
 }
 
 var once sync.Once


### PR DESCRIPTION
This is a backport of an upstream PR to address Prometheus being flooded by the RootCA Publisher Controller.

/assign @s-urbaniak 