### PR TITLE
UPSTREAM: <carry>: openshift-hack/images/os/Dockerfile: Add io.openshift.build.versions, etc.

### DIFF
--- a/openshift-hack/images/os/Dockerfile
+++ b/openshift-hack/images/os/Dockerfile
@@ -21,3 +21,6 @@ RUN set -x && yum install -y ostree rpm-ostree yum-utils selinux-policy-targeted
 
 FROM scratch
 COPY --from=build /srv/ /srv/
+
+LABEL io.openshift.build.version-display-names="machine-os=rhcos image for testing openshift kubernetes kubelet only- if you see this outside of PR runs for openshift kubernetes- you found an urgent blocker bug" \
+      io.openshift.build.versions="machine-os=1.2.3-testing-if-you-see-this-outside-of-PR-runs-for-openshift-kubernetes-you-found-an-urgent-blocker-bug"


### PR DESCRIPTION
For example, consider the current 4.10 RHCOS:

```console
$ oc image info -o json registry.ci.openshift.org/ocp/4.10:machine-os-content | jq -r '.config.config.Labels | to_entries[] | .key + ": " + .value' | grep '^io\.k8s\|^io\.openshift'
io.k8s.description: The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.
io.k8s.display-name: Red Hat Universal Base Image 8
io.openshift.build.version-display-names: machine-os=Red Hat Enterprise Linux CoreOS
io.openshift.build.versions: machine-os=49.84.202109102026-0
io.openshift.expose-services:
io.openshift.tags: base rhel8
```

A bunch of those seem to be inherited from the UBI base image, so we can leave them alone.  But the `io.openshift.build.*` entries are RHCOS-specific, and are [consumed][1] [by][2] `oc adm release new ...` and
friends to answer questions like "which RHCOS is in this release?":

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.12-x86_64 | jq .displayVersions
{
  "kubernetes": {
    "Version": "1.21.1",
    "DisplayName": ""
  },
  "machine-os": {
    "Version": "48.84.202109100857-0",
    "DisplayName": "Red Hat Enterprise Linux CoreOS"
  }
}
```

Setting this label will avoid failures when consumers like [driver-toolkit's version consumer][3]:

```yaml
name: 0.0.1-snapshot-machine-os
```

[bump into][4] ci-tools-built `machine-os-content` images that lack the `io.openshift.build.versions` declaration of `machine-os` version:

    error: unable to create a release: unknown version reference "machine-os"

I've gone with generic testing values, so hopefully this is not something that local maintainers need to remember to bump for each OpenShift z stream.

[1]: https://github.com/openshift/oc/blob/f94afb52dc8a3185b3b9eacaf92ec34d80f8708d/pkg/cli/admin/release/image_mapper.go#L328-L334
[2]: https://github.com/openshift/oc/blob/f94afb52dc8a3185b3b9eacaf92ec34d80f8708d/pkg/cli/admin/release/annotations.go#L19-L28
[3]: https://github.com/openshift/driver-toolkit/commit/464accad880f2eaaf1f150464e58e6ebc58245fe#diff-4caed9b2b966a8fa7a016ae28976634a2d3d1b635c4e820d5c038b2305d6af53R18
[4]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/959/pull-ci-openshift-kubernetes-master-images/1438398678602616832#1:build-log.txt%3A97