### PR TITLE
Bug 1992016: UPSTREAM: <carry>: add OPENSHIFT_MAX_HOUSEKEEPING_INTERVAL_DURATION and OPENSHIFT_EVICTION_MONITORING_PERIOD_DURATION

### DIFF
--- a/cmd/kubelet/app/options/globalflags_linux.go
+++ b/cmd/kubelet/app/options/globalflags_linux.go
@@ -45,6 +45,7 @@ func addCadvisorFlags(fs *pflag.FlagSet) {
 	register(global, local, "docker_root")
 	// e2e node tests rely on this
 	register(global, local, "housekeeping_interval")
+	register(global, local, "max_housekeeping_interval")
 
 	// These flags were implicit from cadvisor, and are mistakes that should be registered deprecated:
 	const deprecated = "This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed."

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -60,10 +60,17 @@ const defaultHousekeepingInterval = 10 * time.Second
 const allowDynamicHousekeeping = true
 
 func init() {
+	maxHouseKeeping := maxHousekeepingInterval.String()
+	if value := os.Getenv("OPENSHIFT_MAX_HOUSEKEEPING_INTERVAL_DURATION"); value != "" {
+		klog.Infof("Detected OPENSHIFT_MAX_HOUSEKEEPING_INTERVAL_DURATION: %v", value)
+		maxHouseKeeping = value
+	}
 	// Override cAdvisor flag defaults.
 	flagOverrides := map[string]string{
 		// Override the default cAdvisor housekeeping interval.
 		"housekeeping_interval": defaultHousekeepingInterval.String(),
+		// Override the default max cAdvisor housekeeping interval.
+		"max_housekeeping_interval": maxHouseKeeping,
 		// Disable event storage by default.
 		"event_storage_event_limit": "default=0",
 		"event_storage_age_limit":   "default=0",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -144,10 +144,6 @@ const (
 	// housekeeping is running no new pods are started or deleted).
 	housekeepingWarningDuration = time.Second * 15
 
-	// Period for performing eviction monitoring.
-	// ensure this is kept in sync with internal cadvisor housekeeping.
-	evictionMonitoringPeriod = time.Second * 10
-
 	// The path in containers' filesystems where the hosts file is mounted.
 	linuxEtcHostsPath   = "/etc/hosts"
 	windowsEtcHostsPath = "C:\\Windows\\System32\\drivers\\etc\\hosts"
@@ -182,6 +178,21 @@ const (
 	// nodeLeaseRenewIntervalFraction is the fraction of lease duration to renew the lease
 	nodeLeaseRenewIntervalFraction = 0.25
 )
+
+var (
+	// Period for performing eviction monitoring.
+	// ensure this is kept in sync with internal cadvisor housekeeping.
+	evictionMonitoringPeriod = time.Second * 10
+)
+
+func init() {
+	if value := os.Getenv("OPENSHIFT_EVICTION_MONITORING_PERIOD_DURATION"); value != "" {
+		if duration, err := time.ParseDuration(value); err == nil {
+			klog.Infof("Detected OPENSHIFT_EVICTION_MONITORING_PERIOD_DURATION: %v", value)
+			evictionMonitoringPeriod = duration
+		}
+	}
+}
 
 var etcHostsPath = getContainerEtcHostsPath()
 


### PR DESCRIPTION
Adds `OPENSHIFT_MAX_HOUSEKEEPING_INTERVAL_DURATION` and `OPENSHIFT_EVICTION_MONITORING_PERIOD_DURATION` overrride environmental variable for SNO and Openshift.