### PR TITLE
Bug 1994655: openshift-apiserver should not set Available=False APIServicesAvailable on update 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -464,6 +464,11 @@ func (c *Config) AddPostStartHookOrDie(name string, hook PostStartHookFunc) {
 	}
 }
 
+// HasBeenReadySignal exposes a server's lifecycle signal which is signaled when the readyz endpoint succeeds for the first time.
+func (c *Config) HasBeenReadySignal() <-chan struct{} {
+	return c.hasBeenReadyCh
+}
+
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedConfig {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -257,7 +257,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		(func() ([]byte, []byte))(s.proxyCurrentCertKeyContent),
 		s.serviceResolver,
 		c.GenericConfig.EgressSelector,
-		c.GenericConfig.LifecycleSignals.HasBeenReady.Signaled(),
+		c.GenericConfig.HasBeenReadySignal(),
 	)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -257,6 +257,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		(func() ([]byte, []byte))(s.proxyCurrentCertKeyContent),
 		s.serviceResolver,
 		c.GenericConfig.EgressSelector,
+		c.GenericConfig.LifecycleSignals.HasBeenReady.Signaled(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
not clean, picks https://github.com/openshift/kubernetes/pull/903 and https://github.com/openshift/kubernetes/pull/915

/assing @sttts @mfojtik 