### PR TITLE
Bug 2005182: UPSTREAM: <carry>: update list of deprecated apis to be removed

### DIFF
--- a/openshift-kube-apiserver/filters/deprecatedapirequest/deprecated.go
+++ b/openshift-kube-apiserver/filters/deprecatedapirequest/deprecated.go
@@ -3,17 +3,45 @@ package deprecatedapirequest
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 var deprecatedApiRemovedRelease = map[schema.GroupVersionResource]string{
+	// Kubernetes APIs
+	{Group: "apps", Version: "v1beta1", Resource: "controllerrevisions"}:                                     "1.16",
+	{Group: "apps", Version: "v1beta1", Resource: "deploymentrollbacks"}:                                     "1.16",
+	{Group: "apps", Version: "v1beta1", Resource: "deployments"}:                                             "1.16",
+	{Group: "apps", Version: "v1beta1", Resource: "scales"}:                                                  "1.16",
+	{Group: "apps", Version: "v1beta1", Resource: "statefulsets"}:                                            "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "controllerrevisions"}:                                     "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "daemonsets"}:                                              "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "deployments"}:                                             "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "replicasets"}:                                             "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "scales"}:                                                  "1.16",
+	{Group: "apps", Version: "v1beta2", Resource: "statefulsets"}:                                            "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "daemonsets"}:                                        "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "deploymentrollbacks"}:                               "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "deployments"}:                                       "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "networkpolicies"}:                                   "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "podsecuritypolicies"}:                               "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}:                                       "1.16",
+	{Group: "extensions", Version: "v1beta1", Resource: "scales"}:                                            "1.16",
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1", Resource: "flowschemas"}:                    "1.21",
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1", Resource: "prioritylevelconfigurations"}:    "1.21",
-	{Group: "extensions", Version: "v1beta1", Resource: "ingresses"}:                                         "1.22",
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:   "1.22",
 	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}: "1.22",
 	{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}:               "1.22",
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:   "1.22",
 	{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"}:               "1.22",
+	{Group: "extensions", Version: "v1beta1", Resource: "ingresses"}:                                         "1.22",
 	{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresses"}:                                  "1.22",
 	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterrolebindings"}:                "1.22",
+	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterroles"}:                       "1.22",
 	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "rolebindings"}:                       "1.22",
 	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "roles"}:                              "1.22",
+	{Group: "scheduling.k8s.io", Version: "v1beta1", Resource: "priorityclasses"}:                            "1.22",
+	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csinodes"}:                                      "1.22",
+	{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}:                                               "1.25",
+	{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"}:                              "1.25",
+	{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"}:                                  "1.25",
+	{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"}:                                   "1.25",
+	// OpenShift APIs
+	{Group: "operator.openshift.io", Version: "v1beta1", Resource: "kubedeschedulers"}: "1.22",
 }
 
 // removedRelease of a specified resource.version.group.


### PR DESCRIPTION
Sync the list of deprecated APIs (and when they will be removed) so the information can be logged successfully using the `APIRequestCount` API.

Ideally, we would like to generate this list, but currently it is not possible without introducing too many dependencies.

Updating this list is especially important for identifying deprecated CRD resources that are not reported on by the upstream deprecation metrics.