### PR TITLE
Bug 1966521: userspace: Don't sync every iptables rule on every service change

### DIFF
--- a/pkg/proxy/iptables/proxier_openshift.go
+++ b/pkg/proxy/iptables/proxier_openshift.go
@@ -13,3 +13,7 @@ func (p *Proxier) SyncProxyRules() {
 func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
 	p.syncRunner = b
 }
+
+func (p *Proxier) ReloadIPTables() {
+	// Ignore this; the iptables proxier has its own iptables.Monitor
+}

--- a/pkg/proxy/userspace/proxier_openshift.go
+++ b/pkg/proxy/userspace/proxier_openshift.go
@@ -11,3 +11,8 @@ func (p *Proxier) SyncProxyRules() {
 func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
 	p.syncRunner = b
 }
+
+func (p *Proxier) ReloadIPTables() {
+	p.forceReload = true
+	p.syncProxyRules()
+}


### PR DESCRIPTION
The userspace proxy re-checks every one of its rules every time
anything changes, to ensure that rules accidentally deleted by
iptables or firewalld restart get recreated promptly. But this sucks
up a ton of CPU when there are lots of idled services and lots of
changes to other (unrelated) services.

Fix it to only do the full re-check in response to openshift-sdn's
iptables.Monitor being triggered, rather than on every sync.

----

the kubernetes half of https://github.com/openshift/sdn/pull/342
