### PR TITLE
Bug 1975283: update Multi-AZ Cluster Volumes test name

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -10921,7 +10921,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] Mounted volume expand Should verify mounted devices can be resized": "Should verify mounted devices can be resized [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-storage] Multi-AZ Cluster Volumes should only be allowed to provision PDs in zones where nodes exist": "should only be allowed to provision PDs in zones where nodes exist [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-storage] Multi-AZ Cluster Volumes should only be allowed to provision PDs in zones where nodes exist": "should only be allowed to provision PDs in zones where nodes exist [Skipped:gce] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs": "should schedule pods in the same zones as statically provisioned PVs [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -145,7 +145,7 @@ var (
 		},
 		"[Skipped:gce]": {
 			// Requires creation of a different compute instance in a different zone and is not compatible with volumeBindingMode of WaitForFirstConsumer which we use in 4.x
-			`\[sig-scheduling\] Multi-AZ Cluster Volumes \[sig-storage\] should only be allowed to provision PDs in zones where nodes exist`,
+			`\[sig-storage\] Multi-AZ Cluster Volumes should only be allowed to provision PDs in zones where nodes exist`,
 
 			// The following tests try to ssh directly to a node. None of our nodes have external IPs
 			`\[k8s.io\] \[sig-node\] crictl should be able to run crictl on the node`,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

﻿This test was renamed upstream in
https://github.com/kubernetes/kubernetes/commit/006dc7477f15e42ae70adc02421a5bacd068ba05

4.9 GCP tests are now failing because this is no longer being skipped.

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1975283

#### Special notes for your reviewer:

This will have to be vendored into origin to fix the tests.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
