### PR TITLE
Bug 1994643: UPSTREAM: <carry>: use lifeCycleSignals for isTerminating

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -410,14 +410,6 @@ func buildGenericConfig(
 	lastErr error,
 ) {
 	genericConfig = genericapiserver.NewConfig(legacyscheme.Codecs)
-	genericConfig.IsTerminating = func() bool {
-		select {
-		case <-stopCh:
-			return true
-		default:
-			return false
-		}
-	}
 	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource()
 
 	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -256,9 +256,6 @@ type Config struct {
 
 	// StorageVersionManager holds the storage versions of the API resources installed by this server.
 	StorageVersionManager storageversion.Manager
-
-	// A func that returns whether the server is terminating. This can be nil.
-	IsTerminating func() bool
 }
 
 // EventSink allows to create events.
@@ -865,7 +862,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithWarningRecorder(handler)
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithHSTS(handler, c.HSTSDirectives)
-	handler = genericfilters.WithHTTPLogging(handler, c.IsTerminating)
+	handler = genericfilters.WithHTTPLogging(handler, c.newIsTerminatingFunc())
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
 		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_config.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+// newIsTerminatingFunc returns a 'func() bool' that relies on the
+// 'ShutdownInitiated' life cycle signal of answer if the apiserver
+// has started the termination process.
+func (c *Config) newIsTerminatingFunc() func() bool {
+	var shutdownCh <-chan struct{}
+	// TODO: a properly initialized Config object should always have lifecycleSignals
+	//  initialized, but some config unit tests leave lifecycleSignals as nil.
+	//  Fix the unit tests upstream and then we can remove this check.
+	if c.lifecycleSignals.ShutdownInitiated != nil {
+		shutdownCh = c.lifecycleSignals.ShutdownInitiated.Signaled()
+	}
+
+	return func() bool {
+		select {
+		case <-shutdownCh:
+			return true
+		default:
+			return false
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
