### PR TITLE
[release-4.6] Bug 1989061: don't apply defaultAllowPrivilegeEscalation:false when container is privileged

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb
 	github.com/opencontainers/selinux v1.5.2
 	github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf
-	github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96
+	github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/library-go v0.0.0-20201123125610-83d6d67a1e98
 	github.com/pkg/errors v0.9.1
@@ -380,7 +380,7 @@ replace (
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf
-	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96
+	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8
 	github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20201123125610-83d6d67a1e98

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/opencontainers/selinux v1.5.2 h1:F6DgIsjgBIcDksLW4D5RG9bXok6oqZ3nvMwj
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf h1:KP/v5AGCaq1Sbe6QrlFGZM1fHBswiHuniMTC4/hgbVw=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96 h1:LmAsTdy0xEVu205QDXES7r1DEXIwJgYDcHpBF/r9rWQ=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8 h1:7IF+1APRKJRCj9fPuentoTuQV+lLITw6cKkoON8dDQs=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rfjtc+o+jVG/29Aclnf3XIF7akxXvadwR0=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -398,7 +398,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -447,7 +447,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -438,7 +438,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -417,7 +417,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -419,7 +419,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -411,7 +411,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/component-base/go.sum
+++ b/staging/src/k8s.io/component-base/go.sum
@@ -412,7 +412,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -444,7 +444,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/kube-controller-manager/go.sum
+++ b/staging/src/k8s.io/kube-controller-manager/go.sum
@@ -397,7 +397,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=

--- a/staging/src/k8s.io/kube-proxy/go.sum
+++ b/staging/src/k8s.io/kube-proxy/go.sum
@@ -397,7 +397,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=

--- a/staging/src/k8s.io/kube-scheduler/go.sum
+++ b/staging/src/k8s.io/kube-scheduler/go.sum
@@ -397,7 +397,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -439,7 +439,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/kubelet/go.sum
+++ b/staging/src/k8s.io/kubelet/go.sum
@@ -399,7 +399,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible/go.mod h1:8METQ1gDhl0KW+pGH4c0DIJYEN/ksVCL6hOuHPmXGnk=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -431,7 +431,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/metrics/go.sum
+++ b/staging/src/k8s.io/metrics/go.sum
@@ -411,7 +411,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -438,7 +438,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
-github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
+github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8/go.mod h1:+B51GHs/jfZzk93MKrSSA8BWxrulVVcxiBG7kdFpd74=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/ginkgo v4.5.0-origin.1+incompatible h1:AGewrYJW8aXFkkf86sSoiO9L/a/QYKZvODVCaB/wk4o=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -931,9 +931,9 @@ github.com/openshift/api/security
 github.com/openshift/api/security/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96 => github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96
+# github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8 => github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8
 ## explicit
-# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210819134745-c2bd527f0f96
+# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20210909133417-9badc0cd05a8
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/validation


### PR DESCRIPTION
this is a manual backport that brings https://github.com/openshift/apiserver-library-go/pull/59 to the repo