### PR TITLE
Bug 1999133: UPSTREAM: 104712: kubelet: add file modified time into static pod uid creation

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +54,7 @@ func generatePodName(name string, nodeName types.NodeName) string {
 	return fmt.Sprintf("%s-%s", name, strings.ToLower(string(nodeName)))
 }
 
-func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName) error {
+func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName, modtime time.Time) error {
 	if len(pod.UID) == 0 {
 		hasher := md5.New()
 		hash.DeepHashObject(hasher, pod)
@@ -62,6 +63,7 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 		if isFile {
 			fmt.Fprintf(hasher, "host:%s", nodeName)
 			fmt.Fprintf(hasher, "file:%s", source)
+			fmt.Fprintf(hasher, "modtime:%v", modtime.Unix())
 		} else {
 			fmt.Fprintf(hasher, "url:%s", source)
 		}

--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -135,12 +135,12 @@ func (s *sourceFile) consumeWatchEvent(e *watchEvent) error {
 		}
 		return s.store.Add(pod)
 	case podDelete:
-		if objKey, keyExist := s.fileKeyMapping[e.fileName]; keyExist {
-			pod, podExist, err := s.store.GetByKey(objKey)
+		if fileInfo, keyExist := s.fileKeyMapping[e.fileName]; keyExist {
+			pod, podExist, err := s.store.GetByKey(fileInfo.objKey)
 			if err != nil {
 				return err
 			} else if !podExist {
-				return fmt.Errorf("the pod with key %s doesn't exist in cache", objKey)
+				return fmt.Errorf("the pod with key %s doesn't exist in cache", fileInfo.objKey)
 			} else {
 				if err = s.store.Delete(pod); err != nil {
 					return fmt.Errorf("failed to remove deleted pod from cache: %v", err)

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -79,7 +79,7 @@ func (s *sourceURL) run() {
 }
 
 func (s *sourceURL) applyDefaults(pod *api.Pod) error {
-	return applyDefaults(pod, s.url, false, s.nodeName)
+	return applyDefaults(pod, s.url, false, s.nodeName, time.Time{})
 }
 
 func (s *sourceURL) extractFromURL() error {


### PR DESCRIPTION
Fixes an issue where static pods could get stuck in a failure state due
to the UID being the same. This patch mixes in the static pod's file
modified time making sure the UID is unique.

