### PR TITLE
Bug 1948311: UPSTREAM: 102107: client-go: add retry logic for Watch and Stream

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -93,7 +93,6 @@ type Request struct {
 	rateLimiter flowcontrol.RateLimiter
 	backoff     BackoffManager
 	timeout     time.Duration
-	maxRetries  int
 
 	// generic components accessible via method setters
 	verb       string
@@ -110,8 +109,9 @@ type Request struct {
 	subresource  string
 
 	// output
-	err  error
-	body io.Reader
+	err   error
+	body  io.Reader
+	retry WithRetry
 }
 
 // NewRequest creates a new request helper object for accessing runtime.Objects on a server.
@@ -142,7 +142,7 @@ func NewRequest(c *RESTClient) *Request {
 		backoff:        backoff,
 		timeout:        timeout,
 		pathPrefix:     pathPrefix,
-		maxRetries:     10,
+		retry:          &withRetry{maxRetries: 10},
 		warningHandler: c.warningHandler,
 	}
 
@@ -408,10 +408,7 @@ func (r *Request) Timeout(d time.Duration) *Request {
 // function is specifically called with a different value.
 // A zero maxRetries prevent it from doing retires and return an error immediately.
 func (r *Request) MaxRetries(maxRetries int) *Request {
-	if maxRetries < 0 {
-		maxRetries = 0
-	}
-	r.maxRetries = maxRetries
+	r.retry.SetMaxRetries(maxRetries)
 	return r
 }
 
@@ -842,6 +839,17 @@ func (r *Request) requestPreflightCheck() error {
 	return nil
 }
 
+func (r *Request) newHTTPRequest(ctx context.Context) (*http.Request, error) {
+	url := r.URL().String()
+	req, err := http.NewRequest(r.verb, url, r.body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header = r.headers
+	return req, nil
+}
+
 // request connects to the server and invokes the provided function when a server response is
 // received. It handles retry behavior and up front validation of requests. It will invoke
 // fn at most once. It will return an error if a problem occurred prior to connecting to the
@@ -881,27 +889,22 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 	}
 
 	// Right now we make about ten retry attempts if we get a Retry-After response.
-	retries := 0
-	var retryInfo string
+	var retryAfter *RetryAfter
 	for {
-
-		url := r.URL().String()
-		req, err := http.NewRequest(r.verb, url, r.body)
+		req, err := r.newHTTPRequest(ctx)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.Header = r.headers
 
 		r.backoff.Sleep(r.backoff.CalculateBackoff(r.URL()))
-		if retries > 0 {
+		if retryAfter != nil {
 			// We are retrying the request that we already send to apiserver
 			// at least once before.
 			// This request should also be throttled with the client-internal rate limiter.
-			if err := r.tryThrottleWithInfo(ctx, retryInfo); err != nil {
+			if err := r.tryThrottleWithInfo(ctx, retryAfter.Reason); err != nil {
 				return err
 			}
-			retryInfo = ""
+			retryAfter = nil
 		}
 		resp, err := client.Do(req)
 		updateURLMetrics(ctx, r, resp, err)
@@ -910,61 +913,46 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 		} else {
 			r.backoff.UpdateBackoff(r.URL(), err, resp.StatusCode)
 		}
-		if err != nil {
-			// "Connection reset by peer" or "apiserver is shutting down" are usually a transient errors.
-			// Thus in case of "GET" operations, we simply retry it.
-			// We are not automatically retrying "write" operations, as
-			// they are not idempotent.
-			if r.verb != "GET" {
-				return err
-			}
-			// For connection errors and apiserver shutdown errors retry.
-			if net.IsConnectionReset(err) || net.IsProbableEOF(err) {
-				// For the purpose of retry, we set the artificial "retry-after" response.
-				// TODO: Should we clean the original response if it exists?
-				resp = &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Header:     http.Header{"Retry-After": []string{"1"}},
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-				}
-			} else {
-				return err
-			}
-		}
 
 		done := func() bool {
-			// Ensure the response body is fully read and closed
-			// before we reconnect, so that we reuse the same TCP
-			// connection.
-			defer func() {
-				const maxBodySlurpSize = 2 << 10
-				if resp.ContentLength <= maxBodySlurpSize {
-					io.Copy(ioutil.Discard, &io.LimitedReader{R: resp.Body, N: maxBodySlurpSize})
-				}
-				resp.Body.Close()
-			}()
+			defer readAndCloseResponseBody(resp)
 
-			retries++
-			if seconds, wait := checkWait(resp); wait && retries <= r.maxRetries {
-				retryInfo = getRetryReason(retries, seconds, resp, err)
-				if seeker, ok := r.body.(io.Seeker); ok && r.body != nil {
-					_, err := seeker.Seek(0, 0)
-					if err != nil {
-						klog.V(4).Infof("Could not retry request, can't Seek() back to beginning of body for %T", r.body)
-						fn(req, resp)
-						return true
-					}
+			// if the the server returns an error in err, the response will be nil.
+			f := func(req *http.Request, resp *http.Response) {
+				if resp == nil {
+					return
 				}
+				fn(req, resp)
+			}
 
-				klog.V(4).Infof("Got a Retry-After %ds response for attempt %d to %v", seconds, retries, url)
-				r.backoff.Sleep(time.Duration(seconds) * time.Second)
+			var retry bool
+			retryAfter, retry = r.retry.NextRetry(req, resp, err, func(req *http.Request, err error) bool {
+				// "Connection reset by peer" or "apiserver is shutting down" are usually a transient errors.
+				// Thus in case of "GET" operations, we simply retry it.
+				// We are not automatically retrying "write" operations, as they are not idempotent.
+				if r.verb != "GET" {
+					return false
+				}
+				// For connection errors and apiserver shutdown errors retry.
+				if net.IsConnectionReset(err) || net.IsProbableEOF(err) {
+					return true
+				}
+				return false
+			})
+			if retry {
+				if err := r.retry.BeforeNextRetry(ctx, r.backoff, retryAfter, req.URL.String(), r.body); err != nil {
+					klog.V(4).Infof("Could not retry request - %v", err)
+					f(req, resp)
+					return true
+				}
 				return false
 			}
-			fn(req, resp)
+
+			f(req, resp)
 			return true
 		}()
 		if done {
-			return nil
+			return err
 		}
 	}
 }
@@ -1196,19 +1184,6 @@ func isTextResponse(resp *http.Response) bool {
 	return strings.HasPrefix(media, "text/")
 }
 
-// checkWait returns true along with a number of seconds if the server instructed us to wait
-// before retrying.
-func checkWait(resp *http.Response) (int, bool) {
-	switch r := resp.StatusCode; {
-	// any 500 error code and 429 can trigger a wait
-	case r == http.StatusTooManyRequests, r >= 500:
-	default:
-		return 0, false
-	}
-	i, ok := retryAfterSeconds(resp)
-	return i, ok
-}
-
 // retryAfterSeconds returns the value of the Retry-After header and true, or 0 and false if
 // the header was missing or not a valid number.
 func retryAfterSeconds(resp *http.Response) (int, bool) {
@@ -1218,26 +1193,6 @@ func retryAfterSeconds(resp *http.Response) (int, bool) {
 		}
 	}
 	return 0, false
-}
-
-func getRetryReason(retries, seconds int, resp *http.Response, err error) string {
-	// priority and fairness sets the UID of the FlowSchema associated with a request
-	// in the following response Header.
-	const responseHeaderMatchedFlowSchemaUID = "X-Kubernetes-PF-FlowSchema-UID"
-
-	message := fmt.Sprintf("retries: %d, retry-after: %ds", retries, seconds)
-
-	switch {
-	case resp.StatusCode == http.StatusTooManyRequests:
-		// it is server-side throttling from priority and fairness
-		flowSchemaUID := resp.Header.Get(responseHeaderMatchedFlowSchemaUID)
-		return fmt.Sprintf("%s - retry-reason: due to server-side throttling, FlowSchema UID: %q", message, flowSchemaUID)
-	case err != nil:
-		// it's a retriable error
-		return fmt.Sprintf("%s - retry-reason: due to retriable error, error: %v", message, err)
-	default:
-		return fmt.Sprintf("%s - retry-reason: %d", message, resp.StatusCode)
-	}
 }
 
 // Result contains the result of calling Request.Do().

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -675,43 +675,88 @@ func (r *Request) Watch(ctx context.Context) (watch.Interface, error) {
 		return nil, r.err
 	}
 
-	url := r.URL().String()
-	req, err := http.NewRequest(r.verb, url, r.body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	req.Header = r.headers
 	client := r.c.Client
 	if client == nil {
 		client = http.DefaultClient
 	}
-	r.backoff.Sleep(r.backoff.CalculateBackoff(r.URL()))
-	resp, err := client.Do(req)
-	updateURLMetrics(ctx, r, resp, err)
-	if r.c.base != nil {
-		if err != nil {
-			r.backoff.UpdateBackoff(r.c.base, err, 0)
-		} else {
-			r.backoff.UpdateBackoff(r.c.base, err, resp.StatusCode)
-		}
-	}
-	if err != nil {
+
+	isErrRetryableFunc := func(request *http.Request, err error) bool {
 		// The watch stream mechanism handles many common partial data errors, so closed
 		// connections can be retried in many cases.
 		if net.IsProbableEOF(err) || net.IsTimeout(err) {
-			return watch.NewEmptyWatch(), nil
+			return true
 		}
-		return nil, err
+		return false
 	}
-	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
-		if result := r.transformResponse(resp, req); result.err != nil {
-			return nil, result.err
+	var retryAfter *RetryAfter
+	url := r.URL().String()
+	for {
+		req, err := r.newHTTPRequest(ctx)
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("for request %s, got status: %v", url, resp.StatusCode)
-	}
 
+		r.backoff.Sleep(r.backoff.CalculateBackoff(r.URL()))
+		if retryAfter != nil {
+			// We are retrying the request that we already send to apiserver
+			// at least once before.
+			// This request should also be throttled with the client-internal rate limiter.
+			if err := r.tryThrottleWithInfo(ctx, retryAfter.Reason); err != nil {
+				return nil, err
+			}
+			retryAfter = nil
+		}
+
+		resp, err := client.Do(req)
+		updateURLMetrics(ctx, r, resp, err)
+		if r.c.base != nil {
+			if err != nil {
+				r.backoff.UpdateBackoff(r.c.base, err, 0)
+			} else {
+				r.backoff.UpdateBackoff(r.c.base, err, resp.StatusCode)
+			}
+		}
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return r.newStreamWatcher(resp)
+		}
+
+		done, transformErr := func() (bool, error) {
+			defer readAndCloseResponseBody(resp)
+
+			var retry bool
+			retryAfter, retry = r.retry.NextRetry(req, resp, err, isErrRetryableFunc)
+			if retry {
+				err := r.retry.BeforeNextRetry(ctx, r.backoff, retryAfter, url, r.body)
+				if err == nil {
+					return false, nil
+				}
+				klog.V(4).Infof("Could not retry request - %v", err)
+			}
+
+			if resp == nil {
+				// the server must have sent us an error in 'err'
+				return true, nil
+			}
+			if result := r.transformResponse(resp, req); result.err != nil {
+				return true, result.err
+			}
+			return true, fmt.Errorf("for request %s, got status: %v", url, resp.StatusCode)
+		}()
+		if done {
+			if isErrRetryableFunc(req, err) {
+				return watch.NewEmptyWatch(), nil
+			}
+			if err == nil {
+				// if the server sent us an HTTP Response object,
+				// we need to return the error object from that.
+				err = transformErr
+			}
+			return nil, err
+		}
+	}
+}
+
+func (r *Request) newStreamWatcher(resp *http.Response) (watch.Interface, error) {
 	contentType := resp.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
@@ -766,49 +811,75 @@ func (r *Request) Stream(ctx context.Context) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	url := r.URL().String()
-	req, err := http.NewRequest(r.verb, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	if r.body != nil {
-		req.Body = ioutil.NopCloser(r.body)
-	}
-	req = req.WithContext(ctx)
-	req.Header = r.headers
 	client := r.c.Client
 	if client == nil {
 		client = http.DefaultClient
 	}
-	r.backoff.Sleep(r.backoff.CalculateBackoff(r.URL()))
-	resp, err := client.Do(req)
-	updateURLMetrics(ctx, r, resp, err)
-	if r.c.base != nil {
+
+	var retryAfter *RetryAfter
+	url := r.URL().String()
+	for {
+		req, err := r.newHTTPRequest(ctx)
 		if err != nil {
-			r.backoff.UpdateBackoff(r.URL(), err, 0)
-		} else {
-			r.backoff.UpdateBackoff(r.URL(), err, resp.StatusCode)
+			return nil, err
 		}
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	switch {
-	case (resp.StatusCode >= 200) && (resp.StatusCode < 300):
-		handleWarnings(resp.Header, r.warningHandler)
-		return resp.Body, nil
-
-	default:
-		// ensure we close the body before returning the error
-		defer resp.Body.Close()
-
-		result := r.transformResponse(resp, req)
-		err := result.Error()
-		if err == nil {
-			err = fmt.Errorf("%d while accessing %v: %s", result.statusCode, url, string(result.body))
+		if r.body != nil {
+			req.Body = ioutil.NopCloser(r.body)
 		}
-		return nil, err
+
+		r.backoff.Sleep(r.backoff.CalculateBackoff(r.URL()))
+		if retryAfter != nil {
+			// We are retrying the request that we already send to apiserver
+			// at least once before.
+			// This request should also be throttled with the client-internal rate limiter.
+			if err := r.tryThrottleWithInfo(ctx, retryAfter.Reason); err != nil {
+				return nil, err
+			}
+			retryAfter = nil
+		}
+
+		resp, err := client.Do(req)
+		updateURLMetrics(ctx, r, resp, err)
+		if r.c.base != nil {
+			if err != nil {
+				r.backoff.UpdateBackoff(r.URL(), err, 0)
+			} else {
+				r.backoff.UpdateBackoff(r.URL(), err, resp.StatusCode)
+			}
+		}
+		if err != nil {
+			// we only retry on an HTTP response with 'Retry-After' header
+			return nil, err
+		}
+
+		switch {
+		case (resp.StatusCode >= 200) && (resp.StatusCode < 300):
+			handleWarnings(resp.Header, r.warningHandler)
+			return resp.Body, nil
+
+		default:
+			done, transformErr := func() (bool, error) {
+				defer resp.Body.Close()
+
+				var retry bool
+				retryAfter, retry = r.retry.NextRetry(req, resp, err, neverRetryError)
+				if retry {
+					err := r.retry.BeforeNextRetry(ctx, r.backoff, retryAfter, url, r.body)
+					if err == nil {
+						return false, nil
+					}
+					klog.V(4).Infof("Could not retry request - %v", err)
+				}
+				result := r.transformResponse(resp, req)
+				if err := result.Error(); err != nil {
+					return true, err
+				}
+				return true, fmt.Errorf("%d while accessing %v: %s", result.statusCode, url, string(result.body))
+			}()
+			if done {
+				return nil, transformErr
+			}
+		}
 	}
 }
 
@@ -940,12 +1011,11 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 				return false
 			})
 			if retry {
-				if err := r.retry.BeforeNextRetry(ctx, r.backoff, retryAfter, req.URL.String(), r.body); err != nil {
-					klog.V(4).Infof("Could not retry request - %v", err)
-					f(req, resp)
-					return true
+				err := r.retry.BeforeNextRetry(ctx, r.backoff, retryAfter, req.URL.String(), r.body)
+				if err == nil {
+					return false
 				}
-				return false
+				klog.V(4).Infof("Could not retry request - %v", err)
 			}
 
 			f(req, resp)

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1093,6 +1093,7 @@ func TestRequestWatch(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run("", func(t *testing.T) {
 			testCase.Request.backoff = &NoBackoff{}
+			testCase.Request.retry = &withRetry{}
 			watch, err := testCase.Request.Watch(context.Background())
 			hasErr := err != nil
 			if hasErr != testCase.Err {
@@ -1194,8 +1195,10 @@ func TestRequestStream(t *testing.T) {
 			},
 		},
 	}
+
 	for i, testCase := range testCases {
 		testCase.Request.backoff = &NoBackoff{}
+		testCase.Request.retry = &withRetry{maxRetries: 0}
 		body, err := testCase.Request.Stream(context.Background())
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -1274,6 +1277,7 @@ func TestRequestDo(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		testCase.Request.backoff = &NoBackoff{}
+		testCase.Request.retry = &withRetry{}
 		body, err := testCase.Request.Do(context.Background()).Raw()
 		hasErr := err != nil
 		if hasErr != testCase.Err {
@@ -1436,8 +1440,8 @@ func TestConnectionResetByPeerIsRetried(t *testing.T) {
 				return nil, &net.OpError{Err: syscall.ECONNRESET}
 			}),
 		},
-		backoff:    backoff,
-		maxRetries: 10,
+		backoff: backoff,
+		retry:   &withRetry{maxRetries: 10},
 	}
 	// We expect two retries of "connection reset by peer" and the success.
 	_, err := req.Do(context.Background()).Raw()
@@ -2311,6 +2315,288 @@ func TestRequestMaxRetries(t *testing.T) {
 			hasError := err != nil
 			if testCase.expectError != hasError {
 				t.Error(" failed checking error")
+			}
+		})
+	}
+}
+
+type responseErr struct {
+	response *http.Response
+	err      error
+}
+
+type seek struct {
+	offset int64
+	whence int
+}
+
+type count struct {
+	// keeps track of the number of Seek(offset, whence) calls.
+	seeks []seek
+	// how many times {Request|Response}.Body.Close() has been invoked
+	closes int
+}
+
+// used to track {Request|Response}.Body
+type readTracker struct {
+	count     *count
+	delegated io.Reader
+}
+
+func (r *readTracker) Seek(offset int64, whence int) (int64, error) {
+	if seeker, ok := r.delegated.(io.Seeker); ok {
+		r.count.seeks = append(r.count.seeks, seek{offset: offset, whence: whence})
+		return seeker.Seek(offset, whence)
+	}
+	return 0, io.EOF
+}
+
+func (r *readTracker) Read(p []byte) (n int, err error) {
+	return r.delegated.Read(p)
+}
+
+func (r *readTracker) Close() error {
+	if closer, ok := r.delegated.(io.Closer); ok {
+		r.count.closes++
+		return closer.Close()
+	}
+	return nil
+}
+
+func newReadTracker(count *count) *readTracker {
+	return &readTracker{
+		count: count,
+	}
+}
+
+func newCount() *count {
+	return &count{
+		closes: 0,
+		seeks:  make([]seek, 0),
+	}
+}
+
+type readSeeker struct{ err error }
+
+func (rs readSeeker) Read([]byte) (int, error)       { return 0, rs.err }
+func (rs readSeeker) Seek(int64, int) (int64, error) { return 0, rs.err }
+
+func unWrap(err error) error {
+	if uerr, ok := err.(*url.Error); ok {
+		return uerr.Err
+	}
+	return err
+}
+
+// noSleepBackOff is a NoBackoff except it does not sleep,
+// used for faster execution of the unit tests.
+type noSleepBackOff struct {
+	*NoBackoff
+}
+
+func (n *noSleepBackOff) Sleep(d time.Duration) {}
+
+func TestRequestWithRetry(t *testing.T) {
+	tests := []struct {
+		name                         string
+		body                         io.Reader
+		serverReturns                responseErr
+		errExpected                  error
+		transformFuncInvokedExpected int
+		roundTripInvokedExpected     int
+	}{
+		{
+			name:                         "server returns retry-after response, request body is not io.Seeker, retry goes ahead",
+			body:                         ioutil.NopCloser(bytes.NewReader([]byte{})),
+			serverReturns:                responseErr{response: retryAfterResponse(), err: nil},
+			errExpected:                  nil,
+			transformFuncInvokedExpected: 1,
+			roundTripInvokedExpected:     2,
+		},
+		{
+			name:                         "server returns retry-after response, request body Seek returns error, retry aborted",
+			body:                         &readSeeker{err: io.EOF},
+			serverReturns:                responseErr{response: retryAfterResponse(), err: nil},
+			errExpected:                  nil,
+			transformFuncInvokedExpected: 1,
+			roundTripInvokedExpected:     1,
+		},
+		{
+			name:                         "server returns retry-after response, request body Seek returns no error, retry goes ahead",
+			body:                         &readSeeker{err: nil},
+			serverReturns:                responseErr{response: retryAfterResponse(), err: nil},
+			errExpected:                  nil,
+			transformFuncInvokedExpected: 1,
+			roundTripInvokedExpected:     2,
+		},
+		{
+			name:                         "server returns retryable err, request body is not io.Seek, retry goes ahead",
+			body:                         ioutil.NopCloser(bytes.NewReader([]byte{})),
+			serverReturns:                responseErr{response: nil, err: io.ErrUnexpectedEOF},
+			errExpected:                  io.ErrUnexpectedEOF,
+			transformFuncInvokedExpected: 0,
+			roundTripInvokedExpected:     2,
+		},
+		{
+			name:                         "server returns retryable err, request body Seek returns error, retry aborted",
+			body:                         &readSeeker{err: io.EOF},
+			serverReturns:                responseErr{response: nil, err: io.ErrUnexpectedEOF},
+			errExpected:                  io.ErrUnexpectedEOF,
+			transformFuncInvokedExpected: 0,
+			roundTripInvokedExpected:     1,
+		},
+		{
+			name:                         "server returns retryable err, request body Seek returns no err, retry goes ahead",
+			body:                         &readSeeker{err: nil},
+			serverReturns:                responseErr{response: nil, err: io.ErrUnexpectedEOF},
+			errExpected:                  io.ErrUnexpectedEOF,
+			transformFuncInvokedExpected: 0,
+			roundTripInvokedExpected:     2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var roundTripInvoked int
+			client := clientForFunc(func(req *http.Request) (*http.Response, error) {
+				roundTripInvoked++
+				return test.serverReturns.response, test.serverReturns.err
+			})
+
+			req := &Request{
+				verb: "GET",
+				body: test.body,
+				c: &RESTClient{
+					Client: client,
+				},
+				backoff: &noSleepBackOff{},
+				retry:   &withRetry{maxRetries: 1},
+			}
+
+			var transformFuncInvoked int
+			err := req.request(context.Background(), func(request *http.Request, response *http.Response) {
+				transformFuncInvoked++
+			})
+
+			if test.roundTripInvokedExpected != roundTripInvoked {
+				t.Errorf("Expected RoundTrip to be invoked %d times, but got: %d", test.roundTripInvokedExpected, roundTripInvoked)
+			}
+			if test.transformFuncInvokedExpected != transformFuncInvoked {
+				t.Errorf("Expected transform func to be invoked %d times, but got: %d", test.transformFuncInvokedExpected, transformFuncInvoked)
+			}
+			if test.errExpected != unWrap(err) {
+				t.Errorf("Expected error: %v, but got: %v", test.errExpected, unWrap(err))
+			}
+		})
+	}
+}
+
+func TestRequestDoWithRetry(t *testing.T) {
+	testRequestWithRetry(t, func(ctx context.Context, r *Request) {
+		r.Do(ctx)
+	})
+}
+
+func TestRequestDORawWithRetry(t *testing.T) {
+	testRequestWithRetry(t, func(ctx context.Context, r *Request) {
+		r.DoRaw(ctx)
+	})
+}
+
+func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Request)) {
+	tests := []struct {
+		name              string
+		verb              string
+		body              func() io.Reader
+		maxRetries        int
+		serverReturns     []responseErr
+		reqCountExpected  *count
+		respCountExpected *count
+	}{
+		{
+			name:       "server always returns retry-after response",
+			verb:       "GET",
+			body:       func() io.Reader { return bytes.NewReader([]byte{}) },
+			maxRetries: 2,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+			},
+			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
+			respCountExpected: &count{closes: 3, seeks: []seek{}},
+		},
+		{
+			name:       "server always returns retryable error",
+			verb:       "GET",
+			body:       func() io.Reader { return bytes.NewReader([]byte{}) },
+			maxRetries: 2,
+			serverReturns: []responseErr{
+				{response: nil, err: io.EOF},
+				{response: nil, err: io.EOF},
+				{response: nil, err: io.EOF},
+			},
+			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
+			respCountExpected: &count{closes: 0, seeks: []seek{}},
+		},
+		{
+			name:       "server returns success on the final retry",
+			verb:       "GET",
+			body:       func() io.Reader { return bytes.NewReader([]byte{}) },
+			maxRetries: 2,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: nil, err: io.EOF},
+				{response: &http.Response{StatusCode: http.StatusOK}, err: nil},
+			},
+			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
+			respCountExpected: &count{closes: 2, seeks: []seek{}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			respCountGot := newCount()
+			responseRecorder := newReadTracker(respCountGot)
+			var attempts int
+			client := clientForFunc(func(req *http.Request) (*http.Response, error) {
+				defer func() {
+					attempts++
+				}()
+
+				resp := test.serverReturns[attempts].response
+				if resp != nil {
+					responseRecorder.delegated = ioutil.NopCloser(bytes.NewReader([]byte{}))
+					resp.Body = responseRecorder
+				}
+				return resp, test.serverReturns[attempts].err
+			})
+
+			reqCountGot := newCount()
+			reqRecorder := newReadTracker(reqCountGot)
+			reqRecorder.delegated = test.body()
+
+			req := &Request{
+				verb: test.verb,
+				body: reqRecorder,
+				c: &RESTClient{
+					Client: client,
+				},
+				backoff: &noSleepBackOff{},
+				retry:   &withRetry{maxRetries: test.maxRetries},
+			}
+
+			doFunc(context.Background(), req)
+
+			attemptsExpected := test.maxRetries + 1
+			if attemptsExpected != attempts {
+				t.Errorf("Expected retries: %d, but got: %d", attemptsExpected, attempts)
+			}
+			if !reflect.DeepEqual(test.reqCountExpected.seeks, reqCountGot.seeks) {
+				t.Errorf("Expected request body to have seek invocation: %v, but got: %v", test.reqCountExpected.seeks, reqCountGot.seeks)
+			}
+			if test.respCountExpected.closes != respCountGot.closes {
+				t.Errorf("Expected response body Close to be invoked %d times, but got: %d", test.respCountExpected.closes, respCountGot.closes)
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -924,53 +924,57 @@ func TestTransformUnstructuredError(t *testing.T) {
 	}
 }
 
-type errorReader struct {
-	err error
-}
-
-func (r errorReader) Read(data []byte) (int, error) { return 0, r.err }
-func (r errorReader) Close() error                  { return nil }
-
 func TestRequestWatch(t *testing.T) {
 	testCases := []struct {
-		Request *Request
-		Expect  []watch.Event
-		Err     bool
-		ErrFn   func(error) bool
-		Empty   bool
+		name             string
+		Request          *Request
+		maxRetries       int
+		serverReturns    []responseErr
+		Expect           []watch.Event
+		attemptsExpected int
+		Err              bool
+		ErrFn            func(error) bool
+		Empty            bool
 	}{
 		{
-			Request: &Request{err: errors.New("bail")},
-			Err:     true,
+			name:             "Request has error",
+			Request:          &Request{err: errors.New("bail")},
+			attemptsExpected: 0,
+			Err:              true,
 		},
 		{
+			name:    "Client is nil, should use http.DefaultClient",
 			Request: &Request{c: &RESTClient{base: &url.URL{}}, pathPrefix: "%"},
 			Err:     true,
 		},
 		{
+			name: "error is not retryable",
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return nil, errors.New("err")
-					}),
 					base: &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: nil, err: errors.New("err")},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 		},
 		{
+			name: "server returns forbidden",
 			Request: &Request{
 				c: &RESTClient{
 					content: defaultContentConfig(),
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusForbidden,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-						}, nil
-					}),
-					base: &url.URL{},
+					base:    &url.URL{},
 				},
 			},
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
 			Expect: []watch.Event{
 				{
 					Type: watch.Error,
@@ -1000,101 +1004,205 @@ func TestRequestWatch(t *testing.T) {
 			},
 		},
 		{
+			name: "server returns forbidden",
 			Request: &Request{
 				c: &RESTClient{
 					content: defaultContentConfig(),
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusForbidden,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-						}, nil
-					}),
-					base: &url.URL{},
+					base:    &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 			ErrFn: func(err error) bool {
 				return apierrors.IsForbidden(err)
 			},
 		},
 		{
+			name: "server returns unauthorized",
 			Request: &Request{
 				c: &RESTClient{
 					content: defaultContentConfig(),
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusUnauthorized,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-						}, nil
-					}),
-					base: &url.URL{},
+					base:    &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 			ErrFn: func(err error) bool {
 				return apierrors.IsUnauthorized(err)
 			},
 		},
 		{
+			name: "server returns unauthorized",
 			Request: &Request{
 				c: &RESTClient{
 					content: defaultContentConfig(),
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusUnauthorized,
-							Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &metav1.Status{
-								Status: metav1.StatusFailure,
-								Reason: metav1.StatusReasonUnauthorized,
-							})))),
-						}, nil
-					}),
-					base: &url.URL{},
+					base:    &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &metav1.Status{
+						Status: metav1.StatusFailure,
+						Reason: metav1.StatusReasonUnauthorized,
+					})))),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 			ErrFn: func(err error) bool {
 				return apierrors.IsUnauthorized(err)
 			},
 		},
 		{
+			name: "server returns EOF error",
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return nil, io.EOF
-					}),
 					base: &url.URL{},
 				},
+			},
+			serverReturns: []responseErr{
+				{response: nil, err: io.EOF},
+			},
+			attemptsExpected: 1,
+			Empty:            true,
+		},
+		{
+			name: "server returns can't write HTTP request on broken connection error",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			serverReturns: []responseErr{
+				{response: nil, err: errors.New("http: can't write HTTP request on broken connection")},
+			},
+			attemptsExpected: 1,
+			Empty:            true,
+		},
+		{
+			name: "server returns connection reset by peer",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			serverReturns: []responseErr{
+				{response: nil, err: errors.New("foo: connection reset by peer")},
+			},
+			attemptsExpected: 1,
+			Empty:            true,
+		},
+		{
+			name: "max retries 2, server always returns EOF error",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       2,
+			attemptsExpected: 3,
+			serverReturns: []responseErr{
+				{response: nil, err: io.EOF},
+				{response: nil, err: io.EOF},
+				{response: nil, err: io.EOF},
 			},
 			Empty: true,
 		},
 		{
+			name: "max retries 1, server returns a retry-after response, request body seek error",
 			Request: &Request{
+				body: &readSeeker{err: io.EOF},
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return nil, errors.New("http: can't write HTTP request on broken connection")
-					}),
 					base: &url.URL{},
 				},
+			},
+			maxRetries:       1,
+			attemptsExpected: 1,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsInternalError(err)
+			},
+		},
+		{
+			name: "max retries 1, server returns a retryable error, request body seek error",
+			Request: &Request{
+				body: &readSeeker{err: io.EOF},
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       1,
+			attemptsExpected: 1,
+			serverReturns: []responseErr{
+				{response: nil, err: io.EOF},
 			},
 			Empty: true,
 		},
 		{
+			name: "max retries 2, server always returns a response with Retry-After header",
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return nil, errors.New("foo: connection reset by peer")
-					}),
 					base: &url.URL{},
 				},
 			},
-			Empty: true,
+			maxRetries:       2,
+			attemptsExpected: 3,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsInternalError(err)
+			},
 		},
 	}
+
 	for _, testCase := range testCases {
-		t.Run("", func(t *testing.T) {
-			testCase.Request.backoff = &NoBackoff{}
-			testCase.Request.retry = &withRetry{}
+		t.Run(testCase.name, func(t *testing.T) {
+			var attemptsGot int
+			client := clientForFunc(func(req *http.Request) (*http.Response, error) {
+				defer func() {
+					attemptsGot++
+				}()
+
+				if attemptsGot >= len(testCase.serverReturns) {
+					t.Fatalf("Wrong test setup, the server does not know what to return")
+				}
+				re := testCase.serverReturns[attemptsGot]
+				return re.response, re.err
+			})
+			if c := testCase.Request.c; c != nil && len(testCase.serverReturns) > 0 {
+				c.Client = client
+			}
+			testCase.Request.backoff = &noSleepBackOff{}
+			testCase.Request.retry = &withRetry{maxRetries: testCase.maxRetries}
+
 			watch, err := testCase.Request.Watch(context.Background())
+
+			if watch == nil && err == nil {
+				t.Fatal("Both watch.Interface and err returned by Watch are nil")
+			}
+			if testCase.attemptsExpected != attemptsGot {
+				t.Errorf("Expected RoundTrip to be invoked %d times, but got: %d", testCase.attemptsExpected, attemptsGot)
+			}
 			hasErr := err != nil
 			if hasErr != testCase.Err {
 				t.Fatalf("expected %t, got %t: %v", testCase.Err, hasErr, err)
@@ -1132,61 +1240,72 @@ func TestRequestWatch(t *testing.T) {
 
 func TestRequestStream(t *testing.T) {
 	testCases := []struct {
-		Request *Request
-		Err     bool
-		ErrFn   func(error) bool
+		name             string
+		Request          *Request
+		maxRetries       int
+		serverReturns    []responseErr
+		attemptsExpected int
+		Err              bool
+		ErrFn            func(error) bool
 	}{
 		{
-			Request: &Request{err: errors.New("bail")},
-			Err:     true,
+			name:             "request has error",
+			Request:          &Request{err: errors.New("bail")},
+			attemptsExpected: 0,
+			Err:              true,
 		},
 		{
+			name:    "Client is nil, should use http.DefaultClient",
 			Request: &Request{c: &RESTClient{base: &url.URL{}}, pathPrefix: "%"},
 			Err:     true,
 		},
 		{
+			name: "server returns an error",
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return nil, errors.New("err")
-					}),
 					base: &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: nil, err: errors.New("err")},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 		},
 		{
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusUnauthorized,
-							Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &metav1.Status{
-								Status: metav1.StatusFailure,
-								Reason: metav1.StatusReasonUnauthorized,
-							})))),
-						}, nil
-					}),
 					content: defaultContentConfig(),
 					base:    &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &metav1.Status{
+						Status: metav1.StatusFailure,
+						Reason: metav1.StatusReasonUnauthorized,
+					})))),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 		},
 		{
 			Request: &Request{
 				c: &RESTClient{
-					Client: clientForFunc(func(req *http.Request) (*http.Response, error) {
-						return &http.Response{
-							StatusCode: http.StatusBadRequest,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"a container name must be specified for pod kube-dns-v20-mz5cv, choose one of: [kubedns dnsmasq healthz]","reason":"BadRequest","code":400}`))),
-						}, nil
-					}),
 					content: defaultContentConfig(),
 					base:    &url.URL{},
 				},
 			},
-			Err: true,
+			serverReturns: []responseErr{
+				{response: &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"a container name must be specified for pod kube-dns-v20-mz5cv, choose one of: [kubedns dnsmasq healthz]","reason":"BadRequest","code":400}`))),
+				}, err: nil},
+			},
+			attemptsExpected: 1,
+			Err:              true,
 			ErrFn: func(err error) bool {
 				if err.Error() == "a container name must be specified for pod kube-dns-v20-mz5cv, choose one of: [kubedns dnsmasq healthz]" {
 					return true
@@ -1194,25 +1313,124 @@ func TestRequestStream(t *testing.T) {
 				return false
 			},
 		},
+		{
+			name: "max retries 1, server returns a retry-after response, request body seek error",
+			Request: &Request{
+				body: &readSeeker{err: io.EOF},
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       1,
+			attemptsExpected: 1,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsInternalError(err)
+			},
+		},
+		{
+			name: "max retries 2, server always returns a response with Retry-After header",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       2,
+			attemptsExpected: 3,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsInternalError(err)
+			},
+		},
+		{
+			name: "server returns EOF after attempt 1, retry aborted",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       2,
+			attemptsExpected: 2,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: nil, err: io.EOF},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return unWrap(err) == io.EOF
+			},
+		},
+		{
+			name: "max retries 2, server returns success on the final attempt",
+			Request: &Request{
+				c: &RESTClient{
+					base: &url.URL{},
+				},
+			},
+			maxRetries:       2,
+			attemptsExpected: 3,
+			serverReturns: []responseErr{
+				{response: retryAfterResponse(), err: nil},
+				{response: retryAfterResponse(), err: nil},
+				{response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, err: nil},
+			},
+		},
 	}
 
-	for i, testCase := range testCases {
-		testCase.Request.backoff = &NoBackoff{}
-		testCase.Request.retry = &withRetry{maxRetries: 0}
-		body, err := testCase.Request.Stream(context.Background())
-		hasErr := err != nil
-		if hasErr != testCase.Err {
-			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
-		}
-		if hasErr && body != nil {
-			t.Errorf("%d: body should be nil when error is returned", i)
-		}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var attemptsGot int
+			client := clientForFunc(func(req *http.Request) (*http.Response, error) {
+				defer func() {
+					attemptsGot++
+				}()
 
-		if hasErr {
-			if testCase.ErrFn != nil && !testCase.ErrFn(err) {
-				t.Errorf("unexpected error: %v", err)
+				if attemptsGot >= len(testCase.serverReturns) {
+					t.Fatalf("Wrong test setup, the server does not know what to return")
+				}
+				re := testCase.serverReturns[attemptsGot]
+				return re.response, re.err
+			})
+			if c := testCase.Request.c; c != nil && len(testCase.serverReturns) > 0 {
+				c.Client = client
 			}
-		}
+			testCase.Request.backoff = &noSleepBackOff{}
+			testCase.Request.retry = &withRetry{maxRetries: testCase.maxRetries}
+
+			body, err := testCase.Request.Stream(context.Background())
+
+			if body == nil && err == nil {
+				t.Fatal("Both body and err returned by Stream are nil")
+			}
+			if testCase.attemptsExpected != attemptsGot {
+				t.Errorf("Expected RoundTrip to be invoked %d times, but got: %d", testCase.attemptsExpected, attemptsGot)
+			}
+
+			hasErr := err != nil
+			if hasErr != testCase.Err {
+				t.Errorf("expected %t, got %t: %v", testCase.Err, hasErr, err)
+			}
+			if hasErr && body != nil {
+				t.Error("body should be nil when error is returned")
+			}
+
+			if hasErr {
+				if testCase.ErrFn != nil && !testCase.ErrFn(err) {
+					t.Errorf("unexpected error: %#v", err)
+				}
+			}
+		})
 	}
 }
 
@@ -1840,57 +2058,87 @@ func TestBody(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	var table = []struct {
-		t   watch.EventType
-		obj runtime.Object
+	tests := []struct {
+		name       string
+		maxRetries int
 	}{
-		{watch.Added, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "first"}}},
-		{watch.Modified, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "second"}}},
-		{watch.Deleted, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "last"}}},
+		{
+			name:       "no retry",
+			maxRetries: 0,
+		},
+		{
+			name:       "with retries",
+			maxRetries: 3,
+		},
 	}
 
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			panic("need flusher!")
-		}
-
-		w.Header().Set("Transfer-Encoding", "chunked")
-		w.WriteHeader(http.StatusOK)
-		flusher.Flush()
-
-		encoder := restclientwatch.NewEncoder(streaming.NewEncoder(w, scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion)), scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion))
-		for _, item := range table {
-			if err := encoder.Encode(&watch.Event{Type: item.t, Object: item.obj}); err != nil {
-				panic(err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var table = []struct {
+				t   watch.EventType
+				obj runtime.Object
+			}{
+				{watch.Added, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "first"}}},
+				{watch.Modified, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "second"}}},
+				{watch.Deleted, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "last"}}},
 			}
-			flusher.Flush()
-		}
-	}))
-	defer testServer.Close()
 
-	s := testRESTClient(t, testServer)
-	watching, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+			var attempts int
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					attempts++
+				}()
 
-	for _, item := range table {
-		got, ok := <-watching.ResultChan()
-		if !ok {
-			t.Fatalf("Unexpected early close")
-		}
-		if e, a := item.t, got.Type; e != a {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-		if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-	}
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					panic("need flusher!")
+				}
 
-	_, ok := <-watching.ResultChan()
-	if ok {
-		t.Fatal("Unexpected non-close")
+				if attempts < test.maxRetries {
+					w.Header().Set("Retry-After", "1")
+					w.WriteHeader(http.StatusTooManyRequests)
+					return
+				}
+
+				w.Header().Set("Transfer-Encoding", "chunked")
+				w.WriteHeader(http.StatusOK)
+				flusher.Flush()
+
+				encoder := restclientwatch.NewEncoder(streaming.NewEncoder(w, scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion)), scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion))
+				for _, item := range table {
+					if err := encoder.Encode(&watch.Event{Type: item.t, Object: item.obj}); err != nil {
+						panic(err)
+					}
+					flusher.Flush()
+				}
+			}))
+			defer testServer.Close()
+
+			s := testRESTClient(t, testServer)
+			watching, err := s.Get().Prefix("path/to/watch/thing").
+				MaxRetries(test.maxRetries).Watch(context.Background())
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			for _, item := range table {
+				got, ok := <-watching.ResultChan()
+				if !ok {
+					t.Fatalf("Unexpected early close")
+				}
+				if e, a := item.t, got.Type; e != a {
+					t.Errorf("Expected %v, got %v", e, a)
+				}
+				if e, a := item.obj, got.Object; !apiequality.Semantic.DeepDerivative(e, a) {
+					t.Errorf("Expected %v, got %v", e, a)
+				}
+			}
+
+			_, ok := <-watching.ResultChan()
+			if ok {
+				t.Fatal("Unexpected non-close")
+			}
+		})
 	}
 }
 
@@ -2333,14 +2581,27 @@ type seek struct {
 type count struct {
 	// keeps track of the number of Seek(offset, whence) calls.
 	seeks []seek
+
 	// how many times {Request|Response}.Body.Close() has been invoked
+	lock   sync.Mutex
 	closes int
+}
+
+func (c *count) close() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.closes++
+}
+func (c *count) getCloseCount() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.closes
 }
 
 // used to track {Request|Response}.Body
 type readTracker struct {
-	count     *count
 	delegated io.Reader
+	count     *count
 }
 
 func (r *readTracker) Seek(offset int64, whence int) (int64, error) {
@@ -2357,7 +2618,7 @@ func (r *readTracker) Read(p []byte) (n int, err error) {
 
 func (r *readTracker) Close() error {
 	if closer, ok := r.delegated.(io.Closer); ok {
-		r.count.closes++
+		r.count.close()
 		return closer.Close()
 	}
 	return nil
@@ -2492,26 +2753,46 @@ func TestRequestWithRetry(t *testing.T) {
 }
 
 func TestRequestDoWithRetry(t *testing.T) {
-	testRequestWithRetry(t, func(ctx context.Context, r *Request) {
+	testRequestWithRetry(t, "Do", func(ctx context.Context, r *Request) {
 		r.Do(ctx)
 	})
 }
 
-func TestRequestDORawWithRetry(t *testing.T) {
-	testRequestWithRetry(t, func(ctx context.Context, r *Request) {
+func TestRequestDoRawWithRetry(t *testing.T) {
+	// both request.Do and request.DoRaw have the same behavior and expectations
+	testRequestWithRetry(t, "Do", func(ctx context.Context, r *Request) {
 		r.DoRaw(ctx)
 	})
 }
 
-func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Request)) {
+func TestRequestStreamWithRetry(t *testing.T) {
+	testRequestWithRetry(t, "Stream", func(ctx context.Context, r *Request) {
+		r.Stream(ctx)
+	})
+}
+
+func TestRequestWatchWithRetry(t *testing.T) {
+	testRequestWithRetry(t, "Watch", func(ctx context.Context, r *Request) {
+		r.Watch(ctx)
+	})
+}
+
+func testRequestWithRetry(t *testing.T, key string, doFunc func(ctx context.Context, r *Request)) {
+	type expected struct {
+		attempts  int
+		reqCount  *count
+		respCount *count
+	}
+
 	tests := []struct {
-		name              string
-		verb              string
-		body              func() io.Reader
-		maxRetries        int
-		serverReturns     []responseErr
-		reqCountExpected  *count
-		respCountExpected *count
+		name          string
+		verb          string
+		body          func() io.Reader
+		maxRetries    int
+		serverReturns []responseErr
+
+		// expectations differ based on whether it is 'Watch', 'Stream' or 'Do'
+		expectations map[string]expected
 	}{
 		{
 			name:       "server always returns retry-after response",
@@ -2523,8 +2804,23 @@ func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Requ
 				{response: retryAfterResponse(), err: nil},
 				{response: retryAfterResponse(), err: nil},
 			},
-			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
-			respCountExpected: &count{closes: 3, seeks: []seek{}},
+			expectations: map[string]expected{
+				"Do": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 3, seeks: []seek{}},
+				},
+				"Watch": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 3, seeks: []seek{}},
+				},
+				"Stream": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 3, seeks: []seek{}},
+				},
+			},
 		},
 		{
 			name:       "server always returns retryable error",
@@ -2536,8 +2832,24 @@ func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Requ
 				{response: nil, err: io.EOF},
 				{response: nil, err: io.EOF},
 			},
-			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
-			respCountExpected: &count{closes: 0, seeks: []seek{}},
+			expectations: map[string]expected{
+				"Do": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 0, seeks: []seek{}},
+				},
+				"Watch": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 0, seeks: []seek{}},
+				},
+				// for Stream, we never retry on any error
+				"Stream": {
+					attempts:  1, // only the first attempt is expected
+					reqCount:  &count{closes: 0, seeks: []seek{}},
+					respCount: &count{closes: 0, seeks: []seek{}},
+				},
+			},
 		},
 		{
 			name:       "server returns success on the final retry",
@@ -2549,8 +2861,24 @@ func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Requ
 				{response: nil, err: io.EOF},
 				{response: &http.Response{StatusCode: http.StatusOK}, err: nil},
 			},
-			reqCountExpected:  &count{closes: 0, seeks: make([]seek, 2)},
-			respCountExpected: &count{closes: 2, seeks: []seek{}},
+			expectations: map[string]expected{
+				"Do": {
+					attempts:  3,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 2)},
+					respCount: &count{closes: 2, seeks: []seek{}},
+				},
+				"Watch": {
+					attempts: 3,
+					reqCount: &count{closes: 0, seeks: make([]seek, 2)},
+					// we don't close the the Body of the final successful response
+					respCount: &count{closes: 1, seeks: []seek{}},
+				},
+				"Stream": {
+					attempts:  2,
+					reqCount:  &count{closes: 0, seeks: make([]seek, 1)},
+					respCount: &count{closes: 1, seeks: []seek{}},
+				},
+			},
 		},
 	}
 
@@ -2580,7 +2908,8 @@ func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Requ
 				verb: test.verb,
 				body: reqRecorder,
 				c: &RESTClient{
-					Client: client,
+					content: defaultContentConfig(),
+					Client:  client,
 				},
 				backoff: &noSleepBackOff{},
 				retry:   &withRetry{maxRetries: test.maxRetries},
@@ -2588,15 +2917,19 @@ func testRequestWithRetry(t *testing.T, doFunc func(ctx context.Context, r *Requ
 
 			doFunc(context.Background(), req)
 
-			attemptsExpected := test.maxRetries + 1
-			if attemptsExpected != attempts {
-				t.Errorf("Expected retries: %d, but got: %d", attemptsExpected, attempts)
+			expected, ok := test.expectations[key]
+			if !ok {
+				t.Fatalf("Wrong test setup - did not find expected for: %s", key)
 			}
-			if !reflect.DeepEqual(test.reqCountExpected.seeks, reqCountGot.seeks) {
-				t.Errorf("Expected request body to have seek invocation: %v, but got: %v", test.reqCountExpected.seeks, reqCountGot.seeks)
+			if expected.attempts != attempts {
+				t.Errorf("Expected retries: %d, but got: %d", expected.attempts, attempts)
 			}
-			if test.respCountExpected.closes != respCountGot.closes {
-				t.Errorf("Expected response body Close to be invoked %d times, but got: %d", test.respCountExpected.closes, respCountGot.closes)
+
+			if !reflect.DeepEqual(expected.reqCount.seeks, reqCountGot.seeks) {
+				t.Errorf("Expected request body to have seek invocation: %v, but got: %v", expected.reqCount.seeks, reqCountGot.seeks)
+			}
+			if expected.respCount.closes != respCountGot.getCloseCount() {
+				t.Errorf("Expected response body Close to be invoked %d times, but got: %d", expected.respCount.closes, respCountGot.getCloseCount())
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/rest/with_retry.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry.go
@@ -43,6 +43,10 @@ func (r IsRetryableErrorFunc) IsErrorRetryable(request *http.Request, err error)
 	return r(request, err)
 }
 
+var neverRetryError = IsRetryableErrorFunc(func(_ *http.Request, _ error) bool {
+	return false
+})
+
 // WithRetry allows the client to retry a request up to a certain number of times
 // Note that WithRetry is not safe for concurrent use by multiple
 // goroutines without additional locking or coordination.

--- a/staging/src/k8s.io/client-go/rest/with_retry.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// IsRetryableErrorFunc allows the client to provide its own function
+// that determines whether the specified err from the server is retryable.
+//
+// request: the original request sent to the server
+// err: the server sent this error to us
+//
+// The function returns true if the error is retryable and the request
+// can be retried, otherwise it returns false.
+// We have four mode of communications - 'Stream', 'Watch', 'Do' and 'DoRaw', this
+// function allows us to customize the retryability aspect of each.
+type IsRetryableErrorFunc func(request *http.Request, err error) bool
+
+func (r IsRetryableErrorFunc) IsErrorRetryable(request *http.Request, err error) bool {
+	return r(request, err)
+}
+
+// WithRetry allows the client to retry a request up to a certain number of times
+// Note that WithRetry is not safe for concurrent use by multiple
+// goroutines without additional locking or coordination.
+type WithRetry interface {
+	// SetMaxRetries makes the request use the specified integer as a ceiling
+	// for retries upon receiving a 429 status code  and the "Retry-After" header
+	// in the response.
+	// A zero maxRetries should prevent from doing any retry and return immediately.
+	SetMaxRetries(maxRetries int)
+
+	// NextRetry advances the retry counter appropriately and returns true if the
+	// request should be retried, otherwise it returns false if:
+	//  - we have already reached the maximum retry threshold.
+	//  - the error does not fall into the retryable category.
+	//  - the server has not sent us a 429, or 5xx status code and the
+	//    'Retry-After' response header is not set with a value.
+	//
+	// if retry is set to true, retryAfter will contain the information
+	// regarding the next retry.
+	//
+	// request: the original request sent to the server
+	// resp: the response sent from the server, it is set if err is nil
+	// err: the server sent this error to us, if err is set then resp is nil.
+	// f: a IsRetryableErrorFunc function provided by the client that determines
+	//    if the err sent by the server is retryable.
+	NextRetry(req *http.Request, resp *http.Response, err error, f IsRetryableErrorFunc) (*RetryAfter, bool)
+
+	// BeforeNextRetry is responsible for carrying out operations that need
+	// to be completed before the next retry is initiated:
+	// - if the request context is already canceled there is no need to
+	//   retry, the function will return ctx.Err().
+	// - we need to seek to the beginning of the request body before we
+	//   initiate the next retry, the function should return an error if
+	//   it fails to do so.
+	// - we should wait the number of seconds the server has asked us to
+	//   in the 'Retry-After' response header.
+	//
+	// If BeforeNextRetry returns an error the client should abort the retry,
+	// otherwise it is safe to initiate the next retry.
+	BeforeNextRetry(ctx context.Context, backoff BackoffManager, retryAfter *RetryAfter, url string, body io.Reader) error
+}
+
+// RetryAfter holds information associated with the next retry.
+type RetryAfter struct {
+	// Wait is the duration the server has asked us to wait before
+	// the next retry is initiated.
+	// This is the value of the 'Retry-After' response header in seconds.
+	Wait time.Duration
+
+	// Attempt is the Nth attempt after which we have received a retryable
+	// error or a 'Retry-After' response header from the server.
+	Attempt int
+
+	// Reason describes why we are retrying the request
+	Reason string
+}
+
+type withRetry struct {
+	maxRetries int
+	attempts   int
+}
+
+func (r *withRetry) SetMaxRetries(maxRetries int) {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	r.maxRetries = maxRetries
+}
+
+func (r *withRetry) NextRetry(req *http.Request, resp *http.Response, err error, f IsRetryableErrorFunc) (*RetryAfter, bool) {
+	if req == nil || (resp == nil && err == nil) {
+		// bad input, we do nothing.
+		return nil, false
+	}
+
+	r.attempts++
+	retryAfter := &RetryAfter{Attempt: r.attempts}
+	if r.attempts > r.maxRetries {
+		return retryAfter, false
+	}
+
+	// if the server returned an error, it takes precedence over the http response.
+	var errIsRetryable bool
+	if f != nil && err != nil && f.IsErrorRetryable(req, err) {
+		errIsRetryable = true
+		// we have a retryable error, for which we will create an
+		// artificial "Retry-After" response.
+		resp = retryAfterResponse()
+	}
+	if err != nil && !errIsRetryable {
+		return retryAfter, false
+	}
+
+	// if we are here, we have either a or b:
+	//  a: we have a retryable error, for which we already
+	//     have an artificial "Retry-After" response.
+	//  b: we have a response from the server for which we
+	//     need to check if it is retryable
+	seconds, wait := checkWait(resp)
+	if !wait {
+		return retryAfter, false
+	}
+
+	retryAfter.Wait = time.Duration(seconds) * time.Second
+	retryAfter.Reason = getRetryReason(r.attempts, seconds, resp, err)
+	return retryAfter, true
+}
+
+func (r *withRetry) BeforeNextRetry(ctx context.Context, backoff BackoffManager, retryAfter *RetryAfter, url string, body io.Reader) error {
+	// Ensure the response body is fully read and closed before
+	// we reconnect, so that we reuse the same TCP connection.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if seeker, ok := body.(io.Seeker); ok && body != nil {
+		if _, err := seeker.Seek(0, 0); err != nil {
+			return fmt.Errorf("can't Seek() back to beginning of body for %T", r)
+		}
+	}
+
+	klog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", retryAfter.Wait, retryAfter.Attempt, url)
+	if backoff != nil {
+		backoff.Sleep(retryAfter.Wait)
+	}
+	return nil
+}
+
+// checkWait returns true along with a number of seconds if
+// the server instructed us to wait before retrying.
+func checkWait(resp *http.Response) (int, bool) {
+	switch r := resp.StatusCode; {
+	// any 500 error code and 429 can trigger a wait
+	case r == http.StatusTooManyRequests, r >= 500:
+	default:
+		return 0, false
+	}
+	i, ok := retryAfterSeconds(resp)
+	return i, ok
+}
+
+func getRetryReason(retries, seconds int, resp *http.Response, err error) string {
+	// priority and fairness sets the UID of the FlowSchema
+	// associated with a request in the following response Header.
+	const responseHeaderMatchedFlowSchemaUID = "X-Kubernetes-PF-FlowSchema-UID"
+
+	message := fmt.Sprintf("retries: %d, retry-after: %ds", retries, seconds)
+
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// it is server-side throttling from priority and fairness
+		flowSchemaUID := resp.Header.Get(responseHeaderMatchedFlowSchemaUID)
+		return fmt.Sprintf("%s - retry-reason: due to server-side throttling, FlowSchema UID: %q", message, flowSchemaUID)
+	case err != nil:
+		// it's a retryable error
+		return fmt.Sprintf("%s - retry-reason: due to retryable error, error: %v", message, err)
+	default:
+		return fmt.Sprintf("%s - retry-reason: %d", message, resp.StatusCode)
+	}
+}
+
+func readAndCloseResponseBody(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+
+	// Ensure the response body is fully read and closed
+	// before we reconnect, so that we reuse the same TCP
+	// connection.
+	const maxBodySlurpSize = 2 << 10
+	defer resp.Body.Close()
+
+	if resp.ContentLength <= maxBodySlurpSize {
+		io.Copy(ioutil.Discard, &io.LimitedReader{R: resp.Body, N: maxBodySlurpSize})
+	}
+}
+
+func retryAfterResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{"Retry-After": []string{"1"}},
+	}
+}

--- a/staging/src/k8s.io/client-go/rest/with_retry_test.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry_test.go
@@ -30,10 +30,6 @@ var alwaysRetryError = IsRetryableErrorFunc(func(_ *http.Request, _ error) bool 
 	return true
 })
 
-var neverRetryError = IsRetryableErrorFunc(func(_ *http.Request, _ error) bool {
-	return false
-})
-
 func TestNextRetry(t *testing.T) {
 	fakeError := errors.New("fake error")
 	tests := []struct {

--- a/staging/src/k8s.io/client-go/rest/with_retry_test.go
+++ b/staging/src/k8s.io/client-go/rest/with_retry_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var alwaysRetryError = IsRetryableErrorFunc(func(_ *http.Request, _ error) bool {
+	return true
+})
+
+var neverRetryError = IsRetryableErrorFunc(func(_ *http.Request, _ error) bool {
+	return false
+})
+
+func TestNextRetry(t *testing.T) {
+	fakeError := errors.New("fake error")
+	tests := []struct {
+		name               string
+		attempts           int
+		maxRetries         int
+		request            *http.Request
+		response           *http.Response
+		err                error
+		retryableErrFunc   IsRetryableErrorFunc
+		retryExpected      []bool
+		retryAfterExpected []*RetryAfter
+	}{
+		{
+			name:               "bad input, response and err are nil",
+			maxRetries:         2,
+			attempts:           1,
+			request:            &http.Request{},
+			response:           nil,
+			err:                nil,
+			retryExpected:      []bool{false},
+			retryAfterExpected: []*RetryAfter{nil},
+		},
+		{
+			name:          "zero maximum retry",
+			maxRetries:    0,
+			attempts:      1,
+			request:       &http.Request{},
+			response:      retryAfterResponse(),
+			err:           nil,
+			retryExpected: []bool{false},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+				},
+			},
+		},
+		{
+			name:       "server returned a retryable error",
+			maxRetries: 3,
+			attempts:   1,
+			request:    &http.Request{},
+			response:   nil,
+			err:        fakeError,
+			retryableErrFunc: func(_ *http.Request, err error) bool {
+				if err == fakeError {
+					return true
+				}
+				return false
+			},
+			retryExpected: []bool{true},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+					Wait:    time.Second,
+					Reason:  "retries: 1, retry-after: 1s - retry-reason: due to retryable error, error: fake error",
+				},
+			},
+		},
+		{
+			name:       "server returned a retryable HTTP 429 response",
+			maxRetries: 3,
+			attempts:   1,
+			request:    &http.Request{},
+			response: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Retry-After":                    []string{"2"},
+					"X-Kubernetes-Pf-Flowschema-Uid": []string{"fs-1"},
+				},
+			},
+			err:           nil,
+			retryExpected: []bool{true},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+					Wait:    2 * time.Second,
+					Reason:  `retries: 1, retry-after: 2s - retry-reason: due to server-side throttling, FlowSchema UID: "fs-1"`,
+				},
+			},
+		},
+		{
+			name:       "server returned a retryable HTTP 5xx response",
+			maxRetries: 3,
+			attempts:   1,
+			request:    &http.Request{},
+			response: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header: http.Header{
+					"Retry-After": []string{"3"},
+				},
+			},
+			err:           nil,
+			retryExpected: []bool{true},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+					Wait:    3 * time.Second,
+					Reason:  "retries: 1, retry-after: 3s - retry-reason: 503",
+				},
+			},
+		},
+		{
+			name:       "server returned a non response without without a Retry-After header",
+			maxRetries: 1,
+			attempts:   1,
+			request:    &http.Request{},
+			response: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{},
+			},
+			err:           nil,
+			retryExpected: []bool{false},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+				},
+			},
+		},
+		{
+			name:       "both response and err are set, err takes precedence",
+			maxRetries: 1,
+			attempts:   1,
+			request:    &http.Request{},
+			response:   retryAfterResponse(),
+			err:        fakeError,
+			retryableErrFunc: func(_ *http.Request, err error) bool {
+				if err == fakeError {
+					return true
+				}
+				return false
+			},
+			retryExpected: []bool{true},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+					Wait:    time.Second,
+					Reason:  "retries: 1, retry-after: 1s - retry-reason: due to retryable error, error: fake error",
+				},
+			},
+		},
+		{
+			name:             "all retries are exhausted",
+			maxRetries:       3,
+			attempts:         4,
+			request:          &http.Request{},
+			response:         nil,
+			err:              fakeError,
+			retryableErrFunc: alwaysRetryError,
+			retryExpected:    []bool{true, true, true, false},
+			retryAfterExpected: []*RetryAfter{
+				{
+					Attempt: 1,
+					Wait:    time.Second,
+					Reason:  "retries: 1, retry-after: 1s - retry-reason: due to retryable error, error: fake error",
+				},
+				{
+					Attempt: 2,
+					Wait:    time.Second,
+					Reason:  "retries: 2, retry-after: 1s - retry-reason: due to retryable error, error: fake error",
+				},
+				{
+					Attempt: 3,
+					Wait:    time.Second,
+					Reason:  "retries: 3, retry-after: 1s - retry-reason: due to retryable error, error: fake error",
+				},
+				{
+					Attempt: 4,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &withRetry{maxRetries: test.maxRetries}
+
+			retryGot := make([]bool, 0)
+			retryAfterGot := make([]*RetryAfter, 0)
+			for i := 0; i < test.attempts; i++ {
+				retryAfter, retry := r.NextRetry(test.request, test.response, test.err, test.retryableErrFunc)
+				retryGot = append(retryGot, retry)
+				retryAfterGot = append(retryAfterGot, retryAfter)
+			}
+
+			if !reflect.DeepEqual(test.retryExpected, retryGot) {
+				t.Errorf("Expected retry: %t, but got: %t", test.retryExpected, retryGot)
+			}
+			if !reflect.DeepEqual(test.retryAfterExpected, retryAfterGot) {
+				t.Errorf("Expected retry-after parameters to match, but got: %s", cmp.Diff(test.retryAfterExpected, retryAfterGot))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Add retry logic for `Watch` and `Stream` (similar to `Request.Do` and `Request.DoRaw`)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
client-go now retries on failures to establish `Watch` and `Stream` ift it receives a `429` or `5xx` with a response header `Retry-After`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
