### PR TITLE
Bug 1994927: Revert "Remove Endpoints write access from aggregated edit role"

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -294,7 +294,7 @@ func clusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Write...).Groups(legacyGroup).Resources("pods", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward").RuleOrDie(),
 				rbacv1helpers.NewRule(Write...).Groups(legacyGroup).Resources("replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
-					"services", "services/proxy", "persistentvolumeclaims", "configmaps", "secrets", "events").RuleOrDie(),
+					"services", "services/proxy", "endpoints", "persistentvolumeclaims", "configmaps", "secrets", "events").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Write...).Groups(appsGroup).Resources(
 					"statefulsets", "statefulsets/scale",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -128,6 +128,7 @@ items:
     - ""
     resources:
     - configmaps
+    - endpoints
     - events
     - persistentvolumeclaims
     - replicationcontrollers


### PR DESCRIPTION
OpenShift has an admission controller to prevent restricted Endpoints
changes, and there's no reason to block non-restricted changes (such
as modifying the annotations of an Endpoints, which is done by "oc
idle").

This reverts commit 416efdab26afe06cf2b57991dfac511769bf508b.

----

split out from #899 because I'm having problems with the other half of that.