### PR TITLE
Bug 1966410: kube-apiserver: add system_client=cluster-policy-controller to apiserver_request_total

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -444,7 +444,7 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 		case "kube-apiserver":
 			apiSelfRequestCounter.WithContext(req.Context()).WithLabelValues(reportedVerb, resource, subresource).Inc()
 			fallthrough
-		case "kube-controller-manager", "kube-scheduler":
+		case "kube-controller-manager", "kube-scheduler", "cluster-policy-controller":
 			systemClient = uas[0]
 		}
 	}


### PR DESCRIPTION
Add cluster-policy-controller to system clients.

Follow-up of https://github.com/openshift/kubernetes/pull/784.