### PR TITLE
Bug 1977383: [release-4.7] Fix watch conformance test

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -83,6 +83,8 @@ go_library(
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",


### PR DESCRIPTION
Pick upstream fix from 1.20 (https://github.com/kubernetes/kubernetes/pull/101981) for watch consistency test failure that is made persistent by the service ca configmap publication proposed by https://github.com/openshift/kubernetes/pull/834.

This fix needs to be merged into origin before it will take effect.

/cc @sttts  @s-urbaniak @soltysh 