### PR TITLE
UPSTREAM: 103861: aws: fallback to user intent when finding public subnets for ELB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -3444,7 +3444,7 @@ func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 			continue
 		}
 
-		isPublic, err := isSubnetPublic(rt, id)
+		isPublic, err := isSubnetPublic(rt, subnet)
 		if err != nil {
 			return nil, err
 		}
@@ -3597,7 +3597,8 @@ func (c *Cloud) resolveSubnetNameOrIDs(subnetNameOrIDs []string) ([]string, erro
 	return subnets, nil
 }
 
-func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
+func isSubnetPublic(rt []*ec2.RouteTable, subnet *ec2.Subnet) (bool, error) {
+	subnetID := aws.StringValue(subnet.SubnetId)
 	var subnetTable *ec2.RouteTable
 	for _, table := range rt {
 		for _, assoc := range table.Associations {
@@ -3637,6 +3638,14 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 		if strings.HasPrefix(aws.StringValue(route.GatewayId), "igw") {
 			return true, nil
 		}
+	}
+
+	// If we couldn't use the subnet table to figure out whether the subnet is public,
+	// we let the users define whether this subnet should be used for internet-facing things
+	// by looking for TagNameSubnetPublicELB tag.
+	tagVal, subnetHasTag := findTag(subnet.Tags, TagNameSubnetPublicELB)
+	if subnetHasTag && (tagVal == "" || tagVal == "1") {
+		return true, nil
 	}
 
 	return false, nil

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -829,12 +829,6 @@ func Test_findELBSubnets(t *testing.T) {
 	subnetA0000002 := &ec2.Subnet{
 		AvailabilityZone: aws.String("us-west-2a"),
 		SubnetId:         aws.String("subnet-a0000002"),
-		Tags: []*ec2.Tag{
-			{
-				Key:   aws.String(TagNameSubnetPublicELB),
-				Value: aws.String("1"),
-			},
-		},
 	}
 	subnetA0000003 := &ec2.Subnet{
 		AvailabilityZone: aws.String("us-west-2a"),
@@ -941,6 +935,26 @@ func Test_findELBSubnets(t *testing.T) {
 				"subnet-a0000002": false,
 			},
 			want: nil,
+		},
+		{
+			name: "public subnet using route table",
+			subnets: []*ec2.Subnet{
+				subnetA0000001,
+			},
+			routeTables: map[string]bool{
+				"subnet-a0000002": true,
+			},
+			want: []string{"subnet-a0000001"},
+		},
+		{
+			name: "public subnet using the elb tag",
+			subnets: []*ec2.Subnet{
+				subnetA0000001,
+			},
+			routeTables: map[string]bool{
+				"subnet-a0000002": false,
+			},
+			want: []string{"subnet-a0000001"},
 		},
 		{
 			name: "prefer role over cluster tag",


### PR DESCRIPTION
Currently the discovery codepath only decides whether a subnet is public
by using the routetables. Only when there are more than one such
subnets, the codepath picks a subnet with PublicSubnetTagName.

There are many network deployments which do not directly attach an igw
to the public subnet, but usage of these subnets is clearly defined by
the user by tagging these subnets with PublicSubnetTagName.
So instead of having the users of SLB define the subnets everytime, it
would be benefitial if the discovery codepath respect the indication on
the public subnets set by the admins of the cluster.

Similarly the aws-load-balancer-controller [1] now solely depends on
PublicSubnetTagName to discover the public subnets for ELB.

In this change, we update the isSubnetPublic function such that when it
fails to decide that a subnet is public using route table rules, if
checks if the subnet has the PublicSubnetTagName, and if the tag exists
and equal to empty("") and "1" value [2] it returns true. So the main check is
still route tables based, and the tag based becomes a fallback.

[1]:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/subnet_resolver.go#L114
[2]:
https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html
