### PR TITLE
Detect unused test-annotating rules

### DIFF
--- a/openshift-hack/e2e/annotate/annotate.go
+++ b/openshift-hack/e2e/annotate/annotate.go
@@ -228,7 +228,8 @@ func (r *ginkgoTestRenamer) generateRename(name, parentName string, node types.T
 			name += " [Suite:openshift/conformance/parallel]"
 		}
 	}
-	if isGoModulePath(node.CodeLocation().FileName, "k8s.io/kubernetes", "test/e2e") {
+	if isGoModulePath(node.CodeLocation().FileName, "k8s.io/kubernetes", "test/e2e") ||
+		isGoModulePath(node.CodeLocation().FileName, "github.com/openshift/kubernetes", "test/e2e") {
 		name += " [Suite:k8s]"
 	}
 


### PR DESCRIPTION
I was trying to figure out if any of the current networking-related test annotations were out of date and ended up doing this. FTR:

```
Unused pattern: [Disabled:Alpha] => \[Feature:CSIServiceAccountToken\]
Unused pattern: [Disabled:Broken] => ServiceAccounts should support OIDC discovery of service account issuer
Unused pattern: [Disabled:Broken] => recreate nodes and ensure they function upon restart
Unused pattern: [Disabled:Broken] => should reject a Pod requesting a RuntimeClass with conflicting node selector
Unused pattern: [Disabled:SpecialConfig] => Advanced Audit should audit API calls
Unused pattern: [Disabled:SpecialConfig] => \[Feature:Audit\]
Unused pattern: [Disabled:SpecialConfig] => \[Feature:ImageQuota\]
Unused pattern: [Disabled:SpecialConfig] => \[sig-cloud-provider-gcp\]
Unused pattern: [Disabled:SpecialConfig] => should check if Kubernetes master services is included in cluster-info
Unused pattern: [Disabled:Unimplemented] => Kubernetes Dashboard
Unused pattern: [Disabled:Unimplemented] => Ubernetes
Unused pattern: [Disabled:Unimplemented] => kube-ui
Unused pattern: [Disabled:Unimplemented] => should proxy to cadvisor
Unused pattern: [Flaky] => \[Feature:HPA\] Horizontal pod autoscaling \(scale resource: CPU\) \[sig-autoscaling\] ReplicationController light Should scale from 1 pod to 2 pods
Unused pattern: [Serial] => DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume
Unused pattern: [Serial] => Should be able to support the 1\.7 Sample API Server using the current Aggregator
Unused pattern: [Serial] => \[Feature:HPA\] Horizontal pod autoscaling \(scale resource: CPU\) \[sig-autoscaling\] ReplicationController light Should scale from 1 pod to 2 pods
Unused pattern: [Serial] => \[Feature:Performance\]
Unused pattern: [Serial] => \[sig-network\] IngressClass \[Feature:Ingress\] should set default value on new IngressClass
Unused pattern: [Serial] => should prevent Ingress creation if more than 1 IngressClass marked as default
Unused pattern: [Skipped:gce] => \[k8s.io\] \[sig-node\] crictl should be able to run crictl on the node
Unused pattern: [Skipped:gce] => \[sig-api-machinery\] AdmissionWebhook should be able to deny pod and configmap creation
Unused pattern: [Skipped:gce] => \[sig-storage\] CSI Volumes CSI Topology test using GCE PD driver \[Serial\]
Unused pattern: [Skipped:gce] => \[sig-storage\] Detaching volumes should not work when mount is in progress
Unused pattern: [Slow] => \[sig-scalability\]
Unused pattern: [sig-arch] => \[Feature:GKELocalSSD\]
Unused pattern: [sig-arch] => \[Feature:GKENodePool\]
Unused pattern: [sig-cluster-lifecycle] => Feature:ClusterAutoscalerScalability
Unused pattern: [sig-cluster-lifecycle] => recreate nodes and ensure they function
Unused pattern: [sig-node] => Downward API should create a pod that prints his name and namespace
Unused pattern: [sig-node] => Liveness liveness pods should be automatically restarted
Unused pattern: [sig-node] => NodeLease
Unused pattern: [sig-node] => Pods should delete a collection of pods
Unused pattern: [sig-node] => Pods should run through the lifecycle of Pods and PodStatus
Unused pattern: [sig-node] => Probing container
Unused pattern: [sig-node] => Secret should create a pod that reads a secret
Unused pattern: [sig-node] => Security Context When creating a
Unused pattern: [sig-node] => \[NodeAlphaFeature
Unused pattern: [sig-node] => \[NodeConformance\]
Unused pattern: [sig-node] => \[NodeFeature
Unused pattern: [sig-node] => lease API
```

(note that in some cases, like a lot of the sig-node tests, the pattern is unused because the test got correctly annotated upstream (and so the rule is no longer necessary) not because the test got deleted/renamed)