### PR TITLE
Add CSI migration feature gates for vSphere and Azure File

### DIFF
--- a/pkg/features/patch_kube_features.go
+++ b/pkg/features/patch_kube_features.go
@@ -19,6 +19,12 @@ var (
 	// Enables the Azure Disk CSI migration for the Attach/Detach controller (ADC) only.
 	ADCCSIMigrationAzureDisk featuregate.Feature = "ADC_CSIMigrationAzureDisk"
 
+	// owner: @fbertina
+	// beta: v1.23
+	//
+	// Enables the Azure File CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationAzureFile featuregate.Feature = "ADC_CSIMigrationAzureFile"
+
 	// owner: @jsafrane
 	// beta: v1.21
 	//
@@ -30,13 +36,21 @@ var (
 	//
 	// Enables the GCE CSI migration for the Attach/Detach controller (ADC) only.
 	ADCCSIMigrationGCEPD featuregate.Feature = "ADC_CSIMigrationGCEPD"
+
+	// owner: @fbertina
+	// beta: v1.23
+	//
+	// Enables the vSphere CSI migration for the Attach/Detach controller (ADC) only.
+	ADCCSIMigrationVSphere featuregate.Feature = "ADC_CSIMigrationVSphere"
 )
 
 var ocpDefaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ADCCSIMigrationAWS:       {Default: true, PreRelease: featuregate.Beta},
 	ADCCSIMigrationAzureDisk: {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationAzureFile: {Default: true, PreRelease: featuregate.Beta},
 	ADCCSIMigrationCinder:    {Default: true, PreRelease: featuregate.Beta},
 	ADCCSIMigrationGCEPD:     {Default: true, PreRelease: featuregate.Beta},
+	ADCCSIMigrationVSphere:   {Default: true, PreRelease: featuregate.Beta},
 }
 
 func init() {

--- a/pkg/volume/csimigration/patch_adc_plugin_manager.go
+++ b/pkg/volume/csimigration/patch_adc_plugin_manager.go
@@ -28,10 +28,14 @@ func (pm PluginManager) adcIsMigrationEnabledForPlugin(pluginName string) bool {
 		return pm.featureGate.Enabled(features.ADCCSIMigrationAWS)
 	case csilibplugins.AzureDiskInTreePluginName:
 		return pm.featureGate.Enabled(features.ADCCSIMigrationAzureDisk)
+	case csilibplugins.AzureFileInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationAzureFile)
 	case csilibplugins.CinderInTreePluginName:
 		return pm.featureGate.Enabled(features.ADCCSIMigrationCinder)
 	case csilibplugins.GCEPDInTreePluginName:
 		return pm.featureGate.Enabled(features.ADCCSIMigrationGCEPD)
+	case csilibplugins.VSphereInTreePluginName:
+		return pm.featureGate.Enabled(features.ADCCSIMigrationVSphere)
 	default:
 		return pm.isMigrationEnabledForPlugin(pluginName)
 	}


### PR DESCRIPTION
This is the next natural step for commits 2d9a8f90b24 and d37e84c5426. This PR introduces custom feature gates to enable the CSI migration in vSphere and Azure File plugins. See openshift/enhancements#549 for details.

We'll stop <carrying> this patch when CSI migration becomes GA (i.e. features.CSIMigrationAzureFile / features.CSIMigrationVSphere are GA).

Epics:

https://issues.redhat.com/browse/STOR-578
https://issues.redhat.com/browse/STOR-614

CC @openshift/storage 
