### PR TITLE
Bug 1994643: UPSTREAM: <carry>: sets X-OpenShift-Internal-If-Not-Ready HTTP Header for GC and Namespace controllers

### DIFF
--- a/cmd/kube-controller-manager/app/config/patch.go
+++ b/cmd/kube-controller-manager/app/config/patch.go
@@ -15,4 +15,5 @@ type OpenShiftContext struct {
 	UnsupportedKubeAPIOverPreferredHost bool
 	PreferredHostRoundTripperWrapperFn  transport.WrapperFunc
 	PreferredHostHealthMonitor          *health.Prober
+	CustomRoundTrippers                 []transport.WrapperFunc
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -136,7 +136,7 @@ controller, and serviceaccounts controller.`,
 				os.Exit(1)
 			}
 
-			if err := SetUpPreferredHostForOpenShift(s); err != nil {
+			if err := SetUpCustomRoundTrippersForOpenShift(s); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -448,6 +448,9 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 		libgorestclient.DefaultServerName(kubeconfig)
 		kubeconfig.Wrap(s.OpenShiftContext.PreferredHostRoundTripperWrapperFn)
 	}
+	for _, customOpenShiftRoundTripper := range s.OpenShiftContext.CustomRoundTrippers {
+		kubeconfig.Wrap(customOpenShiftRoundTripper)
+	}
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {

--- a/cmd/kube-controller-manager/app/patch_test.go
+++ b/cmd/kube-controller-manager/app/patch_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"testing"
+)
+
+func TestRejectIfNotReadyHeaderRT(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		eligibleUsers []string
+		currentUser   string
+		expectHeader  bool
+	}{
+		{
+			name:          "scenario 1: happy path",
+			currentUser:   "system:serviceaccount:kube-system:generic-garbage-collector",
+			eligibleUsers: []string{"generic-garbage-collector", "namespace-controller"},
+			expectHeader:  true,
+		},
+		{
+			name:          "scenario 2: ineligible user",
+			currentUser:   "system:serviceaccount:kube-system:service-account-controller",
+			eligibleUsers: []string{"generic-garbage-collector", "namespace-controller"},
+			expectHeader:  false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// set up the test
+			fakeRT := fakeRTFunc(func(r *http.Request) (*http.Response, error) {
+				// this is where we validate if the header was set or not
+				headerSet := func() bool {
+					if len(r.Header.Get("X-OpenShift-Internal-If-Not-Ready")) > 0 {
+						return true
+					}
+					return false
+				}()
+				if scenario.expectHeader && !headerSet {
+					return nil, fmt.Errorf("%v header wasn't set", textproto.CanonicalMIMEHeaderKey("X-OpenShift-Internal-If-Not-Ready"))
+				}
+				if !scenario.expectHeader && headerSet {
+					return nil, fmt.Errorf("didn't expect %v header", textproto.CanonicalMIMEHeaderKey("X-OpenShift-Internal-If-Not-Ready"))
+				}
+				if scenario.expectHeader {
+					if value := r.Header.Get("X-OpenShift-Internal-If-Not-Ready"); value != "reject" {
+						return nil, fmt.Errorf("unexpected value %v in the %v header, expected \"reject\"", value, textproto.CanonicalMIMEHeaderKey("X-OpenShift-Internal-If-Not-Ready"))
+					}
+				}
+				return nil, nil
+			})
+			target := newRejectIfNotReadyHeaderRoundTripper(scenario.eligibleUsers)(fakeRT)
+			req, err := http.NewRequest("GET", "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("User-Agent", scenario.currentUser)
+
+			// act and validate
+			if _, err := target.RoundTrip(req); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+type fakeRTFunc func(r *http.Request) (*http.Response, error)
+
+func (rt fakeRTFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}


### PR DESCRIPTION
requires https://github.com/openshift/kubernetes/pull/906