### PR TITLE
[release-4.6] Set provider for k8s testing to minimize platform-specific skips

### DIFF
--- a/openshift-hack/test-kubernetes-e2e.sh
+++ b/openshift-hack/test-kubernetes-e2e.sh
@@ -76,6 +76,7 @@ SERVER="$( kubectl config view | grep server | head -n 1 | awk '{print $2}' )"
 ginkgo \
   -nodes "${NODES}" -noColor ${KUBE_E2E_TEST_ARGS} \
   "$( which k8s-e2e.test )" -- \
+  -provider "${PLATFORM}" \
   -report-dir "${test_report_dir}" \
   -host "${SERVER}" \
   -allowed-not-ready-nodes ${unschedulable} \


### PR DESCRIPTION
k8s test jobs will skip all provider-specific testing unless `-provider` is set to the platform the cluster is running on.

REBASE: Suggest squashing with `UPSTREAM: <carry>: Add OpenShift tooling, images, configs and docs`

/cc @deads2k @soltysh @bparees 