### PR TITLE
Bug 1995328: Sloppy netparser

### DIFF
--- a/cluster/images/etcd/migrate/integration_test.go
+++ b/cluster/images/etcd/migrate/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*
@@ -39,6 +40,7 @@ import (
 
 	"github.com/blang/semver"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 var (
@@ -307,7 +309,7 @@ func getOrCreateTestCertFiles(certFileName, keyFileName string, spec TestCertSpe
 func parseIPList(ips []string) []net.IP {
 	var netIPs []net.IP
 	for _, ip := range ips {
-		netIPs = append(netIPs, net.ParseIP(ip))
+		netIPs = append(netIPs, netutils.ParseIPSloppy(ip))
 	}
 	return netIPs
 }
@@ -335,7 +337,7 @@ func generateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 		IsCA:                  true,
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	} else {
 		template.DNSNames = append(template.DNSNames, host)

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -96,14 +96,14 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 
 	// service cidr processing
 	if len(strings.TrimSpace(nodeIPAMConfig.ServiceCIDR)) != 0 {
-		_, serviceCIDR, err = net.ParseCIDR(nodeIPAMConfig.ServiceCIDR)
+		_, serviceCIDR, err = netutils.ParseCIDRSloppy(nodeIPAMConfig.ServiceCIDR)
 		if err != nil {
 			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.ServiceCIDR, err)
 		}
 	}
 
 	if len(strings.TrimSpace(nodeIPAMConfig.SecondaryServiceCIDR)) != 0 {
-		_, secondaryServiceCIDR, err = net.ParseCIDR(nodeIPAMConfig.SecondaryServiceCIDR)
+		_, secondaryServiceCIDR, err = netutils.ParseCIDRSloppy(nodeIPAMConfig.SecondaryServiceCIDR)
 		if err != nil {
 			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.SecondaryServiceCIDR, err)
 		}

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
+	netutils "k8s.io/utils/net"
 )
 
 func TestAddFlags(t *testing.T) {
@@ -124,12 +125,12 @@ func TestAddFlags(t *testing.T) {
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
 		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
-		ServiceClusterIPRanges: (&net.IPNet{IP: net.ParseIP("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
+		ServiceClusterIPRanges: (&net.IPNet{IP: netutils.ParseIPSloppy("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
 		MasterCount:            5,
 		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 		AllowPrivileged:        false,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
-			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+			AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 			MaxRequestsInFlight:         400,
 			MaxMutatingRequestsInFlight: 200,
@@ -175,7 +176,7 @@ func TestAddFlags(t *testing.T) {
 			DefaultWatchCacheSize:   100,
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
-			BindAddress: net.ParseIP("192.168.10.20"),
+			BindAddress: netutils.ParseIPSloppy("192.168.10.20"),
 			BindPort:    6443,
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "/var/run/kubernetes",

--- a/cmd/kube-apiserver/app/options/validation_test.go
+++ b/cmd/kube-apiserver/app/options/validation_test.go
@@ -23,6 +23,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	netutils "k8s.io/utils/net"
 )
 
 func makeOptionsWithCIDRs(serviceCIDR string, secondaryServiceCIDR string) *ServerRunOptions {
@@ -33,14 +34,14 @@ func makeOptionsWithCIDRs(serviceCIDR string, secondaryServiceCIDR string) *Serv
 
 	var primaryCIDR, secondaryCIDR net.IPNet
 	if len(serviceCIDR) > 0 {
-		_, cidr, _ := net.ParseCIDR(serviceCIDR)
+		_, cidr, _ := netutils.ParseCIDRSloppy(serviceCIDR)
 		if cidr != nil {
 			primaryCIDR = *(cidr)
 		}
 	}
 
 	if len(secondaryServiceCIDR) > 0 {
-		_, cidr, _ := net.ParseCIDR(secondaryServiceCIDR)
+		_, cidr, _ := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 		if cidr != nil {
 			secondaryCIDR = *(cidr)
 		}
@@ -151,7 +152,7 @@ func TestClusterServiceIPRange(t *testing.T) {
 }
 
 func getIPnetFromCIDR(cidr string) *net.IPNet {
-	_, ipnet, _ := net.ParseCIDR(cidr)
+	_, ipnet, _ := netutils.ParseCIDRSloppy(cidr)
 	return ipnet
 }
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/admissionenablement"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
 	"k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver"
+	netutils "k8s.io/utils/net"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -727,7 +728,7 @@ func getServiceIPAndRanges(serviceClusterIPRanges string) (net.IP, net.IPNet, ne
 		return apiServerServiceIP, primaryServiceIPRange, net.IPNet{}, nil
 	}
 
-	_, primaryServiceClusterCIDR, err := net.ParseCIDR(serviceClusterIPRangeList[0])
+	_, primaryServiceClusterCIDR, err := netutils.ParseCIDRSloppy(serviceClusterIPRangeList[0])
 	if err != nil {
 		return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("service-cluster-ip-range[0] is not a valid cidr")
 	}
@@ -740,7 +741,7 @@ func getServiceIPAndRanges(serviceClusterIPRanges string) (net.IP, net.IPNet, ne
 	// user provided at least two entries
 	// note: validation asserts that the list is max of two dual stack entries
 	if len(serviceClusterIPRangeList) > 1 {
-		_, secondaryServiceClusterCIDR, err := net.ParseCIDR(serviceClusterIPRangeList[1])
+		_, secondaryServiceClusterCIDR, err := netutils.ParseCIDRSloppy(serviceClusterIPRangeList[1])
 		if err != nil {
 			return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("service-cluster-ip-range[1] is not an ip net")
 		}

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -127,14 +127,14 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 
 	// service cidr processing
 	if len(strings.TrimSpace(ctx.ComponentConfig.NodeIPAMController.ServiceCIDR)) != 0 {
-		_, serviceCIDR, err = net.ParseCIDR(ctx.ComponentConfig.NodeIPAMController.ServiceCIDR)
+		_, serviceCIDR, err = netutils.ParseCIDRSloppy(ctx.ComponentConfig.NodeIPAMController.ServiceCIDR)
 		if err != nil {
 			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.ComponentConfig.NodeIPAMController.ServiceCIDR, err)
 		}
 	}
 
 	if len(strings.TrimSpace(ctx.ComponentConfig.NodeIPAMController.SecondaryServiceCIDR)) != 0 {
-		_, secondaryServiceCIDR, err = net.ParseCIDR(ctx.ComponentConfig.NodeIPAMController.SecondaryServiceCIDR)
+		_, secondaryServiceCIDR, err = netutils.ParseCIDRSloppy(ctx.ComponentConfig.NodeIPAMController.SecondaryServiceCIDR)
 		if err != nil {
 			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.ComponentConfig.NodeIPAMController.SecondaryServiceCIDR, err)
 		}

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -45,6 +45,7 @@ import (
 	kubectrlmgrconfigscheme "k8s.io/kubernetes/pkg/controller/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector"
 	garbagecollectorconfig "k8s.io/kubernetes/pkg/controller/garbagecollector/config"
+	netutils "k8s.io/utils/net"
 
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
@@ -430,7 +431,7 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 		return nil, err
 	}
 
-	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
 	"reflect"
 	"sort"
 	"testing"
@@ -60,6 +59,7 @@ import (
 	ttlafterfinishedconfig "k8s.io/kubernetes/pkg/controller/ttlafterfinished/config"
 	attachdetachconfig "k8s.io/kubernetes/pkg/controller/volume/attachdetach/config"
 	persistentvolumeconfig "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/config"
+	netutils "k8s.io/utils/net"
 )
 
 var args = []string{
@@ -396,7 +396,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,
-			BindAddress: net.ParseIP("192.168.4.21"),
+			BindAddress: netutils.ParseIPSloppy("192.168.4.21"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "/a/b/c",
 				PairName:      "kube-controller-manager",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -86,7 +86,7 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/utils/exec"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -828,13 +828,13 @@ func (s *ProxyServer) CleanupAndExit() error {
 // 2. the primary IP from the Node object, if set
 // 3. if no IP is found it defaults to 127.0.0.1 and IPv4
 func detectNodeIP(client clientset.Interface, hostname, bindAddress string) net.IP {
-	nodeIP := net.ParseIP(bindAddress)
+	nodeIP := netutils.ParseIPSloppy(bindAddress)
 	if nodeIP.IsUnspecified() {
 		nodeIP = utilnode.GetNodeIP(client, hostname)
 	}
 	if nodeIP == nil {
 		klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
-		nodeIP = net.ParseIP("127.0.0.1")
+		nodeIP = netutils.ParseIPSloppy("127.0.0.1")
 	}
 	return nodeIP
 }
@@ -845,8 +845,8 @@ func detectNodeIP(client clientset.Interface, hostname, bindAddress string) net.
 func nodeIPTuple(bindAddress string) [2]net.IP {
 	nodes := [2]net.IP{net.IPv4zero, net.IPv6zero}
 
-	adr := net.ParseIP(bindAddress)
-	if utilsnet.IsIPv6(adr) {
+	adr := netutils.ParseIPSloppy(bindAddress)
+	if netutils.IsIPv6(adr) {
 		nodes[1] = adr
 	} else {
 		nodes[0] = adr

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -26,6 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutils "k8s.io/utils/net"
 
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 
@@ -232,21 +234,21 @@ func Test_detectNodeIP(t *testing.T) {
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "10.0.0.1",
-			expectedIP:  net.ParseIP("10.0.0.1"),
+			expectedIP:  netutils.ParseIPSloppy("10.0.0.1"),
 		},
 		{
 			name:        "Bind address IPv6 unicast address and no Node object",
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "fd00:4321::2",
-			expectedIP:  net.ParseIP("fd00:4321::2"),
+			expectedIP:  netutils.ParseIPSloppy("fd00:4321::2"),
 		},
 		{
 			name:        "No Valid IP found",
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "",
-			expectedIP:  net.ParseIP("127.0.0.1"),
+			expectedIP:  netutils.ParseIPSloppy("127.0.0.1"),
 		},
 		// Disabled because the GetNodeIP method has a backoff retry mechanism
 		// and the test takes more than 30 seconds
@@ -263,56 +265,56 @@ func Test_detectNodeIP(t *testing.T) {
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("192.168.1.1"),
+			expectedIP:  netutils.ParseIPSloppy("192.168.1.1"),
 		},
 		{
 			name:        "Bind address :: and node with IPv4 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("192.168.1.1"),
+			expectedIP:  netutils.ParseIPSloppy("192.168.1.1"),
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with IPv6 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("fd00:1234::1"),
+			expectedIP:  netutils.ParseIPSloppy("fd00:1234::1"),
 		},
 		{
 			name:        "Bind address :: and node with IPv6 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("fd00:1234::1"),
+			expectedIP:  netutils.ParseIPSloppy("fd00:1234::1"),
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with only IPv4 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("90.90.90.90"),
+			expectedIP:  netutils.ParseIPSloppy("90.90.90.90"),
 		},
 		{
 			name:        "Bind address :: and node with only IPv4 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("90.90.90.90"),
+			expectedIP:  netutils.ParseIPSloppy("90.90.90.90"),
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with only IPv6 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("2001:db8::2"),
+			expectedIP:  netutils.ParseIPSloppy("2001:db8::2"),
 		},
 		{
 			name:        "Bind address :: and node with only IPv6 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("2001:db8::2"),
+			expectedIP:  netutils.ParseIPSloppy("2001:db8::2"),
 		},
 	}
 	for _, c := range cases {

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -256,7 +256,7 @@ func Test_detectNodeIP(t *testing.T) {
 		//	nodeInfo:    makeNodeWithAddresses("", "", ""),
 		//	hostname:    "fakeHost",
 		//	bindAddress: "0.0.0.0",
-		//	expectedIP:  net.ParseIP("127.0.0.1"),
+		//	expectedIP:  net.ParseIPSloppy("127.0.0.1"),
 		// },
 		{
 			name:        "Bind address 0.0.0.0 and node with IPv4 InternalIP set",

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -23,7 +24,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"net"
 	goruntime "runtime"
 
 	// Enable pprof HTTP handlers.
@@ -45,6 +45,7 @@ import (
 	utilnetsh "k8s.io/kubernetes/pkg/util/netsh"
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 )
 
 // NewProxyServer returns a new ProxyServer.
@@ -148,7 +149,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 
 		proxier, err = winuserspace.NewProxier(
 			winuserspace.NewLoadBalancerRR(),
-			net.ParseIP(config.BindAddress),
+			netutils.ParseIPSloppy(config.BindAddress),
 			netshInterface,
 			*utilnet.ParsePortRangeOrDie(config.PortRange),
 			// TODO @pires replace below with default values, if applicable

--- a/cmd/kube-scheduler/app/options/insecure_serving.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving.go
@@ -26,6 +26,7 @@ import (
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	netutils "k8s.io/utils/net"
 )
 
 // CombinedInsecureServingOptions sets up to two insecure listeners for healthz and metrics. The flags
@@ -78,11 +79,11 @@ func (o *CombinedInsecureServingOptions) ApplyTo(c *schedulerappconfig.Config, c
 
 	if o.Healthz != nil {
 		o.Healthz.BindPort = o.BindPort
-		o.Healthz.BindAddress = net.ParseIP(o.BindAddress)
+		o.Healthz.BindAddress = netutils.ParseIPSloppy(o.BindAddress)
 	}
 	if o.Metrics != nil {
 		o.Metrics.BindPort = o.BindPort
-		o.Metrics.BindAddress = net.ParseIP(o.BindAddress)
+		o.Metrics.BindAddress = netutils.ParseIPSloppy(o.BindAddress)
 	}
 
 	return o.applyTo(c, componentConfig)
@@ -125,7 +126,7 @@ func updateDeprecatedInsecureServingOptionsFromAddress(is *apiserveroptions.Depr
 	} else {
 		// In the previous `validate` process, we can ensure that the `addr` is legal, so ignore the error
 		host, portInt, _ := splitHostIntPort(addr)
-		is.BindAddress = net.ParseIP(host)
+		is.BindAddress = netutils.ParseIPSloppy(host)
 		is.BindPort = portInt
 	}
 }
@@ -142,7 +143,7 @@ func (o *CombinedInsecureServingOptions) Validate() []error {
 		errors = append(errors, fmt.Errorf("--port %v must be between 0 and 65535, inclusive. 0 for turning off insecure (HTTP) port", o.BindPort))
 	}
 
-	if len(o.BindAddress) > 0 && net.ParseIP(o.BindAddress) == nil {
+	if len(o.BindAddress) > 0 && netutils.ParseIPSloppy(o.BindAddress) == nil {
 		errors = append(errors, fmt.Errorf("--address %v is an invalid IP address", o.BindAddress))
 	}
 

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -45,6 +45,7 @@ import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+	netutils "k8s.io/utils/net"
 
 	libgorestclient "github.com/openshift/library-go/pkg/config/client"
 )
@@ -292,7 +293,7 @@ func (o *Options) Validate() []error {
 // Config return a scheduler config object
 func (o *Options) Config() (*schedulerappconfig.Config, error) {
 	if o.SecureServing != nil {
-		if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+		if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 			return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 		}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/apiendpoint.go
+++ b/cmd/kubeadm/app/apis/kubeadm/apiendpoint.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"strconv"
 
+	netutils "k8s.io/utils/net"
+
 	"github.com/pkg/errors"
 )
 
@@ -29,7 +31,7 @@ func APIEndpointFromString(apiEndpoint string) (APIEndpoint, error) {
 	if err != nil {
 		return APIEndpoint{}, errors.Wrapf(err, "invalid advertise address endpoint: %s", apiEndpoint)
 	}
-	if net.ParseIP(apiEndpointHost) == nil {
+	if netutils.ParseIPSloppy(apiEndpointHost) == nil {
 		return APIEndpoint{}, errors.Errorf("invalid API endpoint IP: %s", apiEndpointHost)
 	}
 	apiEndpointPort, err := net.LookupPort("tcp", apiEndpointPortStr)

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -17,12 +17,11 @@ limitations under the License.
 package componentconfigs
 
 import (
-	"net"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	netutils "k8s.io/utils/net"
 
 	clientset "k8s.io/client-go/kubernetes"
 	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
@@ -76,7 +75,7 @@ func (kp *kubeProxyConfig) Unmarshal(docmap kubeadmapi.DocumentMap) error {
 }
 
 func kubeProxyDefaultBindAddress(localAdvertiseAddress string) string {
-	ip := net.ParseIP(localAdvertiseAddress)
+	ip := netutils.ParseIPSloppy(localAdvertiseAddress)
 	if ip.To4() != nil {
 		return kubeadmapiv1.DefaultProxyBindAddressv4
 	}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 
 	"github.com/pkg/errors"
 )
@@ -601,7 +601,7 @@ func GetDNSIP(svcSubnetList string, isDualStack bool) (net.IP, error) {
 	}
 
 	// Selects the 10th IP in service subnet CIDR range as dnsIP
-	dnsIP, err := utilnet.GetIndexedIP(svcSubnetCIDR, 10)
+	dnsIP, err := netutils.GetIndexedIP(svcSubnetCIDR, 10)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get internal Kubernetes Service IP from the given service CIDR")
 	}
@@ -615,7 +615,7 @@ func GetKubernetesServiceCIDR(svcSubnetList string, isDualStack bool) (*net.IPNe
 		// The default service address family for the cluster is the address family of the first
 		// service cluster IP range configured via the `--service-cluster-ip-range` flag
 		// of the kube-controller-manager and kube-apiserver.
-		svcSubnets, err := utilnet.ParseCIDRs(strings.Split(svcSubnetList, ","))
+		svcSubnets, err := netutils.ParseCIDRs(strings.Split(svcSubnetList, ","))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse ServiceSubnet %v", svcSubnetList)
 		}
@@ -625,7 +625,7 @@ func GetKubernetesServiceCIDR(svcSubnetList string, isDualStack bool) (*net.IPNe
 		return svcSubnets[0], nil
 	}
 	// internal IP address for the API server
-	_, svcSubnet, err := net.ParseCIDR(svcSubnetList)
+	_, svcSubnet, err := netutils.ParseCIDRSloppy(svcSubnetList)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse ServiceSubnet %v", svcSubnetList)
 	}
@@ -638,7 +638,7 @@ func GetAPIServerVirtualIP(svcSubnetList string, isDualStack bool) (net.IP, erro
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get internal Kubernetes Service IP from the given service CIDR")
 	}
-	internalAPIServerVirtualIP, err := utilnet.GetIndexedIP(svcSubnet, 1)
+	internalAPIServerVirtualIP, err := netutils.GetIndexedIP(svcSubnet, 1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get the first IP address from the given CIDR: %s", svcSubnet.String())
 	}

--- a/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
@@ -30,6 +30,7 @@ import (
 	certtestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+	netutils "k8s.io/utils/net"
 
 	certutil "k8s.io/client-go/util/cert"
 )
@@ -46,7 +47,7 @@ var (
 			CommonName:   "test-common-name",
 			Organization: []string{"sig-cluster-lifecycle"},
 			AltNames: certutil.AltNames{
-				IPs:      []net.IP{net.ParseIP("10.100.0.1")},
+				IPs:      []net.IP{netutils.ParseIPSloppy("10.100.0.1")},
 				DNSNames: []string{"test-domain.space"},
 			},
 			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -234,7 +235,7 @@ func TestCertToConfig(t *testing.T) {
 		CommonName:   "test-common-name",
 		Organization: []string{"sig-cluster-lifecycle"},
 		AltNames: certutil.AltNames{
-			IPs:      []net.IP{net.ParseIP("10.100.0.1")},
+			IPs:      []net.IP{netutils.ParseIPSloppy("10.100.0.1")},
 			DNSNames: []string{"test-domain.space"},
 		},
 		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -247,7 +248,7 @@ func TestCertToConfig(t *testing.T) {
 		},
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		DNSNames:    []string{"test-domain.space"},
-		IPAddresses: []net.IP{net.ParseIP("10.100.0.1")},
+		IPAddresses: []net.IP{netutils.ParseIPSloppy("10.100.0.1")},
 	}
 
 	cfg := certToConfig(cert)

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -28,6 +28,7 @@ import (
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
@@ -161,7 +162,7 @@ func writeTestKubeconfig(t *testing.T, dir, name string, caCert *x509.Certificat
 			Organization: []string{"sig-cluster-lifecycle"},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			AltNames: certutil.AltNames{
-				IPs:      []net.IP{net.ParseIP("10.100.0.1")},
+				IPs:      []net.IP{netutils.ParseIPSloppy("10.100.0.1")},
 				DNSNames: []string{"test-domain.space"},
 			},
 		},

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -49,7 +49,7 @@ import (
 	"k8s.io/klog/v2"
 	system "k8s.io/system-validators/validators"
 	utilsexec "k8s.io/utils/exec"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 
 	"github.com/PuerkitoBio/purell"
 	"github.com/pkg/errors"
@@ -431,7 +431,7 @@ func (hst HTTPProxyCheck) Name() string {
 func (hst HTTPProxyCheck) Check() (warnings, errorList []error) {
 	klog.V(1).Infoln("validating if the connectivity type is via proxy or direct")
 	u := &url.URL{Scheme: hst.Proto, Host: hst.Host}
-	if utilsnet.IsIPv6String(hst.Host) {
+	if netutils.IsIPv6String(hst.Host) {
 		u.Host = net.JoinHostPort(hst.Host, "1234")
 	}
 
@@ -473,12 +473,12 @@ func (subnet HTTPProxyCIDRCheck) Check() (warnings, errorList []error) {
 		return nil, nil
 	}
 
-	_, cidr, err := net.ParseCIDR(subnet.CIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(subnet.CIDR)
 	if err != nil {
 		return nil, []error{errors.Wrapf(err, "error parsing CIDR %q", subnet.CIDR)}
 	}
 
-	testIP, err := utilsnet.GetIndexedIP(cidr, 1)
+	testIP, err := netutils.GetIndexedIP(cidr, 1)
 	if err != nil {
 		return nil, []error{errors.Wrapf(err, "unable to get first IP address from the given CIDR (%s)", cidr.String())}
 	}
@@ -936,8 +936,8 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 		checks = addCommonChecks(execer, cfg.KubernetesVersion, &cfg.NodeRegistration, checks)
 
 		// Check if Bridge-netfilter and IPv6 relevant flags are set
-		if ip := net.ParseIP(cfg.LocalAPIEndpoint.AdvertiseAddress); ip != nil {
-			if utilsnet.IsIPv6(ip) {
+		if ip := netutils.ParseIPSloppy(cfg.LocalAPIEndpoint.AdvertiseAddress); ip != nil {
+			if netutils.IsIPv6(ip) {
 				checks = append(checks,
 					FileContentCheck{Path: bridgenf6, Content: []byte{'1'}},
 					FileContentCheck{Path: ipv6DefaultForwarding, Content: []byte{'1'}},
@@ -1001,8 +1001,8 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 			checks = append(checks,
 				HTTPProxyCheck{Proto: "https", Host: ipstr},
 			)
-			if ip := net.ParseIP(ipstr); ip != nil {
-				if utilsnet.IsIPv6(ip) {
+			if ip := netutils.ParseIPSloppy(ipstr); ip != nil {
+				if netutils.IsIPv6(ip) {
 					addIPv6Checks = true
 				}
 			}

--- a/cmd/kubeadm/app/util/apiclient/init_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun.go
@@ -17,18 +17,17 @@ limitations under the License.
 package apiclient
 
 import (
-	"net"
 	"strings"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	core "k8s.io/client-go/testing"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 
 	"github.com/pkg/errors"
 )
@@ -88,12 +87,12 @@ func (idr *InitDryRunGetter) handleKubernetesService(action core.GetAction) (boo
 		return false, nil, nil
 	}
 
-	_, svcSubnet, err := net.ParseCIDR(idr.serviceSubnet)
+	_, svcSubnet, err := netutils.ParseCIDRSloppy(idr.serviceSubnet)
 	if err != nil {
 		return true, nil, errors.Wrapf(err, "error parsing CIDR %q", idr.serviceSubnet)
 	}
 
-	internalAPIServerVirtualIP, err := utilnet.GetIndexedIP(svcSubnet, 1)
+	internalAPIServerVirtualIP, err := netutils.GetIndexedIP(svcSubnet, 1)
 	if err != nil {
 		return true, nil, errors.Wrapf(err, "unable to get first IP address from the given CIDR (%s)", svcSubnet.String())
 	}

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -27,6 +27,7 @@ import (
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -122,7 +123,7 @@ func LowercaseSANs(sans []string) {
 // VerifyAPIServerBindAddress can be used to verify if a bind address for the API Server is 0.0.0.0,
 // in which case this address is not valid and should not be used.
 func VerifyAPIServerBindAddress(address string) error {
-	ip := net.ParseIP(address)
+	ip := netutils.ParseIPSloppy(address)
 	if ip == nil {
 		return errors.Errorf("cannot parse IP address: %s", address)
 	}
@@ -147,7 +148,7 @@ func ChooseAPIServerBindAddress(bindAddress net.IP) (net.IP, error) {
 	if err != nil {
 		if netutil.IsNoRoutesError(err) {
 			klog.Warningf("WARNING: could not obtain a bind address for the API Server: %v; using: %s", err, constants.DefaultAPIServerBindAddress)
-			defaultIP := net.ParseIP(constants.DefaultAPIServerBindAddress)
+			defaultIP := netutils.ParseIPSloppy(constants.DefaultAPIServerBindAddress)
 			if defaultIP == nil {
 				return nil, errors.Errorf("cannot parse default IP address: %s", constants.DefaultAPIServerBindAddress)
 			}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -33,6 +33,7 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/config/strict"
 	kubeadmruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,7 +123,7 @@ func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions,
 // SetAPIEndpointDynamicDefaults checks and sets configuration values for the APIEndpoint object
 func SetAPIEndpointDynamicDefaults(cfg *kubeadmapi.APIEndpoint) error {
 	// validate cfg.API.AdvertiseAddress.
-	addressIP := net.ParseIP(cfg.AdvertiseAddress)
+	addressIP := netutils.ParseIPSloppy(cfg.AdvertiseAddress)
 	if addressIP == nil && cfg.AdvertiseAddress != "" {
 		return errors.Errorf("couldn't use \"%s\" as \"apiserver-advertise-address\", must be ipv4 or ipv6 address", cfg.AdvertiseAddress)
 	}

--- a/cmd/kubeadm/app/util/endpoint.go
+++ b/cmd/kubeadm/app/util/endpoint.go
@@ -25,7 +25,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 
 	"k8s.io/apimachinery/pkg/util/validation"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 
 	"github.com/pkg/errors"
 )
@@ -100,7 +100,7 @@ func ParseHostPort(hostport string) (string, string, error) {
 	}
 
 	// if host is a valid IP, returns it
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
 		return host, port, nil
 	}
 
@@ -115,7 +115,7 @@ func ParseHostPort(hostport string) (string, string, error) {
 // ParsePort parses a string representing a TCP port.
 // If the string is not a valid representation of a TCP port, ParsePort returns an error.
 func ParsePort(port string) (int, error) {
-	portInt, err := utilsnet.ParsePort(port, true)
+	portInt, err := netutils.ParsePort(port, true)
 	if err == nil && (1 <= portInt && portInt <= 65535) {
 		return portInt, nil
 	}
@@ -133,7 +133,7 @@ func parseAPIEndpoint(localEndpoint *kubeadmapi.APIEndpoint) (net.IP, string, er
 	}
 
 	// parse the AdvertiseAddress
-	var ip = net.ParseIP(localEndpoint.AdvertiseAddress)
+	var ip = netutils.ParseIPSloppy(localEndpoint.AdvertiseAddress)
 	if ip == nil {
 		return nil, "", errors.Errorf("invalid value `%s` given for api.advertiseAddress", localEndpoint.AdvertiseAddress)
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	netutils "k8s.io/utils/net"
 
 	certutil "k8s.io/client-go/util/cert"
 )
@@ -633,7 +634,7 @@ func TestGetAPIServerAltNames(t *testing.T) {
 			for _, IPAddress := range rt.expectedIPAddresses {
 				found := false
 				for _, val := range altNames.IPs {
-					if val.Equal(net.ParseIP(IPAddress)) {
+					if val.Equal(netutils.ParseIPSloppy(IPAddress)) {
 						found = true
 						break
 					}
@@ -698,7 +699,7 @@ func TestGetEtcdAltNames(t *testing.T) {
 		t.Run(IPAddress, func(t *testing.T) {
 			found := false
 			for _, val := range altNames.IPs {
-				if val.Equal(net.ParseIP(IPAddress)) {
+				if val.Equal(netutils.ParseIPSloppy(IPAddress)) {
 					found = true
 					break
 				}
@@ -757,7 +758,7 @@ func TestGetEtcdPeerAltNames(t *testing.T) {
 			for _, IPAddress := range expectedIPAddresses {
 				found := false
 				for _, val := range altNames.IPs {
-					if val.Equal(net.ParseIP(IPAddress)) {
+					if val.Equal(netutils.ParseIPSloppy(IPAddress)) {
 						found = true
 						break
 					}

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -3,6 +3,7 @@ module k8s.io/kubernetes/hack/tools
 go 1.16
 
 require (
+	github.com/aojea/sloppy-netparser v0.0.0-20210819225411-1b3bd8b3b975
 	github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.41.1

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -66,6 +66,8 @@ github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
+github.com/aojea/sloppy-netparser v0.0.0-20210819225411-1b3bd8b3b975 h1:3bpBhtHNVCpJiyO1r7w0BjGhQPPk2eD1ZsVAVS5vmiE=
+github.com/aojea/sloppy-netparser v0.0.0-20210819225411-1b3bd8b3b975/go.mod h1:VP81Qd6FKAazakPswOou8ULXGU/j5QH0VcGPzehHx3s=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -187,6 +189,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -637,8 +640,9 @@ github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4l
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -1014,8 +1018,9 @@ golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1157,6 +1162,8 @@ honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
 honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/klog/hack/tools v0.0.0-20210303110520-14dec3377f55 h1:dLsq+jacIVLNk1Jmh5RFmlTiD5kIwjYN5hh8udCyeDc=
 k8s.io/klog/hack/tools v0.0.0-20210303110520-14dec3377f55/go.mod h1:peYvfmhJdUiWTjdEpxAPkauLKX+lwVMfcSIMynAWZ14=
+k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/gofumpt v0.1.1 h1:bi/1aS/5W00E2ny5q65w9SnKpWEF/UIOqDYBILpo9rA=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -20,6 +20,7 @@ package tools
 
 import (
 	// linting tools
+	_ "github.com/aojea/sloppy-netparser"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/go-flow-levee/cmd/levee"

--- a/hack/update-netparse-cve.sh
+++ b/hack/update-netparse-cve.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script replace "net" stdlib IP and CIDR parsers
+# with the ones forked in k8s.io/utils/net to parse IP addresses
+# because of the compatibility break introduced in golang 1.17
+# Reference: #100895
+# Usage: `hack/update-netparse-cve.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+kube::golang::verify_go_version
+
+# Ensure that we find the binaries we build before anything else.
+export GOBIN="${KUBE_OUTPUT_BINPATH}"
+PATH="${GOBIN}:${PATH}"
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on
+
+# Install golangci-lint
+echo 'installing net parser converter'
+pushd "${KUBE_ROOT}/hack/tools" >/dev/null
+  go install github.com/aojea/sloppy-netparser
+popd >/dev/null
+
+cd "${KUBE_ROOT}"
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './.git' \
+        -o -wholename './_output' \
+        -o -wholename './_gopath' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/vendor/*' \
+        -o -wholename './staging/src/k8s.io/client-go/*vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+# replace net.ParseIP() and netParseIPCDR
+find_files | xargs sloppy-netparser
+

--- a/hack/verify-netparse-cve.sh
+++ b/hack/verify-netparse-cve.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks if the "net" stdlib IP and CIDR parsers are used
+# instead of the ones forked in k8s.io/utils/net to parse IP addresses
+# because of the compatibility break introduced in golang 1.17
+# Reference: #100895
+# Usage: `hack/verify-netparse-cve.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+cd "${KUBE_ROOT}"
+
+rc=0
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './.git' \
+        -o -wholename './_output' \
+        -o -wholename './_gopath' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/vendor/*' \
+        -o -wholename './staging/src/k8s.io/client-go/*vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+# find files using net.ParseIP()
+netparseip_matches=$(find_files | xargs grep -nE "net.ParseIP\(.*\)" 2>/dev/null) || true
+if [[ -n "${netparseip_matches}" ]]; then
+  echo "net.ParseIP reject leading zeros in the dot-decimal notation of IPv4 addresses since golang 1.17:" >&2
+  echo "${netparseip_matches}" >&2
+  echo >&2
+  echo "Use k8s.io/utils/net ParseIPSloppy() to parse IP addresses. Kubernetes #100895" >&2
+  echo >&2
+  echo "Run ./hack/update-netparse-cve.sh" >&2
+  echo >&2
+  rc=1
+fi
+
+# find files using net.ParseCIDR()
+netparsecidrs_matches=$(find_files | xargs grep -nE "net.ParseCIDR\(.*\)" 2>/dev/null) || true
+if [[ -n "${netparsecidrs_matches}" ]]; then
+  echo "net.ParseCIDR reject leading zeros in the dot-decimal notation of IPv4 addresses since golang 1.17:" >&2
+  echo "${netparsecidrs_matches}" >&2
+  echo >&2
+  echo "Use k8s.io/utils/net ParseCIDRSloppy() to parse network CIDRs. Kubernetes #100895" >&2
+  echo >&2
+  echo "Run ./hack/update-netparse-cve.sh" >&2
+  echo >&2
+  rc=1
+fi
+
+exit $rc

--- a/openshift-kube-apiserver/admission/customresourcevalidation/oauth/helpers.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/oauth/helpers.go
@@ -1,10 +1,9 @@
 package oauth
 
 import (
-	"net"
-
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	netutils "k8s.io/utils/net"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/config/validation"
@@ -12,7 +11,7 @@ import (
 )
 
 func isValidHostname(hostname string) bool {
-	return len(kvalidation.IsDNS1123Subdomain(hostname)) == 0 || net.ParseIP(hostname) != nil
+	return len(kvalidation.IsDNS1123Subdomain(hostname)) == 0 || netutils.ParseIPSloppy(hostname) != nil
 }
 
 func ValidateRemoteConnectionInfo(remoteConnectionInfo configv1.OAuthRemoteConnectionInfo, fldPath *field.Path) field.ErrorList {

--- a/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission.go
+++ b/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/externalipranger"
 	v1 "k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/externalipranger/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	netutils "k8s.io/utils/net"
 )
 
 const ExternalIPPluginName = "network.openshift.io/ExternalIPRanger"
@@ -80,7 +81,7 @@ func ParseRejectAdmitCIDRRules(rules []string) (reject, admit []*net.IPNet, err 
 			negate = true
 			s = s[1:]
 		}
-		_, cidr, err := net.ParseCIDR(s)
+		_, cidr, err := netutils.ParseCIDRSloppy(s)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -166,7 +167,7 @@ func (r *externalIPRanger) Validate(ctx context.Context, a admission.Attributes,
 	// administrator has limited the range
 	case len(svc.Spec.ExternalIPs) > 0 && len(r.admit) > 0:
 		for i, s := range svc.Spec.ExternalIPs {
-			ip := net.ParseIP(s)
+			ip := netutils.ParseIPSloppy(s)
 			if ip == nil {
 				errs = append(errs, field.Forbidden(field.NewPath("spec", "externalIPs").Index(i), "externalIPs must be a valid address"))
 				continue

--- a/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission_test.go
+++ b/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 
@@ -48,23 +49,23 @@ func TestAdmission(t *testing.T) {
 	}
 	var oldSvc *kapi.Service
 
-	_, ipv4, err := net.ParseCIDR("172.0.0.0/16")
+	_, ipv4, err := netutils.ParseCIDRSloppy("172.0.0.0/16")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, ipv4subset, err := net.ParseCIDR("172.0.1.0/24")
+	_, ipv4subset, err := netutils.ParseCIDRSloppy("172.0.1.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, ipv4offset, err := net.ParseCIDR("172.200.0.0/24")
+	_, ipv4offset, err := netutils.ParseCIDRSloppy("172.200.0.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, none, err := net.ParseCIDR("0.0.0.0/32")
+	_, none, err := netutils.ParseCIDRSloppy("0.0.0.0/32")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, all, err := net.ParseCIDR("0.0.0.0/0")
+	_, all, err := netutils.ParseCIDRSloppy("0.0.0.0/0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
+++ b/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/discovery"
+	netutils "k8s.io/utils/net"
 
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/restrictedendpoints"
@@ -71,7 +72,7 @@ var _ = admission.ValidationInterface(&restrictedEndpointsAdmission{})
 // ParseSimpleCIDRRules parses a list of CIDR strings
 func ParseSimpleCIDRRules(rules []string) (networks []*net.IPNet, err error) {
 	for _, s := range rules {
-		_, cidr, err := net.ParseCIDR(s)
+		_, cidr, err := netutils.ParseCIDRSloppy(s)
 		if err != nil {
 			return nil, err
 		}
@@ -107,12 +108,12 @@ var (
 	}
 	defaultRestrictedNetworks = []*net.IPNet{
 		// IPv4 link-local range 169.254.0.0/16 (including cloud metadata IP)
-		{IP: net.ParseIP("169.254.0.0"), Mask: net.CIDRMask(16, 32)},
+		{IP: netutils.ParseIPSloppy("169.254.0.0"), Mask: net.CIDRMask(16, 32)},
 	}
 )
 
 func checkRestrictedIP(ipString string, restricted []*net.IPNet) error {
-	ip := net.ParseIP(ipString)
+	ip := netutils.ParseIPSloppy(ipString)
 	if ip == nil {
 		return nil
 	}

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -36,6 +35,7 @@ import (
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/features"
+	netutils "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -341,7 +341,7 @@ func validateIngressRules(ingressRules []networking.IngressRule, fldPath *field.
 	for i, ih := range ingressRules {
 		wildcardHost := false
 		if len(ih.Host) > 0 {
-			if isIP := (net.ParseIP(ih.Host) != nil); isIP {
+			if isIP := (netutils.ParseIPSloppy(ih.Host) != nil); isIP {
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("host"), ih.Host, "must be a DNS name, not an IP address"))
 			}
 			// TODO: Ports and ips are allowed in the host part of a url

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -18,7 +18,6 @@ package endpointslicemirroring
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/kubernetes/pkg/apis/discovery/validation"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
+	netutils "k8s.io/utils/net"
 )
 
 // addrTypePortMapKey is used to uniquely identify groups of endpoint ports and
@@ -50,7 +50,7 @@ func (pk addrTypePortMapKey) addressType() discovery.AddressType {
 }
 
 func getAddressType(address string) *discovery.AddressType {
-	ip := net.ParseIP(address)
+	ip := netutils.ParseIPSloppy(address)
 	if ip == nil {
 		return nil
 	}

--- a/pkg/controller/nodeipam/ipam/adapter.go
+++ b/pkg/controller/nodeipam/ipam/adapter.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -25,6 +26,7 @@ import (
 	"net"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +82,7 @@ func (a *adapter) Alias(ctx context.Context, node *v1.Node) (*net.IPNet, error) 
 		klog.Warningf("Node %q has more than one alias assigned (%v), defaulting to the first", node.Name, cidrs)
 	}
 
-	_, cidrRange, err := net.ParseCIDR(cidrs[0])
+	_, cidrRange, err := netutils.ParseCIDRSloppy(cidrs[0])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {
@@ -47,7 +48,7 @@ func TestCIDRSetFullyAllocated(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, _ := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
@@ -198,7 +199,7 @@ func TestIndexToCIDRBlock(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, _ := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		a, err := NewCIDRSet(clusterCIDR, tc.subnetMaskSize)
 		if err != nil {
 			t.Fatalf("error for %v ", tc.description)
@@ -225,7 +226,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, _ := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		a, err := NewCIDRSet(clusterCIDR, 24)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
@@ -286,7 +287,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, _ := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		a, err := NewCIDRSet(clusterCIDR, 24)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
@@ -399,7 +400,7 @@ func TestDoubleOccupyRelease(t *testing.T) {
 	// operations have been executed.
 	numAllocatable24s := (1 << 8) - 3
 
-	_, clusterCIDR, _ := net.ParseCIDR(clusterCIDRStr)
+	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(clusterCIDRStr)
 	a, err := NewCIDRSet(clusterCIDR, 24)
 	if err != nil {
 		t.Fatalf("Error allocating CIDRSet")
@@ -407,7 +408,7 @@ func TestDoubleOccupyRelease(t *testing.T) {
 
 	// Execute the operations
 	for _, op := range operations {
-		_, cidr, _ := net.ParseCIDR(op.cidrStr)
+		_, cidr, _ := netutils.ParseCIDRSloppy(op.cidrStr)
 		switch op.operation {
 		case "occupy":
 			a.Occupy(cidr)
@@ -557,7 +558,7 @@ func TestGetBitforCIDR(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, err := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -566,7 +567,7 @@ func TestGetBitforCIDR(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
-		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		_, subnetCIDR, err := netutils.ParseCIDRSloppy(tc.subNetCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -727,7 +728,7 @@ func TestOccupy(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		_, clusterCIDR, err := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -737,7 +738,7 @@ func TestOccupy(t *testing.T) {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
 
-		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		_, subnetCIDR, err := netutils.ParseCIDRSloppy(tc.subNetCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -796,7 +797,7 @@ func TestCIDRSetv6(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+			_, clusterCIDR, _ := netutils.ParseCIDRSloppy(tc.clusterCIDRStr)
 			a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
 			if gotErr := err != nil; gotErr != tc.expectErr {
 				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
@@ -834,7 +835,7 @@ func TestCIDRSetv6(t *testing.T) {
 
 func TestCidrSetMetrics(t *testing.T) {
 	cidr := "10.0.0.0/16"
-	_, clusterCIDR, _ := net.ParseCIDR(cidr)
+	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(cidr)
 	// We have 256 free cidrs
 	a, err := NewCIDRSet(clusterCIDR, 24)
 	if err != nil {
@@ -880,7 +881,7 @@ func TestCidrSetMetrics(t *testing.T) {
 
 func TestCidrSetMetricsHistogram(t *testing.T) {
 	cidr := "10.0.0.0/16"
-	_, clusterCIDR, _ := net.ParseCIDR(cidr)
+	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(cidr)
 	// We have 256 free cidrs
 	a, err := NewCIDRSet(clusterCIDR, 24)
 	if err != nil {
@@ -890,7 +891,7 @@ func TestCidrSetMetricsHistogram(t *testing.T) {
 
 	// Allocate half of the range
 	// Occupy does not update the nextCandidate
-	_, halfClusterCIDR, _ := net.ParseCIDR("10.0.0.0/17")
+	_, halfClusterCIDR, _ := netutils.ParseCIDRSloppy("10.0.0.0/17")
 	a.Occupy(halfClusterCIDR)
 	em := testMetrics{
 		usage:      0.5,
@@ -917,7 +918,7 @@ func TestCidrSetMetricsHistogram(t *testing.T) {
 func TestCidrSetMetricsDual(t *testing.T) {
 	// create IPv4 cidrSet
 	cidrIPv4 := "10.0.0.0/16"
-	_, clusterCIDRv4, _ := net.ParseCIDR(cidrIPv4)
+	_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy(cidrIPv4)
 	a, err := NewCIDRSet(clusterCIDRv4, 24)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
@@ -925,7 +926,7 @@ func TestCidrSetMetricsDual(t *testing.T) {
 	clearMetrics(map[string]string{"clusterCIDR": cidrIPv4})
 	// create IPv6 cidrSet
 	cidrIPv6 := "2001:db8::/48"
-	_, clusterCIDRv6, _ := net.ParseCIDR(cidrIPv6)
+	_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy(cidrIPv6)
 	b, err := NewCIDRSet(clusterCIDRv6, 64)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
@@ -1012,7 +1013,7 @@ func expectMetrics(t *testing.T, label string, em testMetrics) {
 
 // Benchmarks
 func benchmarkAllocateAllIPv6(cidr string, subnetMaskSize int, b *testing.B) {
-	_, clusterCIDR, _ := net.ParseCIDR(cidr)
+	_, clusterCIDR, _ := netutils.ParseCIDRSloppy(cidr)
 	a, _ := NewCIDRSet(clusterCIDR, subnetMaskSize)
 	for n := 0; n < b.N; n++ {
 		// Allocate the whole range + 1

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -318,7 +319,7 @@ func needPodCIDRsUpdate(node *v1.Node, podCIDRs []*net.IPNet) (bool, error) {
 	if node.Spec.PodCIDR == "" {
 		return true, nil
 	}
-	_, nodePodCIDR, err := net.ParseCIDR(node.Spec.PodCIDR)
+	_, nodePodCIDR, err := netutils.ParseCIDRSloppy(node.Spec.PodCIDR)
 	if err != nil {
 		klog.ErrorS(err, "Found invalid node.Spec.PodCIDR", "node.Spec.PodCIDR", node.Spec.PodCIDR)
 		// We will try to overwrite with new CIDR(s)

--- a/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
+++ b/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -25,8 +26,9 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	informers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -119,7 +121,7 @@ func (c *Controller) Start(nodeInformer informers.NodeInformer) error {
 	}
 	for _, node := range nodes.Items {
 		if node.Spec.PodCIDR != "" {
-			_, cidrRange, err := net.ParseCIDR(node.Spec.PodCIDR)
+			_, cidrRange, err := netutils.ParseCIDRSloppy(node.Spec.PodCIDR)
 			if err == nil {
 				c.set.Occupy(cidrRange)
 				klog.V(3).Infof("Occupying CIDR for node %q (%v)", node.Name, node.Spec.PodCIDR)

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -21,8 +21,9 @@ import (
 	"net"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -224,7 +225,7 @@ func (r *rangeAllocator) occupyCIDRs(node *v1.Node) error {
 		return nil
 	}
 	for idx, cidr := range node.Spec.PodCIDRs {
-		_, podCIDR, err := net.ParseCIDR(cidr)
+		_, podCIDR, err := netutils.ParseCIDRSloppy(cidr)
 		if err != nil {
 			return fmt.Errorf("failed to parse node %s, CIDR %s", node.Name, node.Spec.PodCIDR)
 		}
@@ -286,7 +287,7 @@ func (r *rangeAllocator) ReleaseCIDR(node *v1.Node) error {
 	}
 
 	for idx, cidr := range node.Spec.PodCIDRs {
-		_, podCIDR, err := net.ParseCIDR(cidr)
+		_, podCIDR, err := netutils.ParseCIDRSloppy(cidr)
 		if err != nil {
 			return fmt.Errorf("failed to parse CIDR %s on Node %v: %v", cidr, node.Name, err)
 		}

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/testutil"
+	netutils "k8s.io/utils/net"
 )
 
 const testNodePollInterval = 10 * time.Millisecond
@@ -86,7 +87,7 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
 					return []*net.IPNet{clusterCIDRv4}
 				}(),
 				ServiceCIDR:          nil,
@@ -111,8 +112,8 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/8")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/8")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6}
 				}(),
 				ServiceCIDR:          nil,
@@ -140,7 +141,7 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
 					return []*net.IPNet{clusterCIDRv4}
 				}(),
 				ServiceCIDR:          nil,
@@ -168,8 +169,8 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/8")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/8")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6}
 				}(),
 				ServiceCIDR:          nil,
@@ -198,7 +199,7 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
 					return []*net.IPNet{clusterCIDRv4}
 				}(),
 				ServiceCIDR:          nil,
@@ -227,7 +228,7 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
 					return []*net.IPNet{clusterCIDRv4}
 				}(),
 				ServiceCIDR:          nil,
@@ -256,8 +257,8 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/8")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/8")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6}
 				}(),
 				ServiceCIDR:          nil,
@@ -286,8 +287,8 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/8")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("10.10.0.0/16")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/8")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6}
 				}(),
 				ServiceCIDR:          nil,
@@ -341,7 +342,7 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/24")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/24")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR:          nil,
@@ -366,11 +367,11 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/24")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/24")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR: func() *net.IPNet {
-					_, serviceCIDR, _ := net.ParseCIDR("127.123.234.0/26")
+					_, serviceCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/26")
 					return serviceCIDR
 				}(),
 				SecondaryServiceCIDR: nil,
@@ -395,11 +396,11 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/24")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/24")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR: func() *net.IPNet {
-					_, serviceCIDR, _ := net.ParseCIDR("127.123.234.0/26")
+					_, serviceCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/26")
 					return serviceCIDR
 				}(),
 				SecondaryServiceCIDR: nil,
@@ -426,12 +427,12 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("127.123.234.0/8")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/84")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("127.123.234.0/8")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/84")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6}
 				}(),
 				ServiceCIDR: func() *net.IPNet {
-					_, serviceCIDR, _ := net.ParseCIDR("127.123.234.0/26")
+					_, serviceCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/26")
 					return serviceCIDR
 				}(),
 				SecondaryServiceCIDR: nil,
@@ -452,12 +453,12 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("127.123.234.0/8")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/84")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("127.123.234.0/8")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/84")
 					return []*net.IPNet{clusterCIDRv6, clusterCIDRv4}
 				}(),
 				ServiceCIDR: func() *net.IPNet {
-					_, serviceCIDR, _ := net.ParseCIDR("127.123.234.0/26")
+					_, serviceCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/26")
 					return serviceCIDR
 				}(),
 				SecondaryServiceCIDR: nil,
@@ -478,13 +479,13 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("127.123.234.0/8")
-					_, clusterCIDRv6, _ := net.ParseCIDR("ace:cab:deca::/84")
-					_, clusterCIDRv4_2, _ := net.ParseCIDR("10.0.0.0/8")
+					_, clusterCIDRv4, _ := netutils.ParseCIDRSloppy("127.123.234.0/8")
+					_, clusterCIDRv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/84")
+					_, clusterCIDRv4_2, _ := netutils.ParseCIDRSloppy("10.0.0.0/8")
 					return []*net.IPNet{clusterCIDRv4, clusterCIDRv6, clusterCIDRv4_2}
 				}(),
 				ServiceCIDR: func() *net.IPNet {
-					_, serviceCIDR, _ := net.ParseCIDR("127.123.234.0/26")
+					_, serviceCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/26")
 					return serviceCIDR
 				}(),
 				SecondaryServiceCIDR: nil,
@@ -521,7 +522,7 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("10.10.0.0/22")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("10.10.0.0/22")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR:          nil,
@@ -557,7 +558,7 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 		// pre allocate the cidrs as per the test
 		for idx, allocatedList := range tc.allocatedCIDRs {
 			for _, allocated := range allocatedList {
-				_, cidr, err := net.ParseCIDR(allocated)
+				_, cidr, err := netutils.ParseCIDRSloppy(allocated)
 				if err != nil {
 					t.Fatalf("%v: unexpected error when parsing CIDR %v: %v", tc.description, allocated, err)
 				}
@@ -623,7 +624,7 @@ func TestAllocateOrOccupyCIDRFailure(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/28")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/28")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR:          nil,
@@ -654,7 +655,7 @@ func TestAllocateOrOccupyCIDRFailure(t *testing.T) {
 		// this is a bit of white box testing
 		for setIdx, allocatedList := range tc.allocatedCIDRs {
 			for _, allocated := range allocatedList {
-				_, cidr, err := net.ParseCIDR(allocated)
+				_, cidr, err := netutils.ParseCIDRSloppy(allocated)
 				if err != nil {
 					t.Fatalf("%v: unexpected error when parsing CIDR %v: %v", tc.description, cidr, err)
 				}
@@ -727,7 +728,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/28")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/28")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR:          nil,
@@ -759,7 +760,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 			},
 			allocatorParams: CIDRAllocatorParams{
 				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/28")
+					_, clusterCIDR, _ := netutils.ParseCIDRSloppy("127.123.234.0/28")
 					return []*net.IPNet{clusterCIDR}
 				}(),
 				ServiceCIDR:          nil,
@@ -796,7 +797,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 		// this is a bit of white box testing
 		for setIdx, allocatedList := range tc.allocatedCIDRs {
 			for _, allocated := range allocatedList {
-				_, cidr, err := net.ParseCIDR(allocated)
+				_, cidr, err := netutils.ParseCIDRSloppy(allocated)
 				if err != nil {
 					t.Fatalf("%v: unexpected error when parsing CIDR %v: %v", tc.description, allocated, err)
 				}

--- a/pkg/controller/nodeipam/ipam/sync/sync.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset"
 )
 
@@ -281,7 +282,7 @@ func (op *updateOp) updateAliasFromNode(ctx context.Context, sync *NodeSync, nod
 		return fmt.Errorf("cannot sync to cloud in mode %q", sync.mode)
 	}
 
-	_, aliasRange, err := net.ParseCIDR(node.Spec.PodCIDR)
+	_, aliasRange, err := netutils.ParseCIDRSloppy(node.Spec.PodCIDR)
 	if err != nil {
 		klog.Errorf("Could not parse PodCIDR (%q) for node %q: %v",
 			node.Spec.PodCIDR, node.Name, err)
@@ -364,7 +365,7 @@ func (op *deleteOp) run(sync *NodeSync) error {
 		return nil
 	}
 
-	_, cidrRange, err := net.ParseCIDR(op.node.Spec.PodCIDR)
+	_, cidrRange, err := netutils.ParseCIDRSloppy(op.node.Spec.PodCIDR)
 	if err != nil {
 		klog.Errorf("Deleted node %q has an invalid podCIDR %q: %v",
 			op.node.Name, op.node.Spec.PodCIDR, err)

--- a/pkg/controller/nodeipam/ipam/sync/sync_test.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync_test.go
@@ -28,12 +28,13 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam/test"
+	netutils "k8s.io/utils/net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
-	_, clusterCIDRRange, _ = net.ParseCIDR("10.1.0.0/16")
+	_, clusterCIDRRange, _ = netutils.ParseCIDRSloppy("10.1.0.0/16")
 )
 
 type fakeEvent struct {

--- a/pkg/controller/nodeipam/ipam/test/utils.go
+++ b/pkg/controller/nodeipam/ipam/test/utils.go
@@ -18,12 +18,14 @@ package test
 
 import (
 	"net"
+
+	netutils "k8s.io/utils/net"
 )
 
 // MustParseCIDR returns the CIDR range parsed from s or panics if the string
 // cannot be parsed.
 func MustParseCIDR(s string) *net.IPNet {
-	_, ret, err := net.ParseCIDR(s)
+	_, ret, err := netutils.ParseCIDRSloppy(s)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -89,8 +90,8 @@ func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			clusterCidrs, _ := netutils.ParseCIDRs(strings.Split(tc.clusterCIDR, ","))
-			_, serviceCIDRIpNet, _ := net.ParseCIDR(tc.serviceCIDR)
-			_, secondaryServiceCIDRIpNet, _ := net.ParseCIDR(tc.secondaryServiceCIDR)
+			_, serviceCIDRIpNet, _ := netutils.ParseCIDRSloppy(tc.serviceCIDR)
+			_, secondaryServiceCIDRIpNet, _ := netutils.ParseCIDRSloppy(tc.secondaryServiceCIDR)
 
 			if os.Getenv("EXIT_ON_FATAL") == "1" {
 				// This is the subprocess which runs the actual code.

--- a/pkg/controlplane/controller_test.go
+++ b/pkg/controlplane/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controlplane
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
@@ -28,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
+	netutils "k8s.io/utils/net"
 )
 
 func TestReconcileEndpoints(t *testing.T) {
@@ -401,7 +401,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		}
 		epAdapter := reconcilers.NewEndpointsAdapter(fakeClient.CoreV1(), nil)
 		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
-		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
+		err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
@@ -520,7 +520,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		}
 		epAdapter := reconcilers.NewEndpointsAdapter(fakeClient.CoreV1(), nil)
 		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, epAdapter)
-		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
+		err := reconciler.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
@@ -585,7 +585,7 @@ func TestEmptySubsets(t *testing.T) {
 	endpointPorts := []corev1.EndpointPort{
 		{Name: "foo", Port: 8080, Protocol: "TCP"},
 	}
-	err := reconciler.RemoveEndpoints("foo", net.ParseIP("1.2.3.4"), endpointPorts)
+	err := reconciler.RemoveEndpoints("foo", netutils.ParseIPSloppy("1.2.3.4"), endpointPorts)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -631,7 +631,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset()
 		master.ServiceClient = fakeClient.CoreV1()
-		master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
+		master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, netutils.ParseIPSloppy("1.2.3.4"), test.servicePorts, test.serviceType, false)
 		creates := []core.CreateAction{}
 		for _, action := range fakeClient.Actions() {
 			if action.GetVerb() == "create" {
@@ -913,7 +913,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset(test.service)
 		master.ServiceClient = fakeClient.CoreV1()
-		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, true)
+		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, netutils.ParseIPSloppy("1.2.3.4"), test.servicePorts, test.serviceType, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
@@ -972,7 +972,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset(test.service)
 		master.ServiceClient = fakeClient.CoreV1()
-		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
+		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, netutils.ParseIPSloppy("1.2.3.4"), test.servicePorts, test.serviceType, false)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -57,6 +57,7 @@ import (
 	certificatesrest "k8s.io/kubernetes/pkg/registry/certificates/rest"
 	corerest "k8s.io/kubernetes/pkg/registry/core/rest"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
+	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -72,7 +73,7 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 			APIServerServicePort:    443,
 			MasterCount:             1,
 			EndpointReconcilerType:  reconcilers.MasterCountReconcilerType,
-			ServiceIPRange:          net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)},
+			ServiceIPRange:          net.IPNet{IP: netutils.ParseIPSloppy("10.0.0.0"), Mask: net.CIDRMask(24, 32)},
 		},
 	}
 
@@ -101,7 +102,7 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 	config.GenericConfig.Version = &kubeVersion
 	config.ExtraConfig.StorageFactory = storageFactory
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}
-	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	config.GenericConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.ExtraConfig.KubeletClientConfig = kubeletclient.KubeletClientConfig{Port: 10250}
 	config.ExtraConfig.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -23,7 +23,6 @@ https://github.com/openshift/origin/blob/bb340c5dd5ff72718be86fb194dedc0faed7f4c
 
 import (
 	"context"
-	"net"
 	"reflect"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	netutils "k8s.io/utils/net"
 )
 
 type fakeLeases struct {
@@ -459,7 +459,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 
 		epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
 		r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-		err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
+		err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
@@ -560,7 +560,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			}
 			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-			err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
+			err := r.ReconcileEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts, false)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
@@ -680,7 +680,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			}
 			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
 			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
-			err := r.RemoveEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts)
+			err := r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}

--- a/pkg/kubeapiserver/options/options.go
+++ b/pkg/kubeapiserver/options/options.go
@@ -20,13 +20,14 @@ import (
 	"net"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
 )
 
 // DefaultServiceNodePortRange is the default port range for NodePort services.
 var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
 // DefaultServiceIPCIDR is a CIDR notation of IP range from which to allocate service cluster IPs
-var DefaultServiceIPCIDR = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+var DefaultServiceIPCIDR = net.IPNet{IP: netutils.ParseIPSloppy("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
 
 // DefaultEtcdPathPrefix is the default key prefix of etcd for API Server
 const DefaultEtcdPathPrefix = "/registry"

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -18,16 +18,15 @@ limitations under the License.
 package options
 
 import (
-	"net"
-
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	netutils "k8s.io/utils/net"
 )
 
 // NewSecureServingOptions gives default values for the kube-apiserver which are not the options wanted by
 // "normal" API servers running on the platform
 func NewSecureServingOptions() *genericoptions.SecureServingOptionsWithLoopback {
 	o := genericoptions.SecureServingOptions{
-		BindAddress: net.ParseIP("0.0.0.0"),
+		BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 		BindPort:    6443,
 		Required:    true,
 		ServerCert: genericoptions.GeneratableKeyCert{

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	netutils "k8s.io/utils/net"
 )
 
 // NewKubeletServerCertificateManager creates a certificate manager for the kubelet when retrieving a server certificate
@@ -159,13 +160,13 @@ func addressesToHostnamesAndIPs(addresses []v1.NodeAddress) (dnsNames []string, 
 
 		switch address.Type {
 		case v1.NodeHostName:
-			if ip := net.ParseIP(address.Address); ip != nil {
+			if ip := netutils.ParseIPSloppy(address.Address); ip != nil {
 				seenIPs[address.Address] = true
 			} else {
 				seenDNSNames[address.Address] = true
 			}
 		case v1.NodeExternalIP, v1.NodeInternalIP:
-			if ip := net.ParseIP(address.Address); ip != nil {
+			if ip := netutils.ParseIPSloppy(address.Address); ip != nil {
 				seenIPs[address.Address] = true
 			}
 		case v1.NodeExternalDNS, v1.NodeInternalDNS:
@@ -177,7 +178,7 @@ func addressesToHostnamesAndIPs(addresses []v1.NodeAddress) (dnsNames []string, 
 		dnsNames = append(dnsNames, dnsName)
 	}
 	for ip := range seenIPs {
-		ips = append(ips, net.ParseIP(ip))
+		ips = append(ips, netutils.ParseIPSloppy(ip))
 	}
 
 	// return in stable order

--- a/pkg/kubelet/certificate/kubelet_test.go
+++ b/pkg/kubelet/certificate/kubelet_test.go
@@ -21,7 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	netutils "k8s.io/utils/net"
 )
 
 func TestAddressesToHostnamesAndIPs(t *testing.T) {
@@ -62,7 +63,7 @@ func TestAddressesToHostnamesAndIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
 			},
 			wantDNSNames: []string{"hostname"},
-			wantIPs:      []net.IP{net.ParseIP("1.1.1.1")},
+			wantIPs:      []net.IP{netutils.ParseIPSloppy("1.1.1.1")},
 		},
 		{
 			name: "order values",
@@ -75,7 +76,7 @@ func TestAddressesToHostnamesAndIPs(t *testing.T) {
 				{Type: v1.NodeInternalIP, Address: "3.3.3.3"},
 			},
 			wantDNSNames: []string{"hostname-1", "hostname-2", "hostname-3"},
-			wantIPs:      []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("3.3.3.3")},
+			wantIPs:      []net.IP{netutils.ParseIPSloppy("1.1.1.1"), netutils.ParseIPSloppy("2.2.2.2"), netutils.ParseIPSloppy("3.3.3.3")},
 		},
 		{
 			name: "handle IP and DNS hostnames",
@@ -84,7 +85,7 @@ func TestAddressesToHostnamesAndIPs(t *testing.T) {
 				{Type: v1.NodeHostName, Address: "1.1.1.1"},
 			},
 			wantDNSNames: []string{"hostname"},
-			wantIPs:      []net.IP{net.ParseIP("1.1.1.1")},
+			wantIPs:      []net.IP{netutils.ParseIPSloppy("1.1.1.1")},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
@@ -1,3 +1,4 @@
+//go:build !dockerless
 // +build !dockerless
 
 /*
@@ -21,12 +22,12 @@ package hostport
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	netutils "k8s.io/utils/net"
 )
 
 type fakeChain struct {
@@ -192,7 +193,7 @@ func normalizeRule(rule string) (string, error) {
 		arg := remaining[:end]
 
 		// Normalize un-prefixed IP addresses like iptables does
-		if net.ParseIP(arg) != nil {
+		if netutils.ParseIPSloppy(arg) != nil {
 			arg += "/32"
 		}
 

--- a/pkg/kubelet/dockershim/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_manager_test.go
@@ -1,3 +1,4 @@
+//go:build !dockerless
 // +build !dockerless
 
 /*
@@ -20,7 +21,6 @@ package hostport
 
 import (
 	"bytes"
-	"net"
 	"strings"
 	"testing"
 
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	"k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 )
 
 func TestOpenCloseHostports(t *testing.T) {
@@ -249,7 +250,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod1",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.2"),
+				IP:          netutils.ParseIPSloppy("10.1.1.2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -276,7 +277,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod2",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.3"),
+				IP:          netutils.ParseIPSloppy("10.1.1.3"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -303,7 +304,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod3",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.4"),
+				IP:          netutils.ParseIPSloppy("10.1.1.4"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -320,7 +321,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod3",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("192.168.12.12"),
+				IP:          netutils.ParseIPSloppy("192.168.12.12"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -337,7 +338,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod4",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::2"),
+				IP:          netutils.ParseIPSloppy("2001:beef::2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -356,7 +357,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod5",
 				Namespace:   "ns5",
-				IP:          net.ParseIP("10.1.1.5"),
+				IP:          netutils.ParseIPSloppy("10.1.1.5"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -380,7 +381,7 @@ func TestHostportManager(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod6",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.2"),
+				IP:          netutils.ParseIPSloppy("10.1.1.2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -555,7 +556,7 @@ func TestHostportManagerIPv6(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod1",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::2"),
+				IP:          netutils.ParseIPSloppy("2001:beef::2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -581,7 +582,7 @@ func TestHostportManagerIPv6(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod2",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::3"),
+				IP:          netutils.ParseIPSloppy("2001:beef::3"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -607,7 +608,7 @@ func TestHostportManagerIPv6(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod3",
 				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::4"),
+				IP:          netutils.ParseIPSloppy("2001:beef::4"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{
@@ -623,7 +624,7 @@ func TestHostportManagerIPv6(t *testing.T) {
 			mapping: &PodPortMapping{
 				Name:        "pod4",
 				Namespace:   "ns2",
-				IP:          net.ParseIP("192.168.2.2"),
+				IP:          netutils.ParseIPSloppy("192.168.2.2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
 					{

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && !dockerless
 // +build linux,!dockerless
 
 /*
@@ -259,7 +260,7 @@ func (plugin *kubenetNetworkPlugin) Event(name string, details map[string]interf
 	}
 
 	for idx, currentPodCIDR := range podCIDRs {
-		_, cidr, err := net.ParseCIDR(currentPodCIDR)
+		_, cidr, err := netutils.ParseCIDRSloppy(currentPodCIDR)
 		if nil != err {
 			klog.InfoS("Failed to generate CNI network config with cidr at the index", "podCIDR", currentPodCIDR, "index", idx, "err", err)
 			return
@@ -451,7 +452,7 @@ func (plugin *kubenetNetworkPlugin) addPortMapping(id kubecontainer.ContainerID,
 			Namespace:    namespace,
 			Name:         name,
 			PortMappings: portMappings,
-			IP:           net.ParseIP(ip),
+			IP:           netutils.ParseIPSloppy(ip),
 			HostNetwork:  false,
 		}
 		if netutils.IsIPv6(pm.IP) {
@@ -635,7 +636,7 @@ func (plugin *kubenetNetworkPlugin) getNetworkStatus(id kubecontainer.ContainerI
 
 	ips := make([]net.IP, 0, len(iplist))
 	for _, ip := range iplist {
-		ips = append(ips, net.ParseIP(ip))
+		ips = append(ips, netutils.ParseIPSloppy(ip))
 	}
 
 	return &network.PodNetworkStatus{

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
@@ -1,3 +1,4 @@
+//go:build !dockerless
 // +build !dockerless
 
 /*
@@ -40,6 +41,7 @@ import (
 	sysctltest "k8s.io/kubernetes/pkg/util/sysctl/testing"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+	netutils "k8s.io/utils/net"
 )
 
 // test it fulfills the NetworkPlugin interface
@@ -337,7 +339,7 @@ func TestGetRoutesConfig(t *testing.T) {
 	} {
 		var cidrs []*net.IPNet
 		for _, c := range test.cidrs {
-			_, cidr, err := net.ParseCIDR(c)
+			_, cidr, err := netutils.ParseCIDRSloppy(c)
 			assert.NoError(t, err)
 			cidrs = append(cidrs, cidr)
 		}
@@ -378,7 +380,7 @@ func TestGetRangesConfig(t *testing.T) {
 	} {
 		var cidrs []*net.IPNet
 		for _, c := range test.cidrs {
-			_, cidr, err := net.ParseCIDR(c)
+			_, cidr, err := netutils.ParseCIDRSloppy(c)
 			assert.NoError(t, err)
 			cidrs = append(cidrs, cidr)
 		}

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -1,3 +1,4 @@
+//go:build !dockerless
 // +build !dockerless
 
 /*
@@ -36,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/metrics"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilexec "k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -248,7 +250,7 @@ func getOnePodIP(execer utilexec.Interface, nsenterPath, netnsPath, interfaceNam
 	if len(fields) < 4 {
 		return nil, fmt.Errorf("unexpected address output %s ", lines[0])
 	}
-	ip, _, err := net.ParseCIDR(fields[3])
+	ip, _, err := netutils.ParseCIDRSloppy(fields[3])
 	if err != nil {
 		return nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
 	}

--- a/pkg/kubelet/dockershim/network/testing/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/testing/plugins_test.go
@@ -1,3 +1,4 @@
+//go:build !dockerless
 // +build !dockerless
 
 /*
@@ -20,7 +21,6 @@ package testing
 
 import (
 	"fmt"
-	"net"
 	"sync"
 	"testing"
 
@@ -29,6 +29,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 	sysctltest "k8s.io/kubernetes/pkg/util/sysctl/testing"
+	netutils "k8s.io/utils/net"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -96,7 +97,7 @@ func TestPluginManager(t *testing.T) {
 		containerID := kubecontainer.ContainerID{ID: podName}
 
 		fnp.EXPECT().SetUpPod("", podName, containerID).Return(nil).Times(4)
-		fnp.EXPECT().GetPodNetworkStatus("", podName, containerID).Return(&network.PodNetworkStatus{IP: net.ParseIP("1.2.3.4")}, nil).Times(4)
+		fnp.EXPECT().GetPodNetworkStatus("", podName, containerID).Return(&network.PodNetworkStatus{IP: netutils.ParseIPSloppy("1.2.3.4")}, nil).Times(4)
 		fnp.EXPECT().TearDownPod("", podName, containerID).Return(nil).Times(4)
 
 		for x := 0; x < 4; x++ {
@@ -173,7 +174,7 @@ func (p *hookableFakeNetworkPlugin) TearDownPod(string, string, kubecontainer.Co
 }
 
 func (p *hookableFakeNetworkPlugin) GetPodNetworkStatus(string, string, kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
-	return &network.PodNetworkStatus{IP: net.ParseIP("10.1.2.3")}, nil
+	return &network.PodNetworkStatus{IP: netutils.ParseIPSloppy("10.1.2.3")}, nil
 }
 
 func (p *hookableFakeNetworkPlugin) Status() error {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -38,6 +38,7 @@ import (
 	libcontaineruserns "github.com/opencontainers/runc/libcontainer/userns"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/integer"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -517,7 +518,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	clusterDNS := make([]net.IP, 0, len(kubeCfg.ClusterDNS))
 	for _, ipEntry := range kubeCfg.ClusterDNS {
-		ip := net.ParseIP(ipEntry)
+		ip := netutils.ParseIPSloppy(ipEntry)
 		if ip == nil {
 			klog.InfoS("Invalid clusterDNS IP", "IP", ipEntry)
 		} else {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -58,6 +58,7 @@ import (
 	kubeletvolume "k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	taintutil "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/pkg/volume/util"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -2484,7 +2485,7 @@ func TestValidateNodeIPParam(t *testing.T) {
 		tests = append(tests, successTest)
 	}
 	for _, test := range tests {
-		err := validateNodeIP(net.ParseIP(test.nodeIP))
+		err := validateNodeIP(netutils.ParseIPSloppy(test.nodeIP))
 		if test.success {
 			assert.NoError(t, err, "test %s", test.testName)
 		} else {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -42,6 +42,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	netutils "k8s.io/utils/net"
 
 	// TODO: remove this import if
 	// api.Registry.GroupOrDie(v1.GroupName).GroupVersions[0].String() is changed
@@ -3426,7 +3427,7 @@ func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
 			if tc.nodeIP != "" {
-				kl.nodeIPs = []net.IP{net.ParseIP(tc.nodeIP)}
+				kl.nodeIPs = []net.IP{netutils.ParseIPSloppy(tc.nodeIP)}
 			}
 
 			pod := podWithUIDNameNs("12345", "test-pod", "test-namespace")
@@ -3530,7 +3531,7 @@ func TestSortPodIPs(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
 			if tc.nodeIP != "" {
-				kl.nodeIPs = []net.IP{net.ParseIP(tc.nodeIP)}
+				kl.nodeIPs = []net.IP{netutils.ParseIPSloppy(tc.nodeIP)}
 			}
 
 			podIPs := kl.sortPodIPs(tc.podIPs)

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -18,7 +18,6 @@ package kuberuntime
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 	"runtime"
 	"sort"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
+	netutils "k8s.io/utils/net"
 )
 
 // createPodSandbox creates a pod sandbox and returns (podSandBoxID, message, error).
@@ -298,7 +298,7 @@ func (m *kubeGenericRuntimeManager) determinePodSandboxIPs(podNamespace, podName
 
 	// pick primary IP
 	if len(podSandbox.Network.Ip) != 0 {
-		if net.ParseIP(podSandbox.Network.Ip) == nil {
+		if netutils.ParseIPSloppy(podSandbox.Network.Ip) == nil {
 			klog.InfoS("Pod Sandbox reported an unparseable primary IP", "pod", klog.KRef(podNamespace, podName), "IP", podSandbox.Network.Ip)
 			return nil
 		}
@@ -307,7 +307,7 @@ func (m *kubeGenericRuntimeManager) determinePodSandboxIPs(podNamespace, podName
 
 	// pick additional ips, if cri reported them
 	for _, podIP := range podSandbox.Network.AdditionalIps {
-		if nil == net.ParseIP(podIP.Ip) {
+		if nil == netutils.ParseIPSloppy(podIP.Ip) {
 			klog.InfoS("Pod Sandbox reported an unparseable additional IP", "pod", klog.KRef(podNamespace, podName), "IP", podIP.Ip)
 			return nil
 		}

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -35,6 +35,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
+	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -350,7 +351,7 @@ func TestGetPodDNSType(t *testing.T) {
 	}
 	testClusterDNSDomain := "TEST"
 	clusterNS := "203.0.113.1"
-	testClusterDNS := []net.IP{net.ParseIP(clusterNS)}
+	testClusterDNS := []net.IP{netutils.ParseIPSloppy(clusterNS)}
 
 	configurer := NewConfigurer(recorder, nodeRef, nil, nil, testClusterDNSDomain, "")
 
@@ -477,7 +478,7 @@ func testGetPodDNS(t *testing.T) {
 	}
 	clusterNS := "203.0.113.1"
 	testClusterDNSDomain := "kubernetes.io"
-	testClusterDNS := []net.IP{net.ParseIP(clusterNS)}
+	testClusterDNS := []net.IP{netutils.ParseIPSloppy(clusterNS)}
 
 	configurer := NewConfigurer(recorder, nodeRef, nil, testClusterDNS, testClusterDNSDomain, "")
 
@@ -606,7 +607,7 @@ func TestGetPodDNSCustom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	configurer := NewConfigurer(recorder, nodeRef, nil, []net.IP{net.ParseIP(testClusterNameserver)}, testClusterDNSDomain, tmpfile.Name())
+	configurer := NewConfigurer(recorder, nodeRef, nil, []net.IP{netutils.ParseIPSloppy(testClusterNameserver)}, testClusterDNSDomain, tmpfile.Name())
 
 	testCases := []struct {
 		desc              string

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -42,6 +42,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/volume"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/klog/v2"
 )
@@ -149,13 +150,13 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 				// prefer addresses of the matching family
 				sortedAddresses := make([]v1.NodeAddress, 0, len(cloudNodeAddresses))
 				for _, nodeAddress := range cloudNodeAddresses {
-					ip := net.ParseIP(nodeAddress.Address)
+					ip := netutils.ParseIPSloppy(nodeAddress.Address)
 					if ip == nil || isPreferredIPFamily(ip) {
 						sortedAddresses = append(sortedAddresses, nodeAddress)
 					}
 				}
 				for _, nodeAddress := range cloudNodeAddresses {
-					ip := net.ParseIP(nodeAddress.Address)
+					ip := netutils.ParseIPSloppy(nodeAddress.Address)
 					if ip != nil && !isPreferredIPFamily(ip) {
 						sortedAddresses = append(sortedAddresses, nodeAddress)
 					}
@@ -219,7 +220,7 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 			// unless nodeIP is "::", in which case it is reversed.
 			if nodeIPSpecified {
 				ipAddr = nodeIP
-			} else if addr := net.ParseIP(hostname); addr != nil {
+			} else if addr := netutils.ParseIPSloppy(hostname); addr != nil {
 				ipAddr = addr
 			} else {
 				var addrs []net.IP

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -27,7 +27,7 @@ import (
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,7 @@ func TestNodeAddress(t *testing.T) {
 	}{
 		{
 			name:   "A single InternalIP",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
@@ -79,7 +80,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "NodeIP is external",
-			nodeIP: net.ParseIP("55.55.55.55"),
+			nodeIP: netutils.ParseIPSloppy("55.55.55.55"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -95,7 +96,7 @@ func TestNodeAddress(t *testing.T) {
 		{
 			// Accommodating #45201 and #49202
 			name:   "InternalIP and ExternalIP are the same",
-			nodeIP: net.ParseIP("55.55.55.55"),
+			nodeIP: netutils.ParseIPSloppy("55.55.55.55"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
 				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
@@ -112,7 +113,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "An Internal/ExternalIP, an Internal/ExternalDNS",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -131,7 +132,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "An Internal with multiple internal IPs",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "10.2.2.2"},
@@ -148,7 +149,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "An InternalIP that isn't valid: should error",
-			nodeIP: net.ParseIP("10.2.2.2"),
+			nodeIP: netutils.ParseIPSloppy("10.2.2.2"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -181,7 +182,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "cloud reports hostname, nodeIP is set, no override",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -211,7 +212,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:                  "cloud provider is external",
-			nodeIP:                net.ParseIP("10.0.0.1"),
+			nodeIP:                netutils.ParseIPSloppy("10.0.0.1"),
 			nodeAddresses:         []v1.NodeAddress{},
 			externalCloudProvider: true,
 			expectedAddresses: []v1.NodeAddress{
@@ -250,7 +251,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -266,7 +267,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match with same type as nodeIP",
-			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
@@ -323,7 +324,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "Dual-stack cloud, IPv4 first, request IPv4",
-			nodeIP: net.ParseIP("0.0.0.0"),
+			nodeIP: netutils.ParseIPSloppy("0.0.0.0"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
@@ -338,7 +339,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "Dual-stack cloud, IPv6 first, request IPv4",
-			nodeIP: net.ParseIP("0.0.0.0"),
+			nodeIP: netutils.ParseIPSloppy("0.0.0.0"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
@@ -353,7 +354,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "Dual-stack cloud, IPv4 first, request IPv6",
-			nodeIP: net.ParseIP("::"),
+			nodeIP: netutils.ParseIPSloppy("::"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
@@ -368,7 +369,7 @@ func TestNodeAddress(t *testing.T) {
 		},
 		{
 			name:   "Dual-stack cloud, IPv6 first, request IPv6",
-			nodeIP: net.ParseIP("::"),
+			nodeIP: netutils.ParseIPSloppy("::"),
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
@@ -448,7 +449,7 @@ func TestNodeAddress_NoCloudProvider(t *testing.T) {
 	}{
 		{
 			name:    "Single --node-ip",
-			nodeIPs: []net.IP{net.ParseIP("10.1.1.1")},
+			nodeIPs: []net.IP{netutils.ParseIPSloppy("10.1.1.1")},
 			expectedAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
@@ -456,7 +457,7 @@ func TestNodeAddress_NoCloudProvider(t *testing.T) {
 		},
 		{
 			name:    "Dual --node-ips",
-			nodeIPs: []net.IP{net.ParseIP("10.1.1.1"), net.ParseIP("fd01::1234")},
+			nodeIPs: []net.IP{netutils.ParseIPSloppy("10.1.1.1"), netutils.ParseIPSloppy("fd01::1234")},
 			expectedAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "fd01::1234"},

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/utils/clock"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,7 +145,7 @@ func ListenAndServeKubeletServer(
 	tlsOptions *TLSOptions,
 	auth AuthInterface) {
 
-	address := net.ParseIP(kubeCfg.Address)
+	address := netutils.ParseIPSloppy(kubeCfg.Address)
 	port := uint(kubeCfg.Port)
 	klog.InfoS("Starting to listen", "address", address, "port", port)
 	handler := NewServer(host, resourceAnalyzer, auth, kubeCfg)

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -18,7 +18,6 @@ package kubemark
 
 import (
 	"fmt"
-	"net"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +34,7 @@ import (
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilexec "k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 
 	"k8s.io/klog/v2"
@@ -83,7 +83,7 @@ func NewHollowProxyOrDie(
 		nodeIP := utilnode.GetNodeIP(client, nodeName)
 		if nodeIP == nil {
 			klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1")
-			nodeIP = net.ParseIP("127.0.0.1")
+			nodeIP = netutils.ParseIPSloppy("127.0.0.1")
 		}
 		// Real proxier with fake iptables, sysctl, etc underneath it.
 		//var err error

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"net"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
+	netutils "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 )
 
@@ -131,7 +131,7 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 // based on the given bind address. IPv6 addresses are enclosed in square
 // brackets for appending port.
 func getDefaultAddresses(bindAddress string) (defaultHealthzAddress, defaultMetricsAddress string) {
-	if net.ParseIP(bindAddress).To4() != nil {
+	if netutils.ParseIPSloppy(bindAddress).To4() != nil {
 		return "0.0.0.0", "127.0.0.1"
 	}
 	return "[::]", "[::1]"

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -66,7 +66,7 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(newPath.Child("ConfigSyncPeriod"), config.ConfigSyncPeriod, "must be greater than 0"))
 	}
 
-	if net.ParseIP(config.BindAddress) == nil {
+	if netutils.ParseIPSloppy(config.BindAddress) == nil {
 		allErrs = append(allErrs, field.Invalid(newPath.Child("BindAddress"), config.BindAddress, "not a valid textual representation of an IP address"))
 	}
 
@@ -94,7 +94,7 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(newPath.Child("ClusterCIDR"), config.ClusterCIDR, "only one CIDR allowed (e.g. 10.100.0.0/16 or fde4:8dba:82e1::/48)"))
 		// if we are here means that len(cidrs) == 1, we need to validate it
 		default:
-			if _, _, err := net.ParseCIDR(config.ClusterCIDR); err != nil {
+			if _, _, err := netutils.ParseCIDRSloppy(config.ClusterCIDR); err != nil {
 				allErrs = append(allErrs, field.Invalid(newPath.Child("ClusterCIDR"), config.ClusterCIDR, "must be a valid CIDR block (e.g. 10.100.0.0/16 or fde4:8dba:82e1::/48)"))
 			}
 		}
@@ -228,7 +228,7 @@ func validateHostPort(input string, fldPath *field.Path) field.ErrorList {
 		return allErrs
 	}
 
-	if ip := net.ParseIP(hostIP); ip == nil {
+	if ip := netutils.ParseIPSloppy(hostIP); ip == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, hostIP, "must be a valid IP"))
 	}
 
@@ -275,7 +275,7 @@ func validateKubeProxyNodePortAddress(nodePortAddresses []string, fldPath *field
 	allErrs := field.ErrorList{}
 
 	for i := range nodePortAddresses {
-		if _, _, err := net.ParseCIDR(nodePortAddresses[i]); err != nil {
+		if _, _, err := netutils.ParseCIDRSloppy(nodePortAddresses[i]); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), nodePortAddresses[i], "must be a valid CIDR"))
 		}
 	}
@@ -305,7 +305,7 @@ func validateIPVSExcludeCIDRs(excludeCIDRs []string, fldPath *field.Path) field.
 	allErrs := field.ErrorList{}
 
 	for i := range excludeCIDRs {
-		if _, _, err := net.ParseCIDR(excludeCIDRs[i]); err != nil {
+		if _, _, err := netutils.ParseCIDRSloppy(excludeCIDRs[i]); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), excludeCIDRs[i], "must be a valid CIDR"))
 		}
 	}

--- a/pkg/proxy/ipvs/graceful_termination_test.go
+++ b/pkg/proxy/ipvs/graceful_termination_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package ipvs
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
 	utilipvstest "k8s.io/kubernetes/pkg/util/ipvs/testing"
+	netutils "k8s.io/utils/net"
 )
 
 func Test_GracefulDeleteRS(t *testing.T) {
@@ -37,12 +37,12 @@ func Test_GracefulDeleteRS(t *testing.T) {
 		{
 			name: "graceful delete, no connections results in deleting the real server immediatetly",
 			vs: &utilipvs.VirtualServer{
-				Address:  net.ParseIP("1.1.1.1"),
+				Address:  netutils.ParseIPSloppy("1.1.1.1"),
 				Protocol: "tcp",
 				Port:     uint16(80),
 			},
 			rs: &utilipvs.RealServer{
-				Address:      net.ParseIP("10.0.0.1"),
+				Address:      netutils.ParseIPSloppy("10.0.0.1"),
 				Port:         uint16(80),
 				Weight:       100,
 				ActiveConn:   0,
@@ -55,7 +55,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -67,7 +67,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   0,
@@ -83,7 +83,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -101,12 +101,12 @@ func Test_GracefulDeleteRS(t *testing.T) {
 		{
 			name: "graceful delete, real server has active connections, weight should be 0 but don't delete",
 			vs: &utilipvs.VirtualServer{
-				Address:  net.ParseIP("1.1.1.1"),
+				Address:  netutils.ParseIPSloppy("1.1.1.1"),
 				Protocol: "tcp",
 				Port:     uint16(80),
 			},
 			rs: &utilipvs.RealServer{
-				Address:      net.ParseIP("10.0.0.1"),
+				Address:      netutils.ParseIPSloppy("10.0.0.1"),
 				Port:         uint16(80),
 				Weight:       100,
 				ActiveConn:   10,
@@ -119,7 +119,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -131,7 +131,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   10,
@@ -147,7 +147,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -159,7 +159,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       0,
 							ActiveConn:   10,
@@ -173,12 +173,12 @@ func Test_GracefulDeleteRS(t *testing.T) {
 		{
 			name: "graceful delete, real server has in-active connections, weight should be 0 but don't delete",
 			vs: &utilipvs.VirtualServer{
-				Address:  net.ParseIP("1.1.1.1"),
+				Address:  netutils.ParseIPSloppy("1.1.1.1"),
 				Protocol: "tcp",
 				Port:     uint16(80),
 			},
 			rs: &utilipvs.RealServer{
-				Address:      net.ParseIP("10.0.0.1"),
+				Address:      netutils.ParseIPSloppy("10.0.0.1"),
 				Port:         uint16(80),
 				Weight:       100,
 				ActiveConn:   0,
@@ -191,7 +191,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -203,7 +203,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   0,
@@ -219,7 +219,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -231,7 +231,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       0,
 							ActiveConn:   0,
@@ -245,12 +245,12 @@ func Test_GracefulDeleteRS(t *testing.T) {
 		{
 			name: "graceful delete, real server has connections, but udp connections are deleted immediately",
 			vs: &utilipvs.VirtualServer{
-				Address:  net.ParseIP("1.1.1.1"),
+				Address:  netutils.ParseIPSloppy("1.1.1.1"),
 				Protocol: "udp",
 				Port:     uint16(80),
 			},
 			rs: &utilipvs.RealServer{
-				Address:      net.ParseIP("10.0.0.1"),
+				Address:      netutils.ParseIPSloppy("10.0.0.1"),
 				Port:         uint16(80),
 				Weight:       100,
 				ActiveConn:   10,
@@ -263,7 +263,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "udp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "udp",
 						Port:     uint16(80),
 					},
@@ -275,7 +275,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "udp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   10,
@@ -291,7 +291,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "udp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "udp",
 						Port:     uint16(80),
 					},
@@ -309,12 +309,12 @@ func Test_GracefulDeleteRS(t *testing.T) {
 		{
 			name: "graceful delete, real server mismatch should be no-op",
 			vs: &utilipvs.VirtualServer{
-				Address:  net.ParseIP("1.1.1.1"),
+				Address:  netutils.ParseIPSloppy("1.1.1.1"),
 				Protocol: "tcp",
 				Port:     uint16(80),
 			},
 			rs: &utilipvs.RealServer{
-				Address:      net.ParseIP("10.0.0.1"),
+				Address:      netutils.ParseIPSloppy("10.0.0.1"),
 				Port:         uint16(81), // port mismatched
 				Weight:       100,
 				ActiveConn:   0,
@@ -327,7 +327,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -339,7 +339,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   0,
@@ -355,7 +355,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Port:     80,
 						Protocol: "tcp",
 					}: {
-						Address:  net.ParseIP("1.1.1.1"),
+						Address:  netutils.ParseIPSloppy("1.1.1.1"),
 						Protocol: "tcp",
 						Port:     uint16(80),
 					},
@@ -367,7 +367,7 @@ func Test_GracefulDeleteRS(t *testing.T) {
 						Protocol: "tcp",
 					}: {
 						{
-							Address:      net.ParseIP("10.0.0.1"),
+							Address:      netutils.ParseIPSloppy("10.0.0.1"),
 							Port:         uint16(80),
 							Weight:       100,
 							ActiveConn:   0,

--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -20,9 +21,9 @@ package ipvs
 
 import (
 	"fmt"
-	"net"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	netutils "k8s.io/utils/net"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -44,7 +45,7 @@ func (h *netlinkHandle) EnsureAddressBind(address, devName string) (exist bool, 
 	if err != nil {
 		return false, fmt.Errorf("error get interface: %s, err: %v", devName, err)
 	}
-	addr := net.ParseIP(address)
+	addr := netutils.ParseIPSloppy(address)
 	if addr == nil {
 		return false, fmt.Errorf("error parse ip address: %s", address)
 	}
@@ -64,7 +65,7 @@ func (h *netlinkHandle) UnbindAddress(address, devName string) error {
 	if err != nil {
 		return fmt.Errorf("error get interface: %s, err: %v", devName, err)
 	}
-	addr := net.ParseIP(address)
+	addr := netutils.ParseIPSloppy(address)
 	if addr == nil {
 		return fmt.Errorf("error parse ip address: %s", address)
 	}

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -155,7 +156,7 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 
 	clusterIP := utilproxy.GetClusterIPByFamily(sct.ipFamily, service)
 	info := &BaseServiceInfo{
-		clusterIP:             net.ParseIP(clusterIP),
+		clusterIP:             netutils.ParseIPSloppy(clusterIP),
 		port:                  int(port.Port),
 		protocol:              port.Protocol,
 		nodePort:              int(port.NodePort),

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package proxy
 
 import (
-	"net"
 	"reflect"
 	"testing"
 	"time"
@@ -29,13 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	netutils "k8s.io/utils/net"
 )
 
 const testHostname = "test-hostname"
 
 func makeTestServiceInfo(clusterIP string, port int, protocol string, healthcheckNodePort int, svcInfoFuncs ...func(*BaseServiceInfo)) *BaseServiceInfo {
 	info := &BaseServiceInfo{
-		clusterIP: net.ParseIP(clusterIP),
+		clusterIP: netutils.ParseIPSloppy(clusterIP),
 		port:      port,
 		protocol:  v1.Protocol(protocol),
 	}

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -39,6 +39,7 @@ import (
 	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -328,7 +329,7 @@ func TestTCPProxy(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +354,7 @@ func TestUDPProxy(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +379,7 @@ func TestUDPProxyTimeout(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +418,7 @@ func TestMultiPortProxy(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +441,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 	lb := NewLoadBalancerRR()
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +474,7 @@ func TestTCPProxyStop(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +506,7 @@ func TestUDPProxyStop(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +538,7 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +570,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -602,7 +603,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +641,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +679,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -716,7 +717,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -754,7 +755,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -793,7 +794,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 
 	fexec := makeFakeExec()
 
-	p, err := createProxier(lb, net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(lb, netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Second, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -851,7 +852,7 @@ func TestOnServiceAddChangeMap(t *testing.T) {
 	fexec := makeFakeExec()
 
 	// Use long minSyncPeriod so we can test that immediate syncs work
-	p, err := createProxier(NewLoadBalancerRR(), net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Minute, udpIdleTimeoutForTest, newProxySocket)
+	p, err := createProxier(NewLoadBalancerRR(), netutils.ParseIPSloppy("0.0.0.0"), ipttest.NewFake(), fexec, netutils.ParseIPSloppy("127.0.0.1"), nil, time.Minute, time.Minute, udpIdleTimeoutForTest, newProxySocket)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/proxy/util/endpoints.go
+++ b/pkg/proxy/util/endpoints.go
@@ -22,13 +22,14 @@ import (
 	"strconv"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 // IPPart returns just the IP part of an IP or IP:port or endpoint string. If the IP
 // part is an IPv6 address enclosed in brackets (e.g. "[fd00:1::5]:9999"),
 // then the brackets are stripped as well.
 func IPPart(s string) string {
-	if ip := net.ParseIP(s); ip != nil {
+	if ip := netutils.ParseIPSloppy(s); ip != nil {
 		// IP address without port
 		return s
 	}
@@ -39,7 +40,7 @@ func IPPart(s string) string {
 		return ""
 	}
 	// Check if host string is a valid IP address
-	ip := net.ParseIP(host)
+	ip := netutils.ParseIPSloppy(host)
 	if ip == nil {
 		klog.Errorf("invalid IP part '%s'", host)
 		return ""

--- a/pkg/proxy/util/endpoints_test.go
+++ b/pkg/proxy/util/endpoints_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"net"
 	"testing"
+
+	netutils "k8s.io/utils/net"
 )
 
 func TestIPPart(t *testing.T) {
@@ -112,7 +113,7 @@ func TestToCIDR(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		ip := net.ParseIP(tc.ip)
+		ip := netutils.ParseIPSloppy(tc.ip)
 		addr := ToCIDR(ip)
 		if addr != tc.expectedAddr {
 			t.Errorf("Unexpected host address for %s: Expected: %s, Got %s", tc.ip, tc.expectedAddr, addr)

--- a/pkg/proxy/util/iptables/traffic.go
+++ b/pkg/proxy/util/iptables/traffic.go
@@ -18,11 +18,10 @@ package iptables
 
 import (
 	"fmt"
-	"net"
 
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 // LocalTrafficDetector in a interface to take action (jump) based on whether traffic originated locally
@@ -66,10 +65,10 @@ type detectLocalByCIDR struct {
 // NewDetectLocalByCIDR implements the LocalTrafficDetector interface using a CIDR. This can be used when a single CIDR
 // range can be used to capture the notion of local traffic.
 func NewDetectLocalByCIDR(cidr string, ipt utiliptables.Interface) (LocalTrafficDetector, error) {
-	if utilnet.IsIPv6CIDRString(cidr) != ipt.IsIPv6() {
+	if netutils.IsIPv6CIDRString(cidr) != ipt.IsIPv6() {
 		return nil, fmt.Errorf("CIDR %s has incorrect IP version: expect isIPv6=%t", cidr, ipt.IsIPv6())
 	}
-	_, _, err := net.ParseCIDR(cidr)
+	_, _, err := netutils.ParseCIDRSloppy(cidr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fake "k8s.io/kubernetes/pkg/proxy/util/testing"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 func TestValidateWorks(t *testing.T) {
@@ -141,7 +141,7 @@ func (r *dummyResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IP
 	}
 	resp := []net.IPAddr{}
 	for _, ipString := range r.ips {
-		resp = append(resp, net.IPAddr{IP: net.ParseIP(ipString)})
+		resp = append(resp, net.IPAddr{IP: netutils.ParseIPSloppy(ipString)})
 	}
 	return resp, nil
 }
@@ -187,13 +187,13 @@ func TestIsAllowedHost(t *testing.T) {
 	for i := range testCases {
 		var denyList []*net.IPNet
 		for _, cidrStr := range testCases[i].denied {
-			_, ipNet, err := net.ParseCIDR(cidrStr)
+			_, ipNet, err := netutils.ParseCIDRSloppy(cidrStr)
 			if err != nil {
 				t.Fatalf("bad IP for test case: %v: %v", cidrStr, err)
 			}
 			denyList = append(denyList, ipNet)
 		}
-		got := IsAllowedHost(net.ParseIP(testCases[i].ip), denyList)
+		got := IsAllowedHost(netutils.ParseIPSloppy(testCases[i].ip), denyList)
 		if testCases[i].want != got {
 			t.Errorf("case %d: expected %v, got %v", i, testCases[i].want, got)
 		}
@@ -281,7 +281,7 @@ func TestShouldSkipService(t *testing.T) {
 
 func TestNewFilteredDialContext(t *testing.T) {
 
-	_, cidr, _ := net.ParseCIDR("1.1.1.1/28")
+	_, cidr, _ := netutils.ParseCIDRSloppy("1.1.1.1/28")
 
 	testCases := []struct {
 		name string
@@ -324,7 +324,7 @@ func TestNewFilteredDialContext(t *testing.T) {
 			opts:              &FilteredDialOptions{AllowLocalLoopback: false},
 			dial:              "127.0.0.1:8080",
 			expectResolve:     "127.0.0.1",
-			resolveTo:         []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}},
+			resolveTo:         []net.IPAddr{{IP: netutils.ParseIPSloppy("127.0.0.1")}},
 			expectWrappedDial: false,
 			expectErr:         "address not allowed",
 		},
@@ -333,7 +333,7 @@ func TestNewFilteredDialContext(t *testing.T) {
 			opts:              &FilteredDialOptions{AllowLocalLoopback: false, DialHostCIDRDenylist: []*net.IPNet{cidr}},
 			dial:              "foo.com:8080",
 			expectResolve:     "foo.com",
-			resolveTo:         []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}},
+			resolveTo:         []net.IPAddr{{IP: netutils.ParseIPSloppy("1.1.1.1")}},
 			expectWrappedDial: false,
 			expectErr:         "address not allowed",
 		},
@@ -342,7 +342,7 @@ func TestNewFilteredDialContext(t *testing.T) {
 			opts:              &FilteredDialOptions{AllowLocalLoopback: false, DialHostCIDRDenylist: []*net.IPNet{cidr}},
 			dial:              "foo.com:8080",
 			expectResolve:     "foo.com",
-			resolveTo:         []net.IPAddr{{IP: net.ParseIP("2.2.2.2")}},
+			resolveTo:         []net.IPAddr{{IP: netutils.ParseIPSloppy("2.2.2.2")}},
 			expectWrappedDial: true,
 			expectErr:         "",
 		},
@@ -417,11 +417,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 2, MTU: 0, Name: "eth1", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("100.200.201.1"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("100.200.201.1"), Mask: net.CIDRMask(24, 32)}},
 				},
 			},
 			expected: sets.NewString("10.20.30.51"),
@@ -432,11 +432,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
 				},
 			},
 			expected: sets.NewString("0.0.0.0/0"),
@@ -447,11 +447,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("::1"), Mask: net.CIDRMask(128, 128)}},
 				},
 			},
 			expected: sets.NewString("2001:db8::1", "::1"),
@@ -462,11 +462,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("::1"), Mask: net.CIDRMask(128, 128)}},
 				},
 			},
 			expected: sets.NewString("::/0"),
@@ -477,11 +477,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
 				},
 			},
 			expected: sets.NewString("127.0.0.1"),
@@ -492,7 +492,7 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.1.1"), Mask: net.CIDRMask(8, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("127.0.1.1"), Mask: net.CIDRMask(8, 32)}},
 				},
 			},
 			expected: sets.NewString("127.0.1.1"),
@@ -503,11 +503,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("10.20.30.51"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 2, MTU: 0, Name: "eth1", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("100.200.201.1"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("100.200.201.1"), Mask: net.CIDRMask(24, 32)}},
 				},
 			},
 			expected: sets.NewString("10.20.30.51", "100.200.201.1"),
@@ -518,11 +518,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("192.168.1.2"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("192.168.1.2"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
 				},
 			},
 			expected:    nil,
@@ -534,11 +534,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("192.168.1.2"), Mask: net.CIDRMask(24, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("192.168.1.2"), Mask: net.CIDRMask(24, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("127.0.0.1"), Mask: net.CIDRMask(8, 32)}},
 				},
 			},
 			expected: sets.NewString("0.0.0.0/0", "::/0"),
@@ -549,11 +549,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::1"), Mask: net.CIDRMask(32, 128)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("::1"), Mask: net.CIDRMask(128, 128)}},
 				},
 			},
 			expected: sets.NewString("0.0.0.0/0", "::/0"),
@@ -564,7 +564,7 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
 				},
 			},
 			expected: sets.NewString("0.0.0.0/0"),
@@ -575,11 +575,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("::1"), Mask: net.CIDRMask(128, 128)}},
 				},
 			},
 			expected: sets.NewString("0.0.0.0/0", "::1"),
@@ -590,11 +590,11 @@ func TestGetNodeAddresses(t *testing.T) {
 			itfAddrsPairs: []InterfaceAddrsPair{
 				{
 					itf:   net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("1.2.3.4"), Mask: net.CIDRMask(30, 32)}},
 				},
 				{
 					itf:   net.Interface{Index: 1, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0},
-					addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)}},
+					addrs: []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("::1"), Mask: net.CIDRMask(128, 128)}},
 				},
 			},
 			expected: sets.NewString("::/0", "1.2.3.4"),
@@ -1063,22 +1063,22 @@ func (c *fakeClosable) Close() error {
 
 func TestRevertPorts(t *testing.T) {
 	testCases := []struct {
-		replacementPorts []utilnet.LocalPort
-		existingPorts    []utilnet.LocalPort
+		replacementPorts []netutils.LocalPort
+		existingPorts    []netutils.LocalPort
 		expectToBeClose  []bool
 	}{
 		{
-			replacementPorts: []utilnet.LocalPort{
+			replacementPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
 			},
-			existingPorts:   []utilnet.LocalPort{},
+			existingPorts:   []netutils.LocalPort{},
 			expectToBeClose: []bool{true, true, true},
 		},
 		{
-			replacementPorts: []utilnet.LocalPort{},
-			existingPorts: []utilnet.LocalPort{
+			replacementPorts: []netutils.LocalPort{},
+			existingPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
@@ -1086,12 +1086,12 @@ func TestRevertPorts(t *testing.T) {
 			expectToBeClose: []bool{},
 		},
 		{
-			replacementPorts: []utilnet.LocalPort{
+			replacementPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
 			},
-			existingPorts: []utilnet.LocalPort{
+			existingPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
@@ -1099,24 +1099,24 @@ func TestRevertPorts(t *testing.T) {
 			expectToBeClose: []bool{false, false, false},
 		},
 		{
-			replacementPorts: []utilnet.LocalPort{
+			replacementPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
 			},
-			existingPorts: []utilnet.LocalPort{
+			existingPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5003},
 			},
 			expectToBeClose: []bool{false, true, false},
 		},
 		{
-			replacementPorts: []utilnet.LocalPort{
+			replacementPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
 			},
-			existingPorts: []utilnet.LocalPort{
+			existingPorts: []netutils.LocalPort{
 				{Port: 5001},
 				{Port: 5002},
 				{Port: 5003},
@@ -1127,11 +1127,11 @@ func TestRevertPorts(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		replacementPortsMap := make(map[utilnet.LocalPort]utilnet.Closeable)
+		replacementPortsMap := make(map[netutils.LocalPort]netutils.Closeable)
 		for _, lp := range tc.replacementPorts {
 			replacementPortsMap[lp] = &fakeClosable{}
 		}
-		existingPortsMap := make(map[utilnet.LocalPort]utilnet.Closeable)
+		existingPortsMap := make(map[netutils.LocalPort]netutils.Closeable)
 		for _, lp := range tc.existingPorts {
 			existingPortsMap[lp] = &fakeClosable{}
 		}

--- a/pkg/proxy/winkernel/hnsV1.go
+++ b/pkg/proxy/winkernel/hnsV1.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -21,10 +22,11 @@ package winkernel
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/Microsoft/hcsshim"
 	"k8s.io/klog/v2"
-	"net"
-	"strings"
+	netutils "k8s.io/utils/net"
 )
 
 type HostNetworkService interface {
@@ -113,7 +115,7 @@ func (hns hnsV1) createEndpoint(ep *endpointsInfo, networkName string) (*endpoin
 	}
 	hnsEndpoint := &hcsshim.HNSEndpoint{
 		MacAddress: ep.macAddress,
-		IPAddress:  net.ParseIP(ep.ip),
+		IPAddress:  netutils.ParseIPSloppy(ep.ip),
 	}
 
 	var createdEndpoint *hcsshim.HNSEndpoint

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
+	netutils "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -73,9 +75,9 @@ func (hns fakeHNS) getEndpointByID(id string) (*endpointsInfo, error) {
 }
 
 func (hns fakeHNS) getEndpointByIpAddress(ip string, networkName string) (*endpointsInfo, error) {
-	_, ipNet, _ := net.ParseCIDR(destinationPrefix)
+	_, ipNet, _ := netutils.ParseCIDRSloppy(destinationPrefix)
 
-	if ipNet.Contains(net.ParseIP(ip)) {
+	if ipNet.Contains(netutils.ParseIPSloppy(ip)) {
 		return &endpointsInfo{
 			ip:         ip,
 			isLocal:    false,
@@ -144,7 +146,7 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clust
 
 func TestCreateServiceVip(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
 	}
@@ -199,7 +201,7 @@ func TestCreateServiceVip(t *testing.T) {
 
 func TestCreateRemoteEndpointOverlay(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
 	}
@@ -264,7 +266,7 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 
 func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "L2Bridge")
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge")
 	if proxier == nil {
 		t.Error()
 	}
@@ -328,7 +330,7 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 func TestSharedRemoteEndpointDelete(t *testing.T) {
 	syncPeriod := 30 * time.Second
 	tcpProtocol := v1.ProtocolTCP
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "L2Bridge")
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge")
 	if proxier == nil {
 		t.Error()
 	}
@@ -470,7 +472,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 }
 func TestSharedRemoteEndpointUpdate(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "L2Bridge")
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge")
 	if proxier == nil {
 		t.Error()
 	}
@@ -645,7 +647,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 func TestCreateLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
 	tcpProtocol := v1.ProtocolTCP
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
 	}
@@ -703,7 +705,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 
 func TestCreateDsrLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
 	}
@@ -765,7 +767,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 
 func TestEndpointSlice(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
 	}

--- a/pkg/proxy/winuserspace/proxier.go
+++ b/pkg/proxy/winuserspace/proxier.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -106,8 +107,8 @@ var (
 )
 
 // Used below.
-var localhostIPv4 = net.ParseIP("127.0.0.1")
-var localhostIPv6 = net.ParseIP("::1")
+var localhostIPv4 = netutils.ParseIPSloppy("127.0.0.1")
+var localhostIPv6 = netutils.ParseIPSloppy("::1")
 
 // NewProxier returns a new Proxier given a LoadBalancer and an address on
 // which to listen. It is assumed that there is only a single Proxier active
@@ -208,7 +209,7 @@ func (proxier *Proxier) setServiceInfo(service ServicePortPortalName, info *serv
 func (proxier *Proxier) addServicePortPortal(servicePortPortalName ServicePortPortalName, protocol v1.Protocol, listenIP string, port int, timeout time.Duration) (*serviceInfo, error) {
 	var serviceIP net.IP
 	if listenIP != allAvailableInterfaces {
-		if serviceIP = net.ParseIP(listenIP); serviceIP == nil {
+		if serviceIP = netutils.ParseIPSloppy(listenIP); serviceIP == nil {
 			return nil, fmt.Errorf("could not parse ip '%q'", listenIP)
 		}
 		// add the IP address.  Node port binds to all interfaces.
@@ -259,7 +260,7 @@ func (proxier *Proxier) closeServicePortPortal(servicePortPortalName ServicePort
 
 	// close the PortalProxy by deleting the service IP address
 	if info.portal.ip != allAvailableInterfaces {
-		serviceIP := net.ParseIP(info.portal.ip)
+		serviceIP := netutils.ParseIPSloppy(info.portal.ip)
 		args := proxier.netshIPv4AddressDeleteArgs(serviceIP)
 		if err := proxier.netsh.DeleteIPAddress(args); err != nil {
 			return err

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/proxy"
 	netshtest "k8s.io/kubernetes/pkg/util/netsh/testing"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -251,7 +252,7 @@ func TestTCPProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +279,7 @@ func TestUDPProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +306,7 @@ func TestUDPProxyTimeout(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +345,7 @@ func TestMultiPortProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +375,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 	serviceX := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +441,7 @@ func TestTCPProxyStop(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +485,7 @@ func TestUDPProxyStop(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,7 +523,7 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +568,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -612,7 +613,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +675,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -735,7 +736,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,7 +784,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -828,7 +829,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +882,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+	p, err := createProxier(lb, netutils.ParseIPSloppy(listenIP), netshtest.NewFake(), netutils.ParseIPSloppy("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	netutils "k8s.io/utils/net"
 )
 
 func TestAllocate(t *testing.T) {
@@ -64,7 +65,7 @@ func TestAllocate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		_, cidr, err := net.ParseCIDR(tc.cidr)
+		_, cidr, err := netutils.ParseCIDRSloppy(tc.cidr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,7 +110,7 @@ func TestAllocate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		released := net.ParseIP(tc.released)
+		released := netutils.ParseIPSloppy(tc.released)
 		if err := r.Release(released); err != nil {
 			t.Fatal(err)
 		}
@@ -131,12 +132,12 @@ func TestAllocate(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, outOfRange := range tc.outOfRange {
-			err = r.Allocate(net.ParseIP(outOfRange))
+			err = r.Allocate(netutils.ParseIPSloppy(outOfRange))
 			if _, ok := err.(*ErrNotInRange); !ok {
 				t.Fatal(err)
 			}
 		}
-		if err := r.Allocate(net.ParseIP(tc.alreadyAllocated)); err != ErrAllocated {
+		if err := r.Allocate(netutils.ParseIPSloppy(tc.alreadyAllocated)); err != ErrAllocated {
 			t.Fatal(err)
 		}
 		if f := r.Free(); f != 1 {
@@ -158,7 +159,7 @@ func TestAllocate(t *testing.T) {
 }
 
 func TestAllocateTiny(t *testing.T) {
-	_, cidr, err := net.ParseCIDR("192.168.1.0/32")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.1.0/32")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +176,7 @@ func TestAllocateTiny(t *testing.T) {
 }
 
 func TestAllocateSmall(t *testing.T) {
-	_, cidr, err := net.ParseCIDR("192.168.1.240/30")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.1.240/30")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,10 +199,10 @@ func TestAllocateSmall(t *testing.T) {
 		found.Insert(ip.String())
 	}
 	for s := range found {
-		if !r.Has(net.ParseIP(s)) {
+		if !r.Has(netutils.ParseIPSloppy(s)) {
 			t.Fatalf("missing: %s", s)
 		}
-		if err := r.Allocate(net.ParseIP(s)); err != ErrAllocated {
+		if err := r.Allocate(netutils.ParseIPSloppy(s)); err != ErrAllocated {
 			t.Fatal(err)
 		}
 	}
@@ -219,7 +220,7 @@ func TestAllocateSmall(t *testing.T) {
 }
 
 func TestForEach(t *testing.T) {
-	_, cidr, err := net.ParseCIDR("192.168.1.0/24")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.1.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +238,7 @@ func TestForEach(t *testing.T) {
 			t.Fatal(err)
 		}
 		for ips := range tc {
-			ip := net.ParseIP(ips)
+			ip := netutils.ParseIPSloppy(ips)
 			if err := r.Allocate(ip); err != nil {
 				t.Errorf("[%d] error allocating IP %v: %v", i, ip, err)
 			}
@@ -259,7 +260,7 @@ func TestForEach(t *testing.T) {
 }
 
 func TestSnapshot(t *testing.T) {
-	_, cidr, err := net.ParseCIDR("192.168.1.0/24")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.1.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +283,7 @@ func TestSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, network, err := net.ParseCIDR(dst.Range)
+	_, network, err := netutils.ParseCIDRSloppy(dst.Range)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +292,7 @@ func TestSnapshot(t *testing.T) {
 		t.Fatalf("mismatched networks: %s : %s", network, cidr)
 	}
 
-	_, otherCidr, err := net.ParseCIDR("192.168.2.0/24")
+	_, otherCidr, err := netutils.ParseCIDRSloppy("192.168.2.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +322,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestNewFromSnapshot(t *testing.T) {
-	_, cidr, err := net.ParseCIDR("192.168.0.0/24")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.0.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/registry/core/rangeallocation"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
-	netutil "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 // Repair is a controller loop that periodically examines all service ClusterIP allocations
@@ -82,7 +82,7 @@ func NewRepair(interval time.Duration, serviceClient corev1client.ServicesGetter
 
 	primary := v1.IPv4Protocol
 	secondary := v1.IPv6Protocol
-	if netutil.IsIPv6(network.IP) {
+	if netutils.IsIPv6(network.IP) {
 		primary = v1.IPv6Protocol
 	}
 
@@ -196,7 +196,7 @@ func (c *Repair) runOnce() error {
 	}
 
 	getFamilyByIP := func(ip net.IP) v1.IPFamily {
-		if netutil.IsIPv6(ip) {
+		if netutils.IsIPv6(ip) {
 			return v1.IPv6Protocol
 		}
 		return v1.IPv4Protocol
@@ -210,7 +210,7 @@ func (c *Repair) runOnce() error {
 		}
 
 		for _, ip := range svc.Spec.ClusterIPs {
-			ip := net.ParseIP(ip)
+			ip := netutils.ParseIPSloppy(ip)
 			if ip == nil {
 				// cluster IP is corrupt
 				c.recorder.Eventf(&svc, v1.EventTypeWarning, "ClusterIPNotValid", "Cluster IP %s is not a valid IP; please recreate service", ip)

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -45,7 +45,7 @@ import (
 	registry "k8s.io/kubernetes/pkg/registry/core/service"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
-	netutil "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -108,7 +108,7 @@ func NewREST(
 	// detect this cluster default Service IPFamily (ipfamily of --service-cluster-ip-range[0])
 	serviceIPFamily := api.IPv4Protocol
 	cidr := serviceIPs.CIDR()
-	if netutil.IsIPv6CIDR(&cidr) {
+	if netutils.IsIPv6CIDR(&cidr) {
 		serviceIPFamily = api.IPv6Protocol
 	}
 
@@ -612,7 +612,7 @@ func (rs *REST) allocClusterIPs(service *api.Service, toAlloc map[api.IPFamily]s
 			}
 			allocated[family] = allocatedIP.String()
 		} else {
-			parsedIP := net.ParseIP(ip)
+			parsedIP := netutils.ParseIPSloppy(ip)
 			if err := allocator.Allocate(parsedIP); err != nil {
 				el := field.ErrorList{field.Invalid(field.NewPath("spec", "clusterIPs"), service.Spec.ClusterIPs, fmt.Sprintf("failed to allocate IP %v: %v", ip, err))}
 				return allocated, errors.NewInvalid(api.Kind("Service"), service.Name, el)
@@ -638,7 +638,7 @@ func (rs *REST) releaseClusterIPs(toRelease map[api.IPFamily]string) (map[api.IP
 			continue
 		}
 
-		parsedIP := net.ParseIP(ip)
+		parsedIP := netutils.ParseIPSloppy(ip)
 		if err := allocator.Release(parsedIP); err != nil {
 			return released, err
 		}
@@ -825,7 +825,7 @@ func (rs *REST) releaseServiceClusterIP(service *api.Service) (released map[api.
 
 	// we need to do that to handle cases where allocator is no longer configured on
 	// cluster
-	if netutil.IsIPv6String(service.Spec.ClusterIP) {
+	if netutils.IsIPv6String(service.Spec.ClusterIP) {
 		toRelease[api.IPv6Protocol] = service.Spec.ClusterIP
 	} else {
 		toRelease[api.IPv4Protocol] = service.Spec.ClusterIP
@@ -852,7 +852,7 @@ func (rs *REST) releaseServiceClusterIPs(service *api.Service) (released map[api
 
 	toRelease := make(map[api.IPFamily]string)
 	for _, ip := range service.Spec.ClusterIPs {
-		if netutil.IsIPv6String(ip) {
+		if netutils.IsIPv6String(ip) {
 			toRelease[api.IPv6Protocol] = ip
 		} else {
 			toRelease[api.IPv4Protocol] = ip
@@ -974,7 +974,7 @@ func (rs *REST) tryDefaultValidateServiceClusterIPFields(oldService, service *ap
 
 		// we have previously validated for ip correctness and if family exist it will match ip family
 		// so the following is safe to do
-		isIPv6 := netutil.IsIPv6String(ip)
+		isIPv6 := netutils.IsIPv6String(ip)
 
 		// Family is not specified yet.
 		if i >= len(service.Spec.IPFamilies) {

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package storage
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
+	netutils "k8s.io/utils/net"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -421,7 +421,7 @@ func TestServiceDefaultOnRead(t *testing.T) {
 				ResourcePrefix:          "services",
 			}
 
-			_, cidr, err := net.ParseCIDR("10.0.0.0/24")
+			_, cidr, err := netutils.ParseCIDRSloppy("10.0.0.0/24")
 			if err != nil {
 				t.Fatalf("failed to parse CIDR")
 			}
@@ -479,7 +479,7 @@ func TestServiceDefaulting(t *testing.T) {
 			ResourcePrefix:          "services",
 		}
 
-		_, cidr, err := net.ParseCIDR(primaryCIDR)
+		_, cidr, err := netutils.ParseCIDRSloppy(primaryCIDR)
 		if err != nil {
 			t.Fatalf("failed to parse CIDR %s", primaryCIDR)
 		}

--- a/pkg/registry/core/service/strategy_test.go
+++ b/pkg/registry/core/service/strategy_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
@@ -34,11 +33,12 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	netutils "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
 
 func newStrategy(cidr string, hasSecondary bool) (testStrategy Strategy, testStatusStrategy Strategy) {
-	_, testCIDR, err := net.ParseCIDR(cidr)
+	_, testCIDR, err := netutils.ParseCIDRSloppy(cidr)
 	if err != nil {
 		panic("invalid CIDR")
 	}

--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kube-scheduler/config/v1beta1"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	netutils "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 )
 
@@ -143,7 +144,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 		} else {
 			// Something went wrong splitting the host/port, could just be a missing port so check if the
 			// existing value is a valid IP address. If so, use that with the default scheduler port
-			if host := net.ParseIP(*obj.HealthzBindAddress); host != nil {
+			if host := netutils.ParseIPSloppy(*obj.HealthzBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.HealthzBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.HealthzBindAddress = &hostPort
 			} else {
@@ -165,7 +166,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 		} else {
 			// Something went wrong splitting the host/port, could just be a missing port so check if the
 			// existing value is a valid IP address. If so, use that with the default scheduler port
-			if host := net.ParseIP(*obj.MetricsBindAddress); host != nil {
+			if host := netutils.ParseIPSloppy(*obj.MetricsBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.MetricsBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.MetricsBindAddress = &hostPort
 			} else {

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kube-scheduler/config/v1beta2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	netutils "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 )
 
@@ -141,7 +142,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta2.KubeSchedulerConfigurat
 		} else {
 			// Something went wrong splitting the host/port, could just be a missing port so check if the
 			// existing value is a valid IP address. If so, use that with the default scheduler port
-			if host := net.ParseIP(*obj.HealthzBindAddress); host != nil {
+			if host := netutils.ParseIPSloppy(*obj.HealthzBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.HealthzBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.HealthzBindAddress = &hostPort
 			}
@@ -160,7 +161,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta2.KubeSchedulerConfigurat
 		} else {
 			// Something went wrong splitting the host/port, could just be a missing port so check if the
 			// existing value is a valid IP address. If so, use that with the default scheduler port
-			if host := net.ParseIP(*obj.MetricsBindAddress); host != nil {
+			if host := netutils.ParseIPSloppy(*obj.MetricsBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.MetricsBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.MetricsBindAddress = &hostPort
 			}

--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/klog/v2"
 )
@@ -103,7 +105,7 @@ func (t *tcShaper) nextClassID() (int, error) {
 // Convert a CIDR from text to a hex representation
 // Strips any masked parts of the IP, so 1.2.3.4/16 becomes hex(1.2.0.0)/ffffffff
 func hexCIDR(cidr string) (string, error) {
-	ip, ipnet, err := net.ParseCIDR(cidr)
+	ip, ipnet, err := netutils.ParseCIDRSloppy(cidr)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -30,7 +30,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	corev1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 // TODO(mikedanese): remove these flag wrapper types when we remove command line flags
@@ -53,7 +53,7 @@ func (v IPVar) Set(s string) error {
 		v.Val = nil
 		return nil
 	}
-	if net.ParseIP(s) == nil {
+	if netutils.ParseIPSloppy(s) == nil {
 		return fmt.Errorf("%q is not a valid IP address", s)
 	}
 	if v.Val == nil {
@@ -96,7 +96,7 @@ func (v IPPortVar) Set(s string) error {
 
 	// Both IP and IP:port are valid.
 	// Attempt to parse into IP first.
-	if net.ParseIP(s) != nil {
+	if netutils.ParseIPSloppy(s) != nil {
 		*v.Val = s
 		return nil
 	}
@@ -106,10 +106,10 @@ func (v IPPortVar) Set(s string) error {
 	if err != nil {
 		return fmt.Errorf("%q is not in a valid format (ip or ip:port): %v", s, err)
 	}
-	if net.ParseIP(host) == nil {
+	if netutils.ParseIPSloppy(host) == nil {
 		return fmt.Errorf("%q is not a valid IP address", host)
 	}
-	if _, err := utilsnet.ParsePort(port, true); err != nil {
+	if _, err := netutils.ParsePort(port, true); err != nil {
 		return fmt.Errorf("%q is not a valid number", port)
 	}
 	*v.Val = s

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -19,13 +19,13 @@ package ipset
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 )
 
 // Interface is an injectable interface for running ipset commands.  Implementations must be goroutine-safe.
@@ -183,7 +183,7 @@ func (e *Entry) Validate(set *IPSet) bool {
 		}
 
 		// IP2 can not be empty for `hash:ip,port,ip` type ip set
-		if net.ParseIP(e.IP2) == nil {
+		if netutils.ParseIPSloppy(e.IP2) == nil {
 			klog.Errorf("Error parsing entry %v second ip address %v for ipset %v", e, e.IP2, set)
 			return false
 		}
@@ -194,7 +194,7 @@ func (e *Entry) Validate(set *IPSet) bool {
 		}
 
 		// Net can not be empty for `hash:ip,port,net` type ip set
-		if _, ipNet, err := net.ParseCIDR(e.Net); ipNet == nil {
+		if _, ipNet, err := netutils.ParseCIDRSloppy(e.Net); ipNet == nil {
 			klog.Errorf("Error parsing entry %v ip net %v for ipset %v, error: %v", e, e.Net, set, err)
 			return false
 		}
@@ -250,7 +250,7 @@ func (e *Entry) checkIPandProtocol(set *IPSet) bool {
 		return false
 	}
 
-	if net.ParseIP(e.IP) == nil {
+	if netutils.ParseIPSloppy(e.IP) == nil {
 		klog.Errorf("Error parsing entry %v ip address %v for ipset %v", e, e.IP, set)
 		return false
 	}

--- a/pkg/util/ipvs/ipvs_linux_test.go
+++ b/pkg/util/ipvs/ipvs_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -20,10 +21,11 @@ package ipvs
 
 import (
 	"fmt"
-	"net"
 	"reflect"
 	"syscall"
 	"testing"
+
+	netutils "k8s.io/utils/net"
 
 	libipvs "github.com/moby/ipvs"
 )
@@ -65,7 +67,7 @@ func Test_toVirtualServer(t *testing.T) {
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("0.0.0.0"),
+				Address:   netutils.ParseIPSloppy("0.0.0.0"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "",
@@ -85,11 +87,11 @@ func Test_toVirtualServer(t *testing.T) {
 				Timeout:       100,
 				Netmask:       128,
 				AddressFamily: syscall.AF_INET6,
-				Address:       net.ParseIP("2012::beef"),
+				Address:       netutils.ParseIPSloppy("2012::beef"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "UDP",
 				Port:      33434,
 				Scheduler: "wlc",
@@ -109,11 +111,11 @@ func Test_toVirtualServer(t *testing.T) {
 				Timeout:       0,
 				Netmask:       0xffffffff,
 				AddressFamily: syscall.AF_INET,
-				Address:       net.ParseIP("1.2.3.4"),
+				Address:       netutils.ParseIPSloppy("1.2.3.4"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "lc",
@@ -137,7 +139,7 @@ func Test_toVirtualServer(t *testing.T) {
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("::0"),
+				Address:   netutils.ParseIPSloppy("::0"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -161,7 +163,7 @@ func Test_toVirtualServer(t *testing.T) {
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("0.0.0.0"),
+				Address:   netutils.ParseIPSloppy("0.0.0.0"),
 				Protocol:  "SCTP",
 				Port:      80,
 				Scheduler: "",
@@ -204,11 +206,11 @@ func Test_toIPVSService(t *testing.T) {
 				Timeout:       0,
 				Netmask:       0xffffffff,
 				AddressFamily: syscall.AF_INET,
-				Address:       net.ParseIP("0.0.0.0"),
+				Address:       netutils.ParseIPSloppy("0.0.0.0"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("0.0.0.0"),
+				Address:   netutils.ParseIPSloppy("0.0.0.0"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "",
@@ -226,11 +228,11 @@ func Test_toIPVSService(t *testing.T) {
 				Timeout:       100,
 				Netmask:       128,
 				AddressFamily: syscall.AF_INET6,
-				Address:       net.ParseIP("2012::beef"),
+				Address:       netutils.ParseIPSloppy("2012::beef"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "UDP",
 				Port:      33434,
 				Scheduler: "wlc",
@@ -248,11 +250,11 @@ func Test_toIPVSService(t *testing.T) {
 				Timeout:       0,
 				Netmask:       0xffffffff,
 				AddressFamily: syscall.AF_INET,
-				Address:       net.ParseIP("1.2.3.4"),
+				Address:       netutils.ParseIPSloppy("1.2.3.4"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "lc",
@@ -270,11 +272,11 @@ func Test_toIPVSService(t *testing.T) {
 				Timeout:       0,
 				Netmask:       128,
 				AddressFamily: syscall.AF_INET6,
-				Address:       net.ParseIP("::0"),
+				Address:       netutils.ParseIPSloppy("::0"),
 				PEName:        "",
 			},
 			VirtualServer{
-				Address:   net.ParseIP("::0"),
+				Address:   netutils.ParseIPSloppy("::0"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -305,10 +307,10 @@ func Test_toRealServer(t *testing.T) {
 				Port:            54321,
 				ConnectionFlags: 0,
 				Weight:          1,
-				Address:         net.ParseIP("1.2.3.4"),
+				Address:         netutils.ParseIPSloppy("1.2.3.4"),
 			},
 			RealServer{
-				Address: net.ParseIP("1.2.3.4"),
+				Address: netutils.ParseIPSloppy("1.2.3.4"),
 				Port:    54321,
 				Weight:  1,
 			},
@@ -318,10 +320,10 @@ func Test_toRealServer(t *testing.T) {
 				Port:            53,
 				ConnectionFlags: 0,
 				Weight:          1,
-				Address:         net.ParseIP("2002::cafe"),
+				Address:         netutils.ParseIPSloppy("2002::cafe"),
 			},
 			RealServer{
-				Address: net.ParseIP("2002::cafe"),
+				Address: netutils.ParseIPSloppy("2002::cafe"),
 				Port:    53,
 				Weight:  1,
 			},
@@ -345,7 +347,7 @@ func Test_toIPVSDestination(t *testing.T) {
 	}{
 		{
 			RealServer{
-				Address: net.ParseIP("1.2.3.4"),
+				Address: netutils.ParseIPSloppy("1.2.3.4"),
 				Port:    54321,
 				Weight:  1,
 			},
@@ -353,12 +355,12 @@ func Test_toIPVSDestination(t *testing.T) {
 				Port:            54321,
 				ConnectionFlags: 0,
 				Weight:          1,
-				Address:         net.ParseIP("1.2.3.4"),
+				Address:         netutils.ParseIPSloppy("1.2.3.4"),
 			},
 		},
 		{
 			RealServer{
-				Address: net.ParseIP("2002::cafe"),
+				Address: netutils.ParseIPSloppy("2002::cafe"),
 				Port:    53,
 				Weight:  1,
 			},
@@ -366,7 +368,7 @@ func Test_toIPVSDestination(t *testing.T) {
 				Port:            53,
 				ConnectionFlags: 0,
 				Weight:          1,
-				Address:         net.ParseIP("2002::cafe"),
+				Address:         netutils.ParseIPSloppy("2002::cafe"),
 			},
 		},
 	}

--- a/pkg/util/ipvs/ipvs_test.go
+++ b/pkg/util/ipvs/ipvs_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package ipvs
 
 import (
-	"net"
 	"reflect"
 	"sort"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/version"
+	netutils "k8s.io/utils/net"
 )
 
 func TestVirtualServerEqual(t *testing.T) {
@@ -34,7 +34,7 @@ func TestVirtualServerEqual(t *testing.T) {
 	}{
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("10.20.30.40"),
+				Address:   netutils.ParseIPSloppy("10.20.30.40"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -42,7 +42,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("10.20.30.41"),
+				Address:   netutils.ParseIPSloppy("10.20.30.41"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -54,7 +54,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -62,7 +62,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("2017::beef"),
+				Address:   netutils.ParseIPSloppy("2017::beef"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -74,7 +74,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "TCP",
 				Port:      0,
 				Scheduler: "wrr",
@@ -82,7 +82,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("2012::beeef"),
+				Address:   netutils.ParseIPSloppy("2012::beeef"),
 				Protocol:  "UDP",
 				Port:      0,
 				Scheduler: "wrr",
@@ -94,7 +94,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "wrr",
@@ -102,7 +102,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "TCP",
 				Port:      8080,
 				Scheduler: "wrr",
@@ -114,7 +114,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "rr",
@@ -122,7 +122,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "wlc",
@@ -134,7 +134,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "rr",
@@ -142,7 +142,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "rr",
@@ -154,7 +154,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -162,7 +162,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "",
 				Port:      0,
 				Scheduler: "wrr",
@@ -174,7 +174,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "rr",
@@ -182,7 +182,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   10800,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "TCP",
 				Port:      80,
 				Scheduler: "rr",
@@ -194,7 +194,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("2012::beef"),
+				Address:   netutils.ParseIPSloppy("2012::beef"),
 				Protocol:  "TCP",
 				Port:      0,
 				Scheduler: "wrr",
@@ -202,7 +202,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   0,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("2012::beeef"),
+				Address:   netutils.ParseIPSloppy("2012::beeef"),
 				Protocol:  "SCTP",
 				Port:      0,
 				Scheduler: "wrr",
@@ -214,7 +214,7 @@ func TestVirtualServerEqual(t *testing.T) {
 		},
 		{
 			svcA: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "SCTP",
 				Port:      80,
 				Scheduler: "rr",
@@ -222,7 +222,7 @@ func TestVirtualServerEqual(t *testing.T) {
 				Timeout:   10800,
 			},
 			svcB: &VirtualServer{
-				Address:   net.ParseIP("1.2.3.4"),
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
 				Protocol:  "SCTP",
 				Port:      80,
 				Scheduler: "rr",
@@ -251,11 +251,11 @@ func TestRealServerEqual(t *testing.T) {
 	}{
 		{
 			rsA: &RealServer{
-				Address: net.ParseIP("10.20.30.40"),
+				Address: netutils.ParseIPSloppy("10.20.30.40"),
 				Port:    80,
 			},
 			rsB: &RealServer{
-				Address: net.ParseIP("10.20.30.41"),
+				Address: netutils.ParseIPSloppy("10.20.30.41"),
 				Port:    80,
 			},
 			equal:  false,
@@ -263,11 +263,11 @@ func TestRealServerEqual(t *testing.T) {
 		},
 		{
 			rsA: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    80,
 			},
 			rsB: &RealServer{
-				Address: net.ParseIP("2017::beef"),
+				Address: netutils.ParseIPSloppy("2017::beef"),
 				Port:    80,
 			},
 			equal:  false,
@@ -275,11 +275,11 @@ func TestRealServerEqual(t *testing.T) {
 		},
 		{
 			rsA: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    80,
 			},
 			rsB: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    8080,
 			},
 			equal:  false,
@@ -287,11 +287,11 @@ func TestRealServerEqual(t *testing.T) {
 		},
 		{
 			rsA: &RealServer{
-				Address: net.ParseIP("1.2.3.4"),
+				Address: netutils.ParseIPSloppy("1.2.3.4"),
 				Port:    3080,
 			},
 			rsB: &RealServer{
-				Address: net.ParseIP("1.2.3.4"),
+				Address: netutils.ParseIPSloppy("1.2.3.4"),
 				Port:    3080,
 			},
 			equal:  true,
@@ -299,11 +299,11 @@ func TestRealServerEqual(t *testing.T) {
 		},
 		{
 			rsA: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    3080,
 			},
 			rsB: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    3080,
 			},
 			equal:  true,
@@ -326,7 +326,7 @@ func TestFrontendServiceString(t *testing.T) {
 	}{
 		{
 			svc: &VirtualServer{
-				Address:  net.ParseIP("10.20.30.40"),
+				Address:  netutils.ParseIPSloppy("10.20.30.40"),
 				Protocol: "TCP",
 				Port:     80,
 			},
@@ -334,7 +334,7 @@ func TestFrontendServiceString(t *testing.T) {
 		},
 		{
 			svc: &VirtualServer{
-				Address:  net.ParseIP("2012::beef"),
+				Address:  netutils.ParseIPSloppy("2012::beef"),
 				Protocol: "UDP",
 				Port:     8080,
 			},
@@ -342,7 +342,7 @@ func TestFrontendServiceString(t *testing.T) {
 		},
 		{
 			svc: &VirtualServer{
-				Address:  net.ParseIP("10.20.30.41"),
+				Address:  netutils.ParseIPSloppy("10.20.30.41"),
 				Protocol: "ESP",
 				Port:     1234,
 			},
@@ -364,14 +364,14 @@ func TestFrontendDestinationString(t *testing.T) {
 	}{
 		{
 			svc: &RealServer{
-				Address: net.ParseIP("10.20.30.40"),
+				Address: netutils.ParseIPSloppy("10.20.30.40"),
 				Port:    80,
 			},
 			expected: "10.20.30.40:80",
 		},
 		{
 			svc: &RealServer{
-				Address: net.ParseIP("2012::beef"),
+				Address: netutils.ParseIPSloppy("2012::beef"),
 				Port:    8080,
 			},
 			expected: "[2012::beef]:8080",

--- a/pkg/util/ipvs/testing/fake_test.go
+++ b/pkg/util/ipvs/testing/fake_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package testing
 
 import (
-	"net"
 	"testing"
 
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
+	netutils "k8s.io/utils/net"
 )
 
 func TestVirtualServer(t *testing.T) {
@@ -28,7 +28,7 @@ func TestVirtualServer(t *testing.T) {
 	fake := NewFake()
 	// Add a virtual server
 	vs1 := &utilipvs.VirtualServer{
-		Address:  net.ParseIP("1.2.3.4"),
+		Address:  netutils.ParseIPSloppy("1.2.3.4"),
 		Port:     uint16(80),
 		Protocol: string("TCP"),
 		Flags:    utilipvs.FlagHashed,
@@ -47,7 +47,7 @@ func TestVirtualServer(t *testing.T) {
 	}
 	// Update virtual server
 	vs12 := &utilipvs.VirtualServer{
-		Address:  net.ParseIP("1.2.3.4"),
+		Address:  netutils.ParseIPSloppy("1.2.3.4"),
 		Port:     uint16(80),
 		Protocol: string("TCP"),
 		Flags:    utilipvs.FlagPersistent,
@@ -66,7 +66,7 @@ func TestVirtualServer(t *testing.T) {
 	}
 	// Add another virtual server
 	vs2 := &utilipvs.VirtualServer{
-		Address:  net.ParseIP("10::40"),
+		Address:  netutils.ParseIPSloppy("10::40"),
 		Port:     uint16(8080),
 		Protocol: string("UDP"),
 	}
@@ -76,7 +76,7 @@ func TestVirtualServer(t *testing.T) {
 	}
 	// Add another virtual server
 	vs3 := &utilipvs.VirtualServer{
-		Address:  net.ParseIP("10::40"),
+		Address:  netutils.ParseIPSloppy("10::40"),
 		Port:     uint16(7777),
 		Protocol: string("SCTP"),
 	}
@@ -122,14 +122,14 @@ func TestRealServer(t *testing.T) {
 	fake := NewFake()
 	// Add a virtual server
 	vs := &utilipvs.VirtualServer{
-		Address:  net.ParseIP("10.20.30.40"),
+		Address:  netutils.ParseIPSloppy("10.20.30.40"),
 		Port:     uint16(80),
 		Protocol: string("TCP"),
 	}
 	rss := []*utilipvs.RealServer{
-		{Address: net.ParseIP("172.16.2.1"), Port: 8080, Weight: 1},
-		{Address: net.ParseIP("172.16.2.2"), Port: 8080, Weight: 2},
-		{Address: net.ParseIP("172.16.2.3"), Port: 8080, Weight: 3},
+		{Address: netutils.ParseIPSloppy("172.16.2.1"), Port: 8080, Weight: 1},
+		{Address: netutils.ParseIPSloppy("172.16.2.2"), Port: 8080, Weight: 2},
+		{Address: netutils.ParseIPSloppy("172.16.2.3"), Port: 8080, Weight: 3},
 	}
 	err := fake.AddVirtualServer(vs)
 	if err != nil {
@@ -173,7 +173,7 @@ func TestRealServer(t *testing.T) {
 	}
 	// Test delete real server that not exist
 	rs := &utilipvs.RealServer{
-		Address: net.ParseIP("172.16.2.4"),
+		Address: netutils.ParseIPSloppy("172.16.2.4"),
 		Port:    uint16(8080),
 		Weight:  1,
 	}

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -37,7 +37,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/features"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -103,7 +103,7 @@ func GetNodeHostIPs(node *v1.Node) ([]net.IP, error) {
 	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == v1.NodeInternalIP {
-			ip := net.ParseIP(addr.Address)
+			ip := netutils.ParseIPSloppy(addr.Address)
 			if ip != nil {
 				allIPs = append(allIPs, ip)
 			}
@@ -111,7 +111,7 @@ func GetNodeHostIPs(node *v1.Node) ([]net.IP, error) {
 	}
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == v1.NodeExternalIP {
-			ip := net.ParseIP(addr.Address)
+			ip := netutils.ParseIPSloppy(addr.Address)
 			if ip != nil {
 				allIPs = append(allIPs, ip)
 			}
@@ -124,7 +124,7 @@ func GetNodeHostIPs(node *v1.Node) ([]net.IP, error) {
 	nodeIPs := []net.IP{allIPs[0]}
 	if utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
 		for _, ip := range allIPs {
-			if utilnet.IsIPv6(ip) != utilnet.IsIPv6(nodeIPs[0]) {
+			if netutils.IsIPv6(ip) != netutils.IsIPv6(nodeIPs[0]) {
 				nodeIPs = append(nodeIPs, ip)
 				break
 			}

--- a/pkg/util/node/node_test.go
+++ b/pkg/util/node/node_test.go
@@ -26,6 +26,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	netutils "k8s.io/utils/net"
 )
 
 func TestGetPreferredAddress(t *testing.T) {
@@ -120,7 +121,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.1"},
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 			},
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4")},
 		},
 		{
 			name: "IPv4-only, external-first",
@@ -129,7 +130,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 				{Type: v1.NodeInternalIP, Address: "1.2.3.4"},
 			},
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4")},
 		},
 		{
 			name: "IPv4-only, no internal",
@@ -137,7 +138,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.1"},
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 			},
-			expectIPs: []net.IP{net.ParseIP("4.3.2.1")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("4.3.2.1")},
 		},
 		{
 			name: "dual-stack node, single-stack cluster",
@@ -148,7 +149,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeInternalIP, Address: "a:b::c:d"},
 				{Type: v1.NodeExternalIP, Address: "d:c::b:a"},
 			},
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4")},
 		},
 		{
 			name: "dual-stack node, dual-stack cluster",
@@ -160,7 +161,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "d:c::b:a"},
 			},
 			dualStack: true,
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("a:b::c:d")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4"), netutils.ParseIPSloppy("a:b::c:d")},
 		},
 		{
 			name: "dual-stack node, different order, single-stack cluster",
@@ -171,7 +172,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 				{Type: v1.NodeExternalIP, Address: "d:c::b:a"},
 			},
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4")},
 		},
 		{
 			name: "dual-stack node, different order, dual-stack cluster",
@@ -183,7 +184,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "d:c::b:a"},
 			},
 			dualStack: true,
-			expectIPs: []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("a:b::c:d")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("1.2.3.4"), netutils.ParseIPSloppy("a:b::c:d")},
 		},
 		{
 			name: "dual-stack node, IPv6-first, no internal IPv4, single-stack cluster",
@@ -193,7 +194,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.1"},
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 			},
-			expectIPs: []net.IP{net.ParseIP("a:b::c:d")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("a:b::c:d")},
 		},
 		{
 			name: "dual-stack node, IPv6-first, no internal IPv4, dual-stack cluster",
@@ -204,7 +205,7 @@ func TestGetNodeHostIPs(t *testing.T) {
 				{Type: v1.NodeExternalIP, Address: "4.3.2.2"},
 			},
 			dualStack: true,
-			expectIPs: []net.IP{net.ParseIP("a:b::c:d"), net.ParseIP("4.3.2.1")},
+			expectIPs: []net.IP{netutils.ParseIPSloppy("a:b::c:d"), netutils.ParseIPSloppy("4.3.2.1")},
 		},
 	}
 

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,6 +34,7 @@ import (
 	gapi "github.com/heketi/heketi/pkg/glusterfs/api"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
+	netutils "k8s.io/utils/net"
 	utilstrings "k8s.io/utils/strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -992,7 +992,7 @@ func getClusterNodes(cli *gcli.Client, cluster string) (dynamicHostIps []string,
 		}
 		ipaddr := dstrings.Join(nodeInfo.NodeAddRequest.Hostnames.Storage, "")
 		// IP validates if a string is a valid IP address.
-		ip := net.ParseIP(ipaddr)
+		ip := netutils.ParseIPSloppy(ipaddr)
 		if ip == nil {
 			return nil, fmt.Errorf("glusterfs server node ip address %s must be a valid IP address, (e.g. 10.9.8.7)", ipaddr)
 		}

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -35,6 +35,7 @@
   allowedImports:
   - k8s.io/apimachinery
   - k8s.io/kube-openapi
+  - k8s.io/utils/net
   - k8s.io/klog
 
 - baseImportPath: "./vendor/k8s.io/api/"
@@ -150,6 +151,7 @@
   - k8s.io/component-base
   - k8s.io/kube-openapi
   - k8s.io/sample-apiserver
+  - k8s.io/utils/net
   - k8s.io/klog
 
 - baseImportPath: "./vendor/k8s.io/apiextensions-apiserver/"

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -937,6 +937,7 @@ k8s.io/kubernetes v1.22.1/go.mod h1:IGQZrV02n2IBp52+/YwLVMurCEQPKXJ/k8hU3mqEOuA=
 k8s.io/system-validators v1.5.0/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6gRrl0Q=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a h1:8dYfu/Fc9Gz2rNJKB9IQRGgQOh2clmRzNIPPY1xLY5g=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/util/webhook"
 	corev1 "k8s.io/client-go/listers/core/v1"
+	netutils "k8s.io/utils/net"
 )
 
 const defaultEtcdPathPrefix = "/registry/apiextensions.kubernetes.io"
@@ -91,7 +92,7 @@ func (o *CustomResourceDefinitionsServerOptions) Complete() error {
 // Config returns an apiextensions-apiserver configuration.
 func (o CustomResourceDefinitionsServerOptions) Config() (*apiserver.Config, error) {
 	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -36,6 +36,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/staging/src/k8s.io/apimachinery/go.sum
+++ b/staging/src/k8s.io/apimachinery/go.sum
@@ -95,6 +95,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -212,6 +213,8 @@ k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a h1:8dYfu/Fc9Gz2rNJKB9IQRGgQOh2clmRzNIPPY1xLY5g=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 /*
@@ -37,11 +38,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
+	netutils "k8s.io/utils/net"
 )
 
 func TestGetClientIP(t *testing.T) {
 	ipString := "10.0.0.1"
-	ip := net.ParseIP(ipString)
+	ip := netutils.ParseIPSloppy(ipString)
 	invalidIPString := "invalidIPString"
 	testCases := []struct {
 		Request    http.Request

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 type AddressFamily uint
@@ -221,7 +222,7 @@ func getMatchingGlobalIP(addrs []net.Addr, family AddressFamily) (net.IP, error)
 	if len(addrs) > 0 {
 		for i := range addrs {
 			klog.V(4).Infof("Checking addr  %s.", addrs[i].String())
-			ip, _, err := net.ParseCIDR(addrs[i].String())
+			ip, _, err := netutils.ParseCIDRSloppy(addrs[i].String())
 			if err != nil {
 				return nil, err
 			}
@@ -336,7 +337,7 @@ func chooseIPFromHostInterfaces(nw networkInterfacer, addressFamilies AddressFam
 				continue
 			}
 			for _, addr := range addrs {
-				ip, _, err := net.ParseCIDR(addr.String())
+				ip, _, err := netutils.ParseCIDRSloppy(addr.String())
 				if err != nil {
 					return nil, fmt.Errorf("Unable to parse CIDR for interface %q: %s", intf.Name, err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/util_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/util_test.go
@@ -22,10 +22,12 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	netutils "k8s.io/utils/net"
 )
 
 func getIPNet(cidr string) *net.IPNet {
-	_, ipnet, _ := net.ParseCIDR(cidr)
+	_, ipnet, _ := netutils.ParseCIDRSloppy(cidr)
 	return ipnet
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	netutils "k8s.io/utils/net"
 )
 
 const qnameCharFmt string = "[A-Za-z0-9]"
@@ -346,7 +347,7 @@ func IsValidPortName(port string) []string {
 
 // IsValidIP tests that the argument is a valid IP address.
 func IsValidIP(value string) []string {
-	if net.ParseIP(value) == nil {
+	if netutils.ParseIPSloppy(value) == nil {
 		return []string{"must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"}
 	}
 	return nil
@@ -355,7 +356,7 @@ func IsValidIP(value string) []string {
 // IsValidIPv4Address tests that the argument is a valid IPv4 address.
 func IsValidIPv4Address(fldPath *field.Path, value string) field.ErrorList {
 	var allErrors field.ErrorList
-	ip := net.ParseIP(value)
+	ip := netutils.ParseIPSloppy(value)
 	if ip == nil || ip.To4() == nil {
 		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IPv4 address"))
 	}
@@ -365,7 +366,7 @@ func IsValidIPv4Address(fldPath *field.Path, value string) field.ErrorList {
 // IsValidIPv6Address tests that the argument is a valid IPv6 address.
 func IsValidIPv6Address(fldPath *field.Path, value string) field.ErrorList {
 	var allErrors field.ErrorList
-	ip := net.ParseIP(value)
+	ip := netutils.ParseIPSloppy(value)
 	if ip == nil || ip.To4() != nil {
 		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IPv6 address"))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/addresses_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/addresses_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package discovery
 
 import (
-	"net"
 	"net/http"
 	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
 )
 
 func TestGetServerAddressByClientCIDRs(t *testing.T) {
@@ -103,7 +103,7 @@ func TestGetServerAddressByClientCIDRs(t *testing.T) {
 		},
 	}
 
-	_, ipRange, _ := net.ParseCIDR("10.0.0.0/24")
+	_, ipRange, _ := netutils.ParseCIDRSloppy("10.0.0.0/24")
 	discoveryAddresses := DefaultAddresses{DefaultAddress: "ExternalAddress"}
 	discoveryAddresses.CIDRRules = append(discoveryAddresses.CIDRRules,
 		CIDRRule{IPRange: *ipRange, Address: "serviceIP"})

--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -47,7 +47,7 @@ func TestLoopbackHostPortIPv4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+	if ip := netutils.ParseIPSloppy(host); ip == nil || !ip.IsLoopback() {
 		t.Fatalf("expected host to be loopback, got %q", host)
 	}
 	if port != "443" {
@@ -78,7 +78,7 @@ func TestLoopbackHostPortIPv6(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
+	if ip := netutils.ParseIPSloppy(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
 		t.Fatalf("expected IPv6 host to be loopback, got %q", host)
 	}
 	if port != "443" {

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -42,6 +41,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	netutils "k8s.io/utils/net"
 )
 
 func TestAuthorizeClientBearerTokenNoops(t *testing.T) {
@@ -80,7 +80,7 @@ func TestAuthorizeClientBearerTokenNoops(t *testing.T) {
 func TestNewWithDelegate(t *testing.T) {
 	delegateConfig := NewConfig(codecs)
 	delegateConfig.ExternalAddress = "192.168.10.4:443"
-	delegateConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	delegateConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	delegateConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	delegateConfig.LoopbackClientConfig = &rest.Config{}
 	clientset := fake.NewSimpleClientset()
@@ -112,7 +112,7 @@ func TestNewWithDelegate(t *testing.T) {
 
 	wrappingConfig := NewConfig(codecs)
 	wrappingConfig.ExternalAddress = "192.168.10.4:443"
-	wrappingConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	wrappingConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	wrappingConfig.LoopbackClientConfig = &rest.Config{}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates.go
@@ -20,12 +20,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 // BuildNamedCertificates returns a map of *tls.Certificate by name. It's
@@ -77,7 +77,7 @@ func getCertificateNames(cert *x509.Certificate) []string {
 	var names []string
 
 	cn := cert.Subject.CommonName
-	cnIsIP := net.ParseIP(cn) != nil
+	cnIsIP := netutils.ParseIPSloppy(cn) != nil
 	cnIsValidDomain := cn == "*" || len(validation.IsDNS1123Subdomain(strings.TrimPrefix(cn, "*."))) == 0
 	// don't use the CN if it is a valid IP because our IP serving detection may unexpectedly use it to terminate the connection.
 	if !cnIsIP && cnIsValidDomain {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	netutils "k8s.io/utils/net"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -246,7 +248,7 @@ NextTest:
 func parseIPList(ips []string) []net.IP {
 	var netIPs []net.IP
 	for _, ip := range ips {
-		netIPs = append(netIPs, net.ParseIP(ip))
+		netIPs = append(netIPs, netutils.ParseIPSloppy(ip))
 	}
 	return netIPs
 }
@@ -302,7 +304,7 @@ func generateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 		IsCA:                  true,
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	} else {
 		template.DNSNames = append(template.DNSNames, host)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -54,6 +54,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	kubeopenapi "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -127,7 +128,7 @@ func testGetOpenAPIDefinitions(_ kubeopenapi.ReferenceCallback) map[string]kubeo
 func setUp(t *testing.T) (Config, *assert.Assertions) {
 	config := NewConfig(codecs)
 	config.ExternalAddress = "192.168.10.4:443"
-	config.PublicAddress = net.ParseIP("192.168.10.4")
+	config.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.LoopbackClientConfig = &restclient.Config{}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package options
 
 import (
-	"net"
 	"strings"
 	"testing"
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	netutils "k8s.io/utils/net"
 )
 
 func TestServerRunOptionsValidate(t *testing.T) {
@@ -34,7 +34,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when MaxRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         -400,
 				MaxMutatingRequestsInFlight: 200,
@@ -48,7 +48,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when MaxMutatingRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: -200,
@@ -62,7 +62,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when RequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -76,7 +76,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when MinRequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -90,7 +90,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when JSONPatchMaxCopyBytes is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -104,7 +104,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when MaxRequestBodyBytes is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -118,7 +118,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when LivezGracePeriod is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -133,7 +133,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when MinimalShutdownDuration is negative value",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -148,7 +148,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when HSTSHeaders is valid",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				HSTSDirectives:              []string{"fakevalue", "includeSubDomains", "preload"},
 				MaxRequestsInFlight:         400,
@@ -163,7 +163,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 		{
 			name: "Test when ServerRunOptions is valid",
 			testOptions: &ServerRunOptions{
-				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				HSTSDirectives:              []string{"max-age=31536000", "includeSubDomains", "preload"},
 				MaxRequestsInFlight:         400,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/server"
@@ -108,7 +109,7 @@ type GeneratableKeyCert struct {
 
 func NewSecureServingOptions() *SecureServingOptions {
 	return &SecureServingOptions{
-		BindAddress: net.ParseIP("0.0.0.0"),
+		BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 		BindPort:    443,
 		ServerCert: GeneratableKeyCert{
 			PairName:      "apiserver",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
+	netutils "k8s.io/utils/net"
 )
 
 func setUp(t *testing.T) server.Config {
@@ -277,7 +278,7 @@ func TestServerRunWithSNI(t *testing.T) {
 
 			config.EnableIndex = true
 			secureOptions := (&SecureServingOptions{
-				BindAddress: net.ParseIP("127.0.0.1"),
+				BindAddress: netutils.ParseIPSloppy("127.0.0.1"),
 				BindPort:    6443,
 				ServerCert: GeneratableKeyCert{
 					CertKey: CertKey{
@@ -381,7 +382,7 @@ func TestServerRunWithSNI(t *testing.T) {
 func parseIPList(ips []string) []net.IP {
 	var netIPs []net.IP
 	for _, ip := range ips {
-		netIPs = append(netIPs, net.ParseIP(ip))
+		netIPs = append(netIPs, netutils.ParseIPSloppy(ip))
 	}
 	return netIPs
 }
@@ -488,7 +489,7 @@ func generateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 		IsCA:                  true,
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	} else {
 		template.DNSNames = append(template.DNSNames, host)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
+	netutils "k8s.io/utils/net"
 )
 
 func TestEmptyMainCert(t *testing.T) {
@@ -29,7 +30,7 @@ func TestEmptyMainCert(t *testing.T) {
 	var loopbackClientConfig *rest.Config
 
 	s := (&SecureServingOptions{
-		BindAddress: net.ParseIP("127.0.0.1"),
+		BindAddress: netutils.ParseIPSloppy("127.0.0.1"),
 	}).WithLoopback()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 // terminationLoggingListener wraps the given listener to mark late connections
@@ -145,7 +146,7 @@ func isLocal(req *http.Request) bool {
 	host, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
 		// ignore error and keep going
-	} else if ip := net.ParseIP(host); ip != nil {
+	} else if ip := netutils.ParseIPSloppy(host); ip != nil {
 		return ip.IsLoopback()
 	}
 

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -28,9 +28,10 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	netutils "k8s.io/utils/net"
 )
 
 // PortForwardProtocolV1Name is the subprotocol used for port forwarding.
@@ -131,9 +132,9 @@ func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
 				ip := listenAddress{address: "::1", protocol: "tcp6", failureMode: "all"}
 				parsed[ip.address] = ip
 			}
-		} else if net.ParseIP(address).To4() != nil {
+		} else if netutils.ParseIPSloppy(address).To4() != nil {
 			parsed[address] = listenAddress{address: address, protocol: "tcp4", failureMode: "any"}
-		} else if net.ParseIP(address) != nil {
+		} else if netutils.ParseIPSloppy(address) != nil {
 			parsed[address] = listenAddress{address: address, protocol: "tcp6", failureMode: "any"}
 		} else {
 			return nil, fmt.Errorf("%s is not a valid IP", address)

--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/util/keyutil"
+	netutils "k8s.io/utils/net"
 )
 
 const duration365d = time.Hour * 24 * 365
@@ -157,7 +158,7 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 		BasicConstraintsValid: true,
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	} else {
 		template.DNSNames = append(template.DNSNames, host)

--- a/staging/src/k8s.io/client-go/util/cert/csr_test.go
+++ b/staging/src/k8s.io/client-go/util/cert/csr_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/util/keyutil"
+	netutils "k8s.io/utils/net"
 )
 
 func TestMakeCSR(t *testing.T) {
@@ -33,7 +34,7 @@ func TestMakeCSR(t *testing.T) {
 		CommonName: "kube-worker",
 	}
 	dnsSANs := []string{"localhost"}
-	ipSANs := []net.IP{net.ParseIP("127.0.0.1")}
+	ipSANs := []net.IP{netutils.ParseIPSloppy("127.0.0.1")}
 
 	keyData, err := ioutil.ReadFile(keyFile)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	clienttesting "k8s.io/client-go/testing"
+	netutils "k8s.io/utils/net"
 )
 
 var storeCertData = newCertificateData(`-----BEGIN CERTIFICATE-----
@@ -394,11 +395,11 @@ func TestCertSatisfiesTemplate(t *testing.T) {
 			name: "Missing IP addresses in certificate",
 			cert: &x509.Certificate{
 				Subject:     pkix.Name{},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1")},
 			},
 			template: &x509.CertificateRequest{
 				Subject:     pkix.Name{},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.1.2")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1"), netutils.ParseIPSloppy("192.168.1.2")},
 			},
 			shouldSatisfy: false,
 		},
@@ -406,11 +407,11 @@ func TestCertSatisfiesTemplate(t *testing.T) {
 			name: "Extra IP addresses in certificate",
 			cert: &x509.Certificate{
 				Subject:     pkix.Name{},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.1.2")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1"), netutils.ParseIPSloppy("192.168.1.2")},
 			},
 			template: &x509.CertificateRequest{
 				Subject:     pkix.Name{},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1")},
 			},
 			shouldSatisfy: true,
 		},
@@ -422,7 +423,7 @@ func TestCertSatisfiesTemplate(t *testing.T) {
 					Organization: []string{"system:nodes"},
 				},
 				DNSNames:    []string{"foo.example.com"},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1")},
 			},
 			template: &x509.CertificateRequest{
 				Subject: pkix.Name{
@@ -430,7 +431,7 @@ func TestCertSatisfiesTemplate(t *testing.T) {
 					Organization: []string{"system:nodes"},
 				},
 				DNSNames:    []string{"foo.example.com"},
-				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				IPAddresses: []net.IP{netutils.ParseIPSloppy("192.168.1.1")},
 			},
 			shouldSatisfy: true,
 		},

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -24,8 +24,9 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -340,7 +341,7 @@ func (rc *RouteController) updateNetworkingCondition(node *v1.Node, routesCreate
 }
 
 func (rc *RouteController) isResponsibleForRoute(route *cloudprovider.Route) bool {
-	_, cidr, err := net.ParseCIDR(route.DestinationCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(route.DestinationCIDR)
 	if err != nil {
 		klog.Errorf("Ignoring route %s, unparsable CIDR: %v", route.Name, err)
 		return false

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
@@ -31,6 +31,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	fakecloud "k8s.io/cloud-provider/fake"
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
+	netutils "k8s.io/utils/net"
 )
 
 func alwaysReady() bool { return true }
@@ -60,7 +61,7 @@ func TestIsResponsibleForRoute(t *testing.T) {
 		{"a00:100::/10", myClusterRoute, "b00:100::/24", false},
 	}
 	for i, testCase := range testCases {
-		_, cidr, err := net.ParseCIDR(testCase.clusterCIDR)
+		_, cidr, err := netutils.ParseCIDRSloppy(testCase.clusterCIDR)
 		if err != nil {
 			t.Errorf("%d. Error in test case: unparsable cidr %q", i, testCase.clusterCIDR)
 		}
@@ -359,10 +360,10 @@ func TestReconcile(t *testing.T) {
 			t.Error("Error in test: fakecloud doesn't support Routes()")
 		}
 		cidrs := make([]*net.IPNet, 0)
-		_, cidr, _ := net.ParseCIDR("10.120.0.0/16")
+		_, cidr, _ := netutils.ParseCIDRSloppy("10.120.0.0/16")
 		cidrs = append(cidrs, cidr)
 		if testCase.dualStack {
-			_, cidrv6, _ := net.ParseCIDR("ace:cab:deca::/8")
+			_, cidrv6, _ := netutils.ParseCIDRSloppy("ace:cab:deca::/8")
 			cidrs = append(cidrs, cidrv6)
 		}
 

--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -42,6 +42,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	cmoptions "k8s.io/controller-manager/options"
 	"k8s.io/controller-manager/pkg/clientbuilder"
+	netutils "k8s.io/utils/net"
 
 	// add the related feature gates
 	_ "k8s.io/controller-manager/pkg/features/register"
@@ -88,7 +89,7 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 		},
 		SecureServing: apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{
-			BindAddress: net.ParseIP(componentConfig.Generic.Address),
+			BindAddress: netutils.ParseIPSloppy(componentConfig.Generic.Address),
 			BindPort:    int(componentConfig.Generic.Port),
 			BindNetwork: "tcp",
 		}).WithLoopback(),
@@ -247,7 +248,7 @@ func (o *CloudControllerManagerOptions) Config(allControllers, disabledByDefault
 		return nil, err
 	}
 
-	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
 	"reflect"
 	"testing"
 	"time"
@@ -32,6 +31,7 @@ import (
 	cmconfig "k8s.io/controller-manager/config"
 	cmoptions "k8s.io/controller-manager/options"
 	migration "k8s.io/controller-manager/pkg/leadermigration/options"
+	netutils "k8s.io/utils/net"
 )
 
 func TestDefaultFlags(t *testing.T) {
@@ -92,7 +92,7 @@ func TestDefaultFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10258,
-			BindAddress: net.ParseIP("0.0.0.0"),
+			BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "",
 				PairName:      "cloud-controller-manager",
@@ -100,7 +100,7 @@ func TestDefaultFlags(t *testing.T) {
 			HTTP2MaxStreamsPerConnection: 0,
 		}).WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{
-			BindAddress: net.ParseIP("0.0.0.0"),
+			BindAddress: netutils.ParseIPSloppy("0.0.0.0"),
 			BindPort:    int(0),
 			BindNetwork: "tcp",
 		}).WithLoopback(),
@@ -231,7 +231,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,
-			BindAddress: net.ParseIP("192.168.4.21"),
+			BindAddress: netutils.ParseIPSloppy("192.168.4.21"),
 			ServerCert: apiserveroptions.GeneratableKeyCert{
 				CertDirectory: "/a/b/c",
 				PairName:      "cloud-controller-manager",
@@ -239,7 +239,7 @@ func TestAddFlags(t *testing.T) {
 			HTTP2MaxStreamsPerConnection: 47,
 		}).WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{
-			BindAddress: net.ParseIP("192.168.4.10"),
+			BindAddress: netutils.ParseIPSloppy("192.168.4.10"),
 			BindPort:    int(10000),
 			BindNetwork: "tcp",
 		}).WithLoopback(),

--- a/staging/src/k8s.io/cluster-bootstrap/go.sum
+++ b/staging/src/k8s.io/cluster-bootstrap/go.sum
@@ -84,6 +84,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -202,6 +203,8 @@ k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a h1:8dYfu/Fc9Gz2rNJKB9IQRGgQOh2clmRzNIPPY1xLY5g=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/staging/src/k8s.io/csi-translation-lib/go.sum
+++ b/staging/src/k8s.io/csi-translation-lib/go.sum
@@ -85,6 +85,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -197,6 +198,8 @@ k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a h1:8dYfu/Fc9Gz2rNJKB9IQRGgQOh2clmRzNIPPY1xLY5g=
+k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -23,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"path"
 	"regexp"
 	"sort"
@@ -49,6 +49,7 @@ import (
 	"gopkg.in/gcfg.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1591,7 +1592,7 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 
 		for _, internalIP := range networkInterface.PrivateIpAddresses {
 			if ipAddress := aws.StringValue(internalIP.PrivateIpAddress); ipAddress != "" {
-				ip := net.ParseIP(ipAddress)
+				ip := netutils.ParseIPSloppy(ipAddress)
 				if ip == nil {
 					return nil, fmt.Errorf("EC2 instance had invalid private address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
 				}
@@ -1603,7 +1604,7 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 	// TODO: Other IP addresses (multiple ips)?
 	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
 	if publicIPAddress != "" {
-		ip := net.ParseIP(publicIPAddress)
+		ip := netutils.ParseIPSloppy(publicIPAddress)
 		if ip == nil {
 			return nil, fmt.Errorf("EC2 instance had invalid public address: %s (%s)", aws.StringValue(instance.InstanceId), publicIPAddress)
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -38,12 +39,13 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
+	netutils "k8s.io/utils/net"
 )
 
 func fakeGCECloud(vals TestClusterValues) (*Cloud, error) {
@@ -120,7 +122,7 @@ type gceInstance struct {
 
 var (
 	autoSubnetIPRange = &net.IPNet{
-		IP:   net.ParseIP("10.128.0.0"),
+		IP:   netutils.ParseIPSloppy("10.128.0.0"),
 		Mask: net.CIDRMask(9, 32),
 	}
 )
@@ -305,7 +307,7 @@ func lastIPInRange(cidr *net.IPNet) net.IP {
 func subnetsInCIDR(subnets []*compute.Subnetwork, cidr *net.IPNet) ([]*compute.Subnetwork, error) {
 	var res []*compute.Subnetwork
 	for _, subnet := range subnets {
-		_, subnetRange, err := net.ParseCIDR(subnet.IpCidrRange)
+		_, subnetRange, err := netutils.ParseCIDRSloppy(subnet.IpCidrRange)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse CIDR %q for subnet %q: %v", subnet.IpCidrRange, subnet.Name, err)
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
@@ -44,7 +44,7 @@ func TestLastIPInRange(t *testing.T) {
 	} {
 		_, c, err := net.ParseCIDR(tc.cidr)
 		if err != nil {
-			t.Errorf("net.ParseCIDR(%v) = _, %v, %v; want nil", tc.cidr, c, err)
+			t.Errorf("can't parse CIDR %v = _, %v, %v; want nil", tc.cidr, c, err)
 			continue
 		}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -20,12 +21,12 @@ package gce
 
 import (
 	"context"
-	"net"
 	"reflect"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutils "k8s.io/utils/net"
 )
 
 func TestLastIPInRange(t *testing.T) {
@@ -42,7 +43,7 @@ func TestLastIPInRange(t *testing.T) {
 		{"::0/126", "::3"},
 		{"::0/120", "::ff"},
 	} {
-		_, c, err := net.ParseCIDR(tc.cidr)
+		_, c, err := netutils.ParseCIDRSloppy(tc.cidr)
 		if err != nil {
 			t.Errorf("can't parse CIDR %v = _, %v, %v; want nil", tc.cidr, c, err)
 			continue

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -25,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"reflect"
@@ -52,6 +52,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -656,14 +657,14 @@ func getAddressByName(client *gophercloud.ServiceClient, name types.NodeName, ne
 	}
 
 	for _, addr := range addrs {
-		isIPv6 := net.ParseIP(addr.Address).To4() == nil
+		isIPv6 := netutils.ParseIPSloppy(addr.Address).To4() == nil
 		if (addr.Type == v1.NodeInternalIP) && (isIPv6 == needIPv6) {
 			return addr.Address, nil
 		}
 	}
 
 	for _, addr := range addrs {
-		isIPv6 := net.ParseIP(addr.Address).To4() == nil
+		isIPv6 := netutils.ParseIPSloppy(addr.Address).To4() == nil
 		if (addr.Type == v1.NodeExternalIP) && (isIPv6 == needIPv6) {
 			return addr.Address, nil
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -21,7 +22,6 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -40,6 +40,7 @@ import (
 	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/pagination"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1059,7 +1060,7 @@ func (lbaas *LbaasV2) ensureSecurityGroup(clusterName string, apiService *v1.Ser
 		for _, port := range ports {
 			for _, sourceRange := range sourceRanges.StringSlice() {
 				ethertype := rules.EtherType4
-				network, _, err := net.ParseCIDR(sourceRange)
+				network, _, err := netutils.ParseCIDRSloppy(sourceRange)
 
 				if err != nil {
 					return fmt.Errorf("error parsing source range %s as a CIDR: %v", sourceRange, err)

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_routes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_routes.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -21,7 +22,6 @@ package openstack
 import (
 	"context"
 	"errors"
-	"net"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 var errNoRouterID = errors.New("router-id not set in cloud provider config")
@@ -154,7 +155,7 @@ func (r *Routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 
 	onFailure := newCaller()
 
-	ip, _, _ := net.ParseCIDR(route.DestinationCIDR)
+	ip, _, _ := netutils.ParseCIDRSloppy(route.DestinationCIDR)
 	isCIDRv6 := ip.To4() == nil
 	addr, err := getAddressByName(r.compute, route.TargetNode, isCIDRv6)
 
@@ -230,7 +231,7 @@ func (r *Routes) DeleteRoute(ctx context.Context, clusterName string, route *clo
 
 	onFailure := newCaller()
 
-	ip, _, _ := net.ParseCIDR(route.DestinationCIDR)
+	ip, _, _ := netutils.ParseCIDRSloppy(route.DestinationCIDR)
 	isCIDRv6 := ip.To4() == nil
 
 	var addr string

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_routes_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_routes_test.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -20,13 +21,13 @@ package openstack
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	netutils "k8s.io/utils/net"
 )
 
 func TestRoutes(t *testing.T) {
@@ -73,7 +74,7 @@ func TestRoutes(t *testing.T) {
 		t.Fatalf("ListRoutes() error: %v", err)
 	}
 	for _, route := range routelist {
-		_, cidr, err := net.ParseCIDR(route.DestinationCIDR)
+		_, cidr, err := netutils.ParseCIDRSloppy(route.DestinationCIDR)
 		if err != nil {
 			t.Logf("Ignoring route %s, unparsable CIDR: %v", route.Name, err)
 			continue

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1,3 +1,4 @@
+//go:build !providerless
 // +build !providerless
 
 /*
@@ -52,6 +53,7 @@ import (
 	volerr "k8s.io/cloud-provider/volume/errors"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/legacy-cloud-providers/vsphere/vclib"
 	"k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers"
@@ -718,7 +720,7 @@ func (vs *VSphere) getNodeAddressesFromVM(ctx context.Context, nodeName k8stypes
 	for _, v := range vmMoList[0].Guest.Net {
 		if vs.cfg.Network.PublicNetwork == v.Network {
 			for _, ip := range v.IpAddress {
-				if !net.ParseIP(ip).IsLinkLocalUnicast() {
+				if !netutils.ParseIPSloppy(ip).IsLinkLocalUnicast() {
 					nodehelpers.AddToNodeAddresses(&addrs,
 						v1.NodeAddress{
 							Type:    v1.NodeExternalIP,

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/component-base v0.22.1
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 )
 
 replace (

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -39,6 +39,7 @@ import (
 	clientset "k8s.io/sample-apiserver/pkg/generated/clientset/versioned"
 	informers "k8s.io/sample-apiserver/pkg/generated/informers/externalversions"
 	sampleopenapi "k8s.io/sample-apiserver/pkg/generated/openapi"
+	netutils "k8s.io/utils/net"
 )
 
 const defaultEtcdPathPrefix = "/registry/wardle.example.com"
@@ -116,7 +117,7 @@ func (o *WardleServerOptions) Complete() error {
 // Config returns config for the api server given WardleServerOptions
 func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -38,6 +38,7 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -332,7 +333,7 @@ func GenerateRSACerts(host string, isCA bool) ([]byte, []byte, error) {
 
 	hosts := strings.Split(host, ",")
 	for _, h := range hosts {
-		if ip := net.ParseIP(h); ip != nil {
+		if ip := netutils.ParseIPSloppy(h); ip != nil {
 			template.IPAddresses = append(template.IPAddresses, ip)
 		} else {
 			template.DNSNames = append(template.DNSNames, h)

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -48,7 +48,7 @@ import (
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 // NodePortRange should match whatever the default/configured range is
@@ -820,7 +820,7 @@ func testReachabilityOverServiceName(serviceName string, sp v1.ServicePort, exec
 
 func testReachabilityOverClusterIP(clusterIP string, sp v1.ServicePort, execPod *v1.Pod) error {
 	// If .spec.clusterIP is set to "" or "None" for service, ClusterIP is not created, so reachability can not be tested over clusterIP:servicePort
-	if net.ParseIP(clusterIP) == nil {
+	if netutils.ParseIPSloppy(clusterIP) == nil {
 		return fmt.Errorf("unable to parse ClusterIP: %s", clusterIP)
 	}
 	return testEndpointReachability(clusterIP, sp.Port, sp.Protocol, execPod)
@@ -832,7 +832,7 @@ func testReachabilityOverExternalIP(externalIP string, sp v1.ServicePort, execPo
 
 func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v1.Pod, clusterIP string, externalIPs bool) error {
 	internalAddrs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
-	isClusterIPV4 := utilsnet.IsIPv4String(clusterIP)
+	isClusterIPV4 := netutils.IsIPv4String(clusterIP)
 
 	for _, internalAddr := range internalAddrs {
 		// If the node's internal address points to localhost, then we are not
@@ -842,7 +842,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 			continue
 		}
 		// Check service reachability on the node internalIP which is same family as clusterIP
-		if isClusterIPV4 != utilsnet.IsIPv4String(internalAddr) {
+		if isClusterIPV4 != netutils.IsIPv4String(internalAddr) {
 			framework.Logf("skipping testEndpointReachability() for internal adddress %s as it does not match clusterIP (%s) family", internalAddr, clusterIP)
 			continue
 		}
@@ -855,7 +855,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 	if externalIPs {
 		externalAddrs := e2enode.CollectAddresses(nodes, v1.NodeExternalIP)
 		for _, externalAddr := range externalAddrs {
-			if isClusterIPV4 != utilsnet.IsIPv4String(externalAddr) {
+			if isClusterIPV4 != netutils.IsIPv4String(externalAddr) {
 				framework.Logf("skipping testEndpointReachability() for external adddress %s as it does not match clusterIP (%s) family", externalAddr, clusterIP)
 				continue
 			}
@@ -871,7 +871,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 // isInvalidOrLocalhostAddress returns `true` if the provided `ip` is either not
 // parsable or the loopback address. Otherwise it will return `false`.
 func isInvalidOrLocalhostAddress(ip string) bool {
-	parsedIP := net.ParseIP(ip)
+	parsedIP := netutils.ParseIPSloppy(ip)
 	if parsedIP == nil || parsedIP.IsLoopback() {
 		return true
 	}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -63,6 +63,7 @@ import (
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	uexec "k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 
 	// TODO: Remove the following imports (ref: https://github.com/kubernetes/kubernetes/issues/81245)
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -1265,7 +1266,7 @@ func getControlPlaneAddresses(c clientset.Interface) ([]string, []string, []stri
 	if err != nil {
 		Failf("Failed to parse hostname: %v", err)
 	}
-	if net.ParseIP(hostURL.Host) != nil {
+	if netutils.ParseIPSloppy(hostURL.Host) != nil {
 		externalIPs = append(externalIPs, hostURL.Host)
 	} else {
 		hostnames = append(hostnames, hostURL.Host)

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	netutils "k8s.io/utils/net"
 
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -73,7 +74,7 @@ func (k *kubeManager) initializeCluster(model *Model) error {
 			if err != nil {
 				return err
 			}
-			if net.ParseIP(svc.Spec.ClusterIP) == nil {
+			if netutils.ParseIPSloppy(svc.Spec.ClusterIP) == nil {
 				return fmt.Errorf("empty IP address found for service %s/%s", svc.Namespace, svc.Name)
 			}
 			pod.ServiceIP = svc.Spec.ClusterIP

--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/kubernetes/test/e2e/storage/utils"
 	"net"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/kubernetes/test/e2e/storage/utils"
 
 	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
@@ -42,7 +43,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 /*
@@ -1346,7 +1347,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 				framework.ExpectNoError(err, "Error occurred while getting pod status.")
 			}
 			hostMask := 32
-			if utilnet.IsIPv6String(podServerStatus.Status.PodIP) {
+			if netutils.IsIPv6String(podServerStatus.Status.PodIP) {
 				hostMask = 128
 			}
 			podServerCIDR := fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, hostMask)
@@ -1416,11 +1417,11 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 
 			allowMask := 24
 			hostMask := 32
-			if utilnet.IsIPv6String(podServerStatus.Status.PodIP) {
+			if netutils.IsIPv6String(podServerStatus.Status.PodIP) {
 				allowMask = 64
 				hostMask = 128
 			}
-			_, podServerAllowSubnet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, allowMask))
+			_, podServerAllowSubnet, err := netutils.ParseCIDRSloppy(fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, allowMask))
 			framework.ExpectNoError(err, "could not parse allow subnet")
 			podServerAllowCIDR := podServerAllowSubnet.String()
 
@@ -1479,11 +1480,11 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 
 			allowMask := 24
 			hostMask := 32
-			if utilnet.IsIPv6String(podServerStatus.Status.PodIP) {
+			if netutils.IsIPv6String(podServerStatus.Status.PodIP) {
 				allowMask = 64
 				hostMask = 128
 			}
-			_, podServerAllowSubnet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, allowMask))
+			_, podServerAllowSubnet, err := netutils.ParseCIDRSloppy(fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, allowMask))
 			framework.ExpectNoError(err, "could not parse allow subnet")
 			podServerAllowCIDR := podServerAllowSubnet.String()
 

--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -18,11 +18,11 @@ package netpol
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	netutils "k8s.io/utils/net"
 )
 
 // decouple us from k8smanager.go
@@ -95,7 +95,7 @@ func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobR
 	defer ginkgo.GinkgoRecover()
 	for job := range jobs {
 		podFrom := job.PodFrom
-		if net.ParseIP(job.PodTo.ServiceIP) == nil {
+		if netutils.ParseIPSloppy(job.PodTo.ServiceIP) == nil {
 			results <- &ProbeJobResults{
 				Job:         job,
 				IsConnected: false,

--- a/test/e2e_kubeadm/networking_test.go
+++ b/test/e2e_kubeadm/networking_test.go
@@ -18,12 +18,12 @@ package kubeadm
 
 import (
 	"context"
-	"net"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	netutils "k8s.io/utils/net"
 
 	"github.com/onsi/ginkgo"
 )
@@ -163,14 +163,14 @@ var _ = Describe("networking [setup-networking]", func() {
 
 // ipWithinSubnet returns true if an IP (targetIP) falls within the reference subnet (refIPNet)
 func ipWithinSubnet(refIPNet, targetIP string) bool {
-	_, rNet, _ := net.ParseCIDR(refIPNet)
-	tIP := net.ParseIP(targetIP)
+	_, rNet, _ := netutils.ParseCIDRSloppy(refIPNet)
+	tIP := netutils.ParseIPSloppy(targetIP)
 	return rNet.Contains(tIP)
 }
 
 // subnetWithinSubnet returns true if a subnet (targetNet) falls within the reference subnet (refIPNet)
 func subnetWithinSubnet(refIPNet, targetNet string) bool {
-	_, rNet, _ := net.ParseCIDR(refIPNet)
-	tNet, _, _ := net.ParseCIDR(targetNet)
+	_, rNet, _ := netutils.ParseCIDRSloppy(refIPNet)
+	tNet, _, _ := netutils.ParseCIDRSloppy(targetNet)
 	return rNet.Contains(tNet)
 }

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -19,10 +19,10 @@ package services
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	netutils "k8s.io/utils/net"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apiserver "k8s.io/kubernetes/cmd/kube-apiserver/app"
@@ -60,14 +60,14 @@ func (a *APIServer) Start() error {
 
 	o := options.NewServerRunOptions()
 	o.Etcd.StorageConfig = a.storageConfig
-	_, ipnet, err := net.ParseCIDR(clusterIPRange)
+	_, ipnet, err := netutils.ParseCIDRSloppy(clusterIPRange)
 	if err != nil {
 		return err
 	}
 	if len(framework.TestContext.RuntimeConfig) > 0 {
 		o.APIEnablement.RuntimeConfig = framework.TestContext.RuntimeConfig
 	}
-	o.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
+	o.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
 	o.ServiceClusterIPRanges = ipnet.String()
 	o.AllowPrivileged = true
 	if err := generateTokenFile(tokenFilePath); err != nil {

--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -38,6 +38,7 @@ import (
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
+	netutils "k8s.io/utils/net"
 )
 
 var (
@@ -660,7 +661,7 @@ func parseAddresses(addresses string) ([]string, error) {
 	res := make([]string, 0)
 	split := strings.Split(addresses, ",")
 	for _, address := range split {
-		netAddr := net.ParseIP(address)
+		netAddr := netutils.ParseIPSloppy(address)
 		if netAddr == nil {
 			return nil, fmt.Errorf("parseAddress: invalid address %s", address)
 		}

--- a/test/images/agnhost/no-snat-test/main.go
+++ b/test/images/agnhost/no-snat-test/main.go
@@ -19,13 +19,13 @@ package nosnat
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
+	netutils "k8s.io/utils/net"
 )
 
 // CmdNoSnatTest is used by agnhost Cobra.
@@ -83,10 +83,10 @@ func (m *masqTester) Run() error {
 	}
 
 	// validate that pip and nip are ip addresses.
-	if net.ParseIP(pip) == nil {
+	if netutils.ParseIPSloppy(pip) == nil {
 		return fmt.Errorf("POD_IP env var contained %q, which is not an IP address", pip)
 	}
-	if net.ParseIP(nip) == nil {
+	if netutils.ParseIPSloppy(nip) == nil {
 		return fmt.Errorf("NODE_IP env var contained %q, which is not an IP address", nip)
 	}
 

--- a/test/images/regression-issue-74839/main.go
+++ b/test/images/regression-issue-74839/main.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	netutils "k8s.io/utils/net"
 )
 
 // TCP port to listen
@@ -120,8 +122,8 @@ func probe(ip string) {
 				}
 
 				data := []byte("boom!!!")
-				remoteIP := net.ParseIP(addr.String())
-				localIP := net.ParseIP(conn.LocalAddr().String())
+				remoteIP := netutils.ParseIPSloppy(addr.String())
+				localIP := netutils.ParseIPSloppy(conn.LocalAddr().String())
 				_, err := conn.WriteTo(badPkt.encode(localIP, remoteIP, data[:]), addr)
 				if err != nil {
 					log.Printf("conn.WriteTo() error: %v", err)
@@ -141,10 +143,10 @@ func getIPs() []net.IP {
 	podIP, podIPs := os.Getenv("POD_IP"), os.Getenv("POD_IPS")
 	if podIPs != "" {
 		for _, ip := range strings.Split(podIPs, ",") {
-			ips = append(ips, net.ParseIP(ip))
+			ips = append(ips, netutils.ParseIPSloppy(ip))
 		}
 	} else if podIP != "" {
-		ips = append(ips, net.ParseIP(podIP))
+		ips = append(ips, netutils.ParseIPSloppy(podIP))
 	}
 	return ips
 }

--- a/test/integration/controlplane/synthetic_controlplane_test.go
+++ b/test/integration/controlplane/synthetic_controlplane_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"path"
@@ -51,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -638,7 +638,7 @@ func TestAPIServerService(t *testing.T) {
 
 func TestServiceAlloc(t *testing.T) {
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR("192.168.0.0/29")
+	_, cidr, err := netutils.ParseCIDRSloppy("192.168.0.0/29")
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -19,7 +19,6 @@ package dualstack
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
@@ -38,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/endpointslice"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/integration/framework"
+	netutils "k8s.io/utils/net"
 )
 
 func TestDualStackEndpoints(t *testing.T) {
@@ -52,13 +52,13 @@ func TestDualStackEndpoints(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, dualStack)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("Bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("Bad cidr: %v", err)
 	}

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -54,7 +54,7 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestCreateServiceDualStackIPv6(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -491,13 +491,13 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -718,13 +718,13 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -948,13 +948,13 @@ func TestUpgradeDowngrade(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1063,13 +1063,13 @@ func TestConvertToFromExternalName(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1153,7 +1153,7 @@ func TestExistingServiceDefaulting(t *testing.T) {
 	// Create an IPv4IPv6 dual stack control-plane
 	serviceCIDR := "10.0.0.0/16"
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1236,13 +1236,13 @@ func TestPreferDualStack(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	cfg.ExtraConfig.ServiceIPRange = *cidr
 
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1321,7 +1321,7 @@ func TestServiceUpdate(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, false)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1486,7 +1486,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	cfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1545,7 +1545,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 	closeFn()
 
 	secondaryServiceCIDR := "2001:db8:1::/48"
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
@@ -1582,12 +1582,12 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 	secondaryServiceCIDR := "2001:db8:1::/48"
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 	dualStackCfg := framework.NewIntegrationTestControlPlaneConfig()
-	_, cidr, err := net.ParseCIDR(serviceCIDR)
+	_, cidr, err := netutils.ParseCIDRSloppy(serviceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}
 	dualStackCfg.ExtraConfig.ServiceIPRange = *cidr
-	_, secCidr, err := net.ParseCIDR(secondaryServiceCIDR)
+	_, secCidr, err := netutils.ParseCIDRSloppy(secondaryServiceCIDR)
 	if err != nil {
 		t.Fatalf("bad cidr: %v", err)
 	}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
+	netutils "k8s.io/utils/net"
 
 	// install all APIs
 	_ "k8s.io/kubernetes/pkg/controlplane"
@@ -68,7 +69,7 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 		t.Fatal(err)
 	}
 
-	_, defaultServiceClusterIPRange, err := net.ParseCIDR("10.0.0.0/24")
+	_, defaultServiceClusterIPRange, err := netutils.ParseCIDRSloppy("10.0.0.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -50,6 +50,7 @@ import (
 	wardlev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	wardlev1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	sampleserver "k8s.io/sample-apiserver/pkg/cmd/server"
+	netutils "k8s.io/utils/net"
 )
 
 func TestAggregatedAPIServer(t *testing.T) {
@@ -80,7 +81,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	go func() {
 		o := sampleserver.NewWardleServerOptions(os.Stdout, os.Stderr)
 		o.RecommendedOptions.SecureServing.Listener = listener
-		o.RecommendedOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
+		o.RecommendedOptions.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
 		wardleCmd := sampleserver.NewCommandStartWardleServer(o, stopCh)
 		wardleCmd.SetArgs([]string{
 			"--authentication-kubeconfig", wardleToKASKubeConfigFile,

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
+	netutils "k8s.io/utils/net"
 )
 
 // Config is a struct of configuration directives for NewControlPlaneComponents.
@@ -205,7 +206,7 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 	}
 
 	if controlPlaneConfig.ExtraConfig.ServiceIPRange.IP == nil {
-		controlPlaneConfig.ExtraConfig.ServiceIPRange = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+		controlPlaneConfig.ExtraConfig.ServiceIPRange = net.IPNet{IP: netutils.ParseIPSloppy("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
 	}
 	m, err = controlPlaneConfig.Complete().New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
@@ -263,7 +264,7 @@ func NewIntegrationTestControlPlaneConfig() *controlplane.Config {
 // configured with the provided options.
 func NewIntegrationTestControlPlaneConfigWithOptions(opts *ControlPlaneConfigOptions) *controlplane.Config {
 	controlPlaneConfig := NewControlPlaneConfigWithOptions(opts)
-	controlPlaneConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	controlPlaneConfig.GenericConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	controlPlaneConfig.ExtraConfig.APIResourceConfigSource = controlplane.DefaultAPIResourceConfigSource()
 
 	// TODO: get rid of these tests or port them to secure serving

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/test/utils"
+	netutils "k8s.io/utils/net"
 )
 
 // This key is for testing purposes only and is not considered secure.
@@ -63,7 +64,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 		os.RemoveAll(certDir)
 	}()
 
-	_, defaultServiceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")
+	_, defaultServiceClusterIPRange, _ := netutils.ParseCIDRSloppy("10.0.0.0/24")
 	proxySigningKey, err := utils.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +106,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 
 	kubeAPIServerOptions := options.NewServerRunOptions()
 	kubeAPIServerOptions.SecureServing.Listener = listener
-	kubeAPIServerOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
+	kubeAPIServerOptions.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
 	kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
 	kubeAPIServerOptions.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
 	kubeAPIServerOptions.Etcd.StorageConfig.Prefix = path.Join("/", uuid.New().String(), "registry")

--- a/test/integration/ipamperf/ipam_test.go
+++ b/test/integration/ipamperf/ipam_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
@@ -117,8 +118,8 @@ func TestPerformance(t *testing.T) {
 	apiURL, apiserverShutdown := util.StartApiserver()
 	defer apiserverShutdown()
 
-	_, clusterCIDR, _ := net.ParseCIDR("10.96.0.0/11") // allows up to 8K nodes
-	_, serviceCIDR, _ := net.ParseCIDR("10.94.0.0/24") // does not matter for test - pick upto  250 services
+	_, clusterCIDR, _ := netutils.ParseCIDRSloppy("10.96.0.0/11") // allows up to 8K nodes
+	_, serviceCIDR, _ := netutils.ParseCIDRSloppy("10.94.0.0/24") // does not matter for test - pick upto  250 services
 	subnetMaskSize := 24
 
 	var (


### PR DESCRIPTION
golang 1.17 net.ParseIP and net.ParseCIDR will drop IP addresses with leading zeros.
Kubernetes exposes network parsers with the previous behavior on the k8s.io/utils repository to avoid breaking users that has already data stored in that format.

Backport https://github.com/kubernetes/kubernetes/pull/104368