### PR TITLE
UPSTREAM: <carry>: add CSI migration feature gates for GCE PD and Azure Disk

### DIFF
--- a/pkg/features/patch_kube_features.go
+++ b/pkg/features/patch_kube_features.go
@@ -8,21 +8,35 @@ import (
 
 var (
 	// owner: @jsafrane
-	// alpha: v1.21
+	// beta: v1.21
 	//
 	// Enables the AWS EBS CSI migration for the Attach/Detach controller (ADC) only.
 	ADCCSIMigrationAWS featuregate.Feature = "ADC_CSIMigrationAWS"
 
+	// owner: @fbertina
+	// beta: v1.22
+	//
+	// Enables the Azure Disk CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationAzureDisk featuregate.Feature = "ADC_CSIMigrationAzureDisk"
+
 	// owner: @jsafrane
-	// alpha: v1.21
+	// beta: v1.21
 	//
 	// Enables the Cinder CSI migration for the Attach/Detach controller (ADC) only.
 	ADCCSIMigrationCinder featuregate.Feature = "ADC_CSIMigrationCinder"
+
+	// owner: @fbertina
+	// beta: v1.22
+	//
+	// Enables the GCE CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationGCEPD featuregate.Feature = "ADC_CSIMigrationGCEPD"
 )
 
 var ocpDefaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	ADCCSIMigrationAWS:    {Default: true, PreRelease: featuregate.Beta},
-	ADCCSIMigrationCinder: {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationAWS:       {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationAzureDisk: {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationCinder:    {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationGCEPD:     {Default: true, PreRelease: featuregate.Beta},
 }
 
 func init() {

--- a/pkg/volume/csimigration/patch_adc_plugin_manager.go
+++ b/pkg/volume/csimigration/patch_adc_plugin_manager.go
@@ -26,8 +26,12 @@ func (pm PluginManager) adcIsMigrationEnabledForPlugin(pluginName string) bool {
 	switch pluginName {
 	case csilibplugins.AWSEBSInTreePluginName:
 		return pm.featureGate.Enabled(features.ADCCSIMigrationAWS)
+	case csilibplugins.AzureDiskInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationAzureDisk)
 	case csilibplugins.CinderInTreePluginName:
 		return pm.featureGate.Enabled(features.ADCCSIMigrationCinder)
+	case csilibplugins.GCEPDInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationGCEPD)
 	default:
 		return pm.isMigrationEnabledForPlugin(pluginName)
 	}


### PR DESCRIPTION
This is the continuation of https://github.com/openshift/kubernetes/pull/601.

It introduces custom feature gates to enable the CSI migration for GCE PD and Azure Disk in the AD controller.

See openshift/enhancements#549 for details.

CC @openshift/storage 

Epics:
https://issues.redhat.com/browse/STOR-577
https://issues.redhat.com/browse/STOR-576