### PR TITLE
[release-4.7] bug 1981634: UPSTREAM: <drop>: use the legacy service-ca.crt content for clusters started in 4.7 or before

### DIFF
--- a/openshift-kube-controller-manager/servicecacertpublisher/publisher.go
+++ b/openshift-kube-controller-manager/servicecacertpublisher/publisher.go
@@ -165,7 +165,8 @@ func (c *Publisher) syncNamespace(ns string) (err error) {
 	annotations := map[string]string{
 		// This annotation prompts the service ca operator to inject
 		// the service ca bundle into the configmap.
-		"service.beta.openshift.io/inject-cabundle": "true",
+		// We ONLY inject the vulnerable CA bundle in 4.7 because we want consistency on injected files on upgraded clusters.
+		"service.alpha.openshift.io/inject-vulnerable-legacy-cabundle": "true",
 	}
 
 	cm, err := c.cmLister.ConfigMaps(ns).Get(ServiceCACertConfigMapName)


### PR DESCRIPTION
related to https://github.com/openshift/service-ca-operator/pull/167

This hardcodes us for 4.7 since 4.7 only needs to inject the old service-ca.crt to keep the content identical.