### PR TITLE
[WIP] Bug 1966477 audit.k8s.io/v1beta1 is deprecated

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
@@ -46,8 +46,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/validation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/audit:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
@@ -90,7 +90,7 @@ var expectedPolicy = &audit.Policy{
 }
 
 func TestParser(t *testing.T) {
-	for _, version := range []string{"v1", "v1alpha1", "v1beta1"} {
+	for _, version := range []string{"v1"} {
 		policyDef := strings.Replace(policyDefPattern, "{version}", version, 1)
 		f, err := writePolicy(t, policyDef)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Bus fix on deprecated apiVersion

<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

-->

#### What this PR does / why we need it:
Pod logs are currently reporting the deprecated audit.k8s.io/v1beta1 is in use still. It is being triggered by a conditional.

#### Which issue(s) this PR fixes:

Bug 1966477

