### PR TITLE
Bug 1982868: UPSTREAM: <carry>: admission/managementcpusoverride: cover the roll-back case

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"time"
 
@@ -180,9 +181,16 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
 	}
 
-	// we can not decide the cluster type without status.controlPlaneTopology and status.infrastructureTopology
-	if clusterInfra.Status.ControlPlaneTopology == "" || clusterInfra.Status.InfrastructureTopology == "" {
-		return admission.NewForbidden(attr, fmt.Errorf("%s infrastructure resource has empty status.controlPlaneTopology or status.infrastructureTopology", PluginName))
+	// the infrastructure status is empty, so we can not decide the cluster type
+	if reflect.DeepEqual(clusterInfra.Status, configv1.InfrastructureStatus{}) {
+		return admission.NewForbidden(attr, fmt.Errorf("%s infrastructure resource has empty status", PluginName))
+	}
+
+	// the infrastructure status is not empty, but topology related fields do not have any values indicates that
+	// the cluster is during the roll-back process to the version that does not support the topology fields
+	// the upgrade to 4.8 handled by the CR defaulting
+	if clusterInfra.Status.ControlPlaneTopology == "" && clusterInfra.Status.InfrastructureTopology == "" {
+		return nil
 	}
 
 	// not the SNO cluster, skip mutation
@@ -190,7 +198,6 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 	// should be on or off in a multi-node cluster, and computing that state incorrectly could lead to breaking running clusters.
 	if clusterInfra.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode ||
 		clusterInfra.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
-		pod.Annotations[workloadAdmissionWarning] = "only single-node clusters support workload partitioning"
 		return nil
 	}
 


### PR DESCRIPTION
During the upgrade and roll-back flow 4.7->4.8->4.7, the topology related
fields under the infrastructure can be empty because the
old API does not support them.

The code will equal the empty infrastructure section with the current one.
When the status has some other non-empty field, and topology fields
are empty, we assume that the cluster currently passes
via roll-back and not via the clean install.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

