### PR TITLE
Bug 1996689: Tighten up RestrictedEndpointsAdmission

### DIFF
--- a/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
+++ b/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/klog/v2"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/discovery"
 
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/restrictedendpoints"
@@ -132,7 +133,7 @@ func checkRestrictedPort(protocol kapi.Protocol, port int32, restricted []kapi.E
 	return nil
 }
 
-func (r *restrictedEndpointsAdmission) findRestrictedIP(ep *kapi.Endpoints, restricted []*net.IPNet) error {
+func (r *restrictedEndpointsAdmission) endpointsFindRestrictedIP(ep *kapi.Endpoints, restricted []*net.IPNet) error {
 	for _, subset := range ep.Subsets {
 		for _, addr := range subset.Addresses {
 			if err := checkRestrictedIP(addr.IP, restricted); err != nil {
@@ -148,7 +149,7 @@ func (r *restrictedEndpointsAdmission) findRestrictedIP(ep *kapi.Endpoints, rest
 	return nil
 }
 
-func (r *restrictedEndpointsAdmission) findRestrictedPort(ep *kapi.Endpoints, restricted []kapi.EndpointPort) error {
+func (r *restrictedEndpointsAdmission) endpointsFindRestrictedPort(ep *kapi.Endpoints, restricted []kapi.EndpointPort) error {
 	for _, subset := range ep.Subsets {
 		for _, port := range subset.Ports {
 			if err := checkRestrictedPort(port.Protocol, port.Port, restricted); err != nil {
@@ -159,7 +160,7 @@ func (r *restrictedEndpointsAdmission) findRestrictedPort(ep *kapi.Endpoints, re
 	return nil
 }
 
-func (r *restrictedEndpointsAdmission) checkAccess(ctx context.Context, attr admission.Attributes) (bool, error) {
+func (r *restrictedEndpointsAdmission) endpointsCheckAccess(ctx context.Context, attr admission.Attributes) (bool, error) {
 	authzAttr := authorizer.AttributesRecord{
 		User:            attr.GetUserInfo(),
 		Verb:            "create",
@@ -174,11 +175,7 @@ func (r *restrictedEndpointsAdmission) checkAccess(ctx context.Context, attr adm
 	return authorized == authorizer.DecisionAllow, err
 }
 
-// Admit determines if the endpoints object should be admitted
-func (r *restrictedEndpointsAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
-	if a.GetResource().GroupResource() != kapi.Resource("endpoints") {
-		return nil
-	}
+func (r *restrictedEndpointsAdmission) endpointsValidate(ctx context.Context, a admission.Attributes) error {
 	ep, ok := a.GetObject().(*kapi.Endpoints)
 	if !ok {
 		return nil
@@ -188,18 +185,18 @@ func (r *restrictedEndpointsAdmission) Validate(ctx context.Context, a admission
 		return nil
 	}
 
-	restrictedErr := r.findRestrictedIP(ep, r.restrictedNetworks)
+	restrictedErr := r.endpointsFindRestrictedIP(ep, r.restrictedNetworks)
 	if restrictedErr == nil {
-		restrictedErr = r.findRestrictedIP(ep, defaultRestrictedNetworks)
+		restrictedErr = r.endpointsFindRestrictedIP(ep, defaultRestrictedNetworks)
 	}
 	if restrictedErr == nil {
-		restrictedErr = r.findRestrictedPort(ep, defaultRestrictedPorts)
+		restrictedErr = r.endpointsFindRestrictedPort(ep, defaultRestrictedPorts)
 	}
 	if restrictedErr == nil {
 		return nil
 	}
 
-	allow, err := r.checkAccess(ctx, a)
+	allow, err := r.endpointsCheckAccess(ctx, a)
 	if err != nil {
 		return err
 	}
@@ -207,4 +204,88 @@ func (r *restrictedEndpointsAdmission) Validate(ctx context.Context, a admission
 		return admission.NewForbidden(a, restrictedErr)
 	}
 	return nil
+}
+
+func (r *restrictedEndpointsAdmission) sliceFindRestrictedIP(slice *discovery.EndpointSlice, restricted []*net.IPNet) error {
+	for _, endpoint := range slice.Endpoints {
+		for _, addr := range endpoint.Addresses {
+			if err := checkRestrictedIP(addr, restricted); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *restrictedEndpointsAdmission) sliceFindRestrictedPort(slice *discovery.EndpointSlice, restricted []kapi.EndpointPort) error {
+	for _, port := range slice.Ports {
+		if port.Port == nil {
+			continue
+		}
+		sliceProtocol := kapi.ProtocolTCP
+		if port.Protocol != nil {
+			sliceProtocol = *port.Protocol
+		}
+		if err := checkRestrictedPort(sliceProtocol, *port.Port, restricted); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *restrictedEndpointsAdmission) sliceCheckAccess(ctx context.Context, attr admission.Attributes) (bool, error) {
+	authzAttr := authorizer.AttributesRecord{
+		User:            attr.GetUserInfo(),
+		Verb:            "create",
+		Namespace:       attr.GetNamespace(),
+		Resource:        "endpointslices",
+		Subresource:     "restricted",
+		APIGroup:        discovery.GroupName,
+		Name:            attr.GetName(),
+		ResourceRequest: true,
+	}
+	authorized, _, err := r.authorizer.Authorize(ctx, authzAttr)
+	return authorized == authorizer.DecisionAllow, err
+}
+
+func (r *restrictedEndpointsAdmission) sliceValidate(ctx context.Context, a admission.Attributes) error {
+	slice, ok := a.GetObject().(*discovery.EndpointSlice)
+	if !ok {
+		return nil
+	}
+	old, ok := a.GetOldObject().(*discovery.EndpointSlice)
+	if ok && reflect.DeepEqual(slice.Endpoints, old.Endpoints) && reflect.DeepEqual(slice.Ports, old.Ports) {
+		return nil
+	}
+
+	restrictedErr := r.sliceFindRestrictedIP(slice, r.restrictedNetworks)
+	if restrictedErr == nil {
+		restrictedErr = r.sliceFindRestrictedIP(slice, defaultRestrictedNetworks)
+	}
+	if restrictedErr == nil {
+		restrictedErr = r.sliceFindRestrictedPort(slice, defaultRestrictedPorts)
+	}
+	if restrictedErr == nil {
+		return nil
+	}
+
+	allow, err := r.sliceCheckAccess(ctx, a)
+	if err != nil {
+		return err
+	}
+	if !allow {
+		return admission.NewForbidden(a, restrictedErr)
+	}
+	return nil
+}
+
+// Validate determines if the endpoints or endpointslice object should be admitted
+func (r *restrictedEndpointsAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	if a.GetResource().GroupResource() == kapi.Resource("endpoints") {
+		return r.endpointsValidate(ctx, a)
+	} else if a.GetResource().GroupResource() == discovery.Resource("endpointslices") {
+		return r.sliceValidate(ctx, a)
+	} else {
+		return nil
+	}
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -157,6 +157,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
 			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
+			rbacv1helpers.NewRule("create").Groups(discoveryGroup).Resources("endpointslices/restricted").RuleOrDie(),
 			eventsRule(),
 		},
 	})
@@ -173,6 +174,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			// see https://github.com/openshift/kubernetes/blob/8691466059314c3f7d6dcffcbb76d14596ca716c/pkg/controller/endpointslicemirroring/utils.go#L87-L88
 			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("endpoints/finalizers").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
+			rbacv1helpers.NewRule("create").Groups(discoveryGroup).Resources("endpointslices/restricted").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -511,6 +511,12 @@ items:
     - list
     - update
   - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices/restricted
+    verbs:
+    - create
+  - apiGroups:
     - ""
     - events.k8s.io
     resources:
@@ -560,6 +566,12 @@ items:
     - get
     - list
     - update
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices/restricted
+    verbs:
+    - create
   - apiGroups:
     - ""
     - events.k8s.io


### PR DESCRIPTION
We prevent users from creating Endpoints that point into the cluster or service networks (or to the cloud metadata server, or to the MCS), but we don't currently prevent the creation of EndpointSlices in the same way.

[EDIT] OK, so actually project admins don't normally have EndpointSlice edit permission anyway. So this part isn't needed to prevent the CVE. However, it does make it so that if the admin chooses to give someone EndpointSlice edit permission, then it will work like the existing Endpoints edit permission; they can make any modification _except_ adding restricted endpoints. [The new e2e test](https://github.com/openshift/origin/pull/26423/commits/3927b98e5da61c098c24128364fcdb0944093d42#diff-d5ddebcb0e498481b8443be84f9a99e3903384f7dedcd98b22e4d0d5bb79e05dR98-R111) checks this.

Also, we were failing to block updates to `NotReadyEndpoints` in Endpoints, which could potentially be used for a CVE-2021-25740-like attack in the future.