### PR TITLE
Bug 1982868: UPSTREAM <carry>: ManagementCPUsOverride: Add defaults for missing infrastructure topologies

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -180,9 +180,12 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
 	}
 
-	// we can not decide the cluster type without status.controlPlaneTopology and status.infrastructureTopology
-	if clusterInfra.Status.ControlPlaneTopology == "" || clusterInfra.Status.InfrastructureTopology == "" {
-		return admission.NewForbidden(attr, fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName))
+	if clusterInfra.Status.ControlPlaneTopology == "" {
+		clusterInfra.Status.ControlPlaneTopology = configv1.HighlyAvailableTopologyMode
+	}
+
+	if clusterInfra.Status.InfrastructureTopology == "" {
+		clusterInfra.Status.InfrastructureTopology = configv1.HighlyAvailableTopologyMode
 	}
 
 	// not the SNO cluster, skip mutation

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -169,22 +169,26 @@ func TestAdmit(t *testing.T) {
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: the workload annotation value map["test":"test"] does not have "effect" key`),
 		},
 		{
-			name:               "should return admission error when the infrastructure resource status has empty ControlPlaneTopology",
+			name:               "should not return admission error when the infrastructure resource status has empty ControlPlaneTopology",
 			pod:                testManagedPod("", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
 			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterInfraWithoutControlPlaneTopology(),
-			expectedError:      fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName),
+			expectedAnnotations: map[string]string{
+				workloadAdmissionWarning: "FIXME",
+			},
 		},
 		{
-			name:               "should return admission error when the infrastructure resource status has empty InfrastructureTopology",
+			name:               "should not return admission error when the infrastructure resource status has empty InfrastructureTopology",
 			pod:                testManagedPod("", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
 			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterInfraWithoutInfrastructureTopology(),
-			expectedError:      fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName),
+			expectedAnnotations: map[string]string{
+				workloadAdmissionWarning: "FIXME",
+			},
 		},
 		{
 			name:               "should delete CPU requests and update workload CPU annotations for the burstable pod with managed annotation",


### PR DESCRIPTION
Avoid blocking changes [like][1]:

    deployment openshift-etcd-operator/etcd-operator has a replica failure FailedCreate: pods "etcd-operator-7b677856dc-" is forbidden: autoscaling.openshift.io/ManagementCPUsOverride infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology

when running against 4.7 versions of the Infrastructure CRD, which lack 4.8's topology properties.  4.8 and later CRDs will have [the `HighlyAvailable` default injected by the Kubernetes API server][2], so this commit just fills in those defaults client-side to handle 4.8-admission-plugin vs. 4.7-Infra-CRD version skew.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1982868
[2]: https://github.com/openshift/api/blob/46e2fe0468512c88595dbc5997d890a97f2efb43/config/v1/types_infrastructure.go#L81-L100