### PR TITLE
bug 1979671: UPSTREAM <carry>: Remove pod warning annotation when workload partitioning is disabled

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -214,9 +214,8 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, fmt.Errorf("%s the cluster does not have any nodes", PluginName))
 	}
 
-	// probably the workload feature disabled, because some of cluster nodes do not have workload resource
+	// probably the workload feature disabled, because some cluster nodes do not have workload resource
 	if err := isManagementResourceAvailableForAllNodes(nodes, workloadType); err != nil {
-		pod.Annotations[workloadAdmissionWarning] = err.Error()
 		return nil
 	}
 

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -277,11 +277,8 @@ func TestAdmit(t *testing.T) {
 			pod:                testManagedPod("500m", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			expectedAnnotations: map[string]string{
-				workloadAdmissionWarning: fmt.Sprintf("the node %q does not have resource %q", "node", managedCapacityLabel),
-			},
-			nodes: []*corev1.Node{testNode()},
-			infra: testClusterSNOInfra(),
+			nodes:              []*corev1.Node{testNode()},
+			infra:              testClusterSNOInfra(),
 		},
 		{
 			name:               "should return admission error when the cluster does not have any nodes",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When workload partitioning (currently available only for SNO) is disabled, user will not see any warning related to it. With this PR, the warning specified in the bugzilla ticket below is removed.

#### Which issue(s) this PR fixes:
Fixes **https://bugzilla.redhat.com/show_bug.cgi?id=1979671**
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
