### PR TITLE
Bug 1976379: UPSTREAM: <carry>: Reject the pod creation when we can not decide the cluster type

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -180,6 +180,11 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
 	}
 
+	// we can not decide the cluster type without status.controlPlaneTopology and status.infrastructureTopology
+	if clusterInfra.Status.ControlPlaneTopology == "" || clusterInfra.Status.InfrastructureTopology == "" {
+		return admission.NewForbidden(attr, fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName))
+	}
+
 	// not the SNO cluster, skip mutation
 	// TODO: currently we supports only SNO use case because we have not yet worked out the best approach to determining whether the feature
 	// should be on or off in a multi-node cluster, and computing that state incorrectly could lead to breaking running clusters.

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -169,6 +169,24 @@ func TestAdmit(t *testing.T) {
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: the workload annotation value map["test":"test"] does not have "effect" key`),
 		},
 		{
+			name:               "should return admission error when the infrastructure resource status has empty ControlPlaneTopology",
+			pod:                testManagedPod("", "250m", "500Mi", "250Mi"),
+			expectedCpuRequest: resource.MustParse("250m"),
+			namespace:          testManagedNamespace(),
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			infra:              testClusterInfraWithoutControlPlaneTopology(),
+			expectedError:      fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName),
+		},
+		{
+			name:               "should return admission error when the infrastructure resource status has empty InfrastructureTopology",
+			pod:                testManagedPod("", "250m", "500Mi", "250Mi"),
+			expectedCpuRequest: resource.MustParse("250m"),
+			namespace:          testManagedNamespace(),
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			infra:              testClusterInfraWithoutInfrastructureTopology(),
+			expectedError:      fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName),
+		},
+		{
 			name:               "should delete CPU requests and update workload CPU annotations for the burstable pod with managed annotation",
 			pod:                testManagedPod("", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.Quantity{},
@@ -686,4 +704,16 @@ func testClusterSNOInfra() *configv1.Infrastructure {
 			InfrastructureTopology: configv1.SingleReplicaTopologyMode,
 		},
 	}
+}
+
+func testClusterInfraWithoutControlPlaneTopology() *configv1.Infrastructure {
+	infra := testClusterSNOInfra()
+	infra.Status.ControlPlaneTopology = ""
+	return infra
+}
+
+func testClusterInfraWithoutInfrastructureTopology() *configv1.Infrastructure {
+	infra := testClusterSNOInfra()
+	infra.Status.InfrastructureTopology = ""
+	return infra
 }


### PR DESCRIPTION
It is possible a race condition between pod creation and the update of the
infrastructure resource status with correct values under
Status.ControlPlaneTopology and Status.InfrastructureTopology.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>
