### PR TITLE
UPSTREAM: revert 102925: Revert calculation for resource scoring

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -101,7 +101,7 @@ func balancedResourceScorer(requested, allocable resourceToValueMap) int64 {
 	for name, value := range requested {
 		fraction := float64(value) / float64(allocable[name])
 		if fraction > 1 {
-			fraction = 1
+			return 0
 		}
 		totalFraction += fraction
 		resourceToFractions = append(resourceToFractions, fraction)

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -116,9 +116,7 @@ func mostRequestedScore(requested, capacity int64) int64 {
 		return 0
 	}
 	if requested > capacity {
-		// `requested` might be greater than `capacity` because pods with no
-		// requests get minimum values.
-		requested = capacity
+		return 0
 	}
 
 	return (requested * framework.MaxNodeScore) / capacity


### PR DESCRIPTION
This reverts https://github.com/kubernetes/kubernetes/pull/102925 so we can build a test payload to see if symptoms from https://bugzilla.redhat.com/show_bug.cgi?id=2005076 still exist (this just updates logic, not tests)

Note that there is another PR, https://github.com/kubernetes/kubernetes/pull/101946, which modified this code further. We may also want to try reverting that if symptoms still persist after this change