### PR TITLE
Bug 1971745: only chown if non-windows machine with projected volumes

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -373,6 +373,7 @@ func (w *AtomicWriter) newTimestampDir() (string, error) {
 // writePayloadToDir writes the given payload to the given directory.  The
 // directory must exist.
 func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir string) error {
+	isNotWindows := runtime.GOOS != "windows"
 	for userVisiblePath, fileProjection := range payload {
 		content := fileProjection.Data
 		mode := os.FileMode(fileProjection.Mode)
@@ -400,9 +401,11 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 		if fileProjection.FsUser == nil {
 			continue
 		}
-		if err := os.Chown(fullPath, int(*fileProjection.FsUser), -1); err != nil {
-			klog.Errorf("%s: unable to change file %s with owner %v: %v", w.logContext, fullPath, int(*fileProjection.FsUser), err)
-			return err
+		if isNotWindows {
+			if err := os.Chown(fullPath, int(*fileProjection.FsUser), -1); err != nil {
+				klog.Errorf("%s: unable to change file %s with owner %v: %v", w.logContext, fullPath, int(*fileProjection.FsUser), err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Temporary workaround for 4.8. chown does not exist on Windows with golang.

WIP upstream: https://github.com/kubernetes/kubernetes/pull/102868