### PR TITLE
Bug 1969426: UPSTREAM: 102690: stop leaking pvs in CSI mock snapshot test

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -1585,6 +1585,8 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				_, err = e2epv.WaitForPVClaimBoundPhase(m.cs, []*v1.PersistentVolumeClaim{pvc}, 1*time.Minute)
 				framework.ExpectNoError(err, "Failed to create claim: %v", err)
 
+				m.pvcs = append(m.pvcs, pvc)
+
 				ginkgo.By("Creating Secret")
 				secret := &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
The CSI mock volume snapshot secrets test is leaving the mock PV since the assosicated PVC is deleted at the end of the test together with the namespace but the provisioner expects the external deleter to remove the PV -- that one is already deleted too.

Adding the testing PVC to the list of PVCs to be removed in the cleanup function prior the namespace deletion fixes the issue.

#### Which issue(s) this PR fixes:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1969426

```release-note
NONE
```