### PR TITLE
UPSTREAM: revert 102925: Revert calculation for resource scoring

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -86,10 +86,10 @@ func balancedResourceScorer(requested, allocable resourceToValueMap, includeVolu
 	// fractions might be greater than 1 because pods with no requests get minimum
 	// values.
 	if cpuFraction > 1 {
-		cpuFraction = 1
+		return 0
 	}
 	if memoryFraction > 1 {
-		memoryFraction = 1
+		return 0
 	}
 
 	if includeVolumes && utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes) && allocatableVolumes > 0 {

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -112,7 +112,7 @@ func mostRequestedScore(requested, capacity int64) int64 {
 	if requested > capacity {
 		// `requested` might be greater than `capacity` because pods with no
 		// requests get minimum values.
-		requested = capacity
+		return 0
 	}
 
 	return (requested * framework.MaxNodeScore) / capacity


### PR DESCRIPTION
This reverts https://github.com/kubernetes/kubernetes/pull/102925 so we can build a test payload to see if symptoms from https://bugzilla.redhat.com/show_bug.cgi?id=2005076 still exist (this just updates logic, not tests)

(Unlike https://github.com/openshift/kubernetes/pull/972, this does not have to worry about https://github.com/kubernetes/kubernetes/pull/101946, which modified this code further.)