### PR TITLE
bug 2008181: UPSTREAM: 105205: e2e scheduling priorities: do not reference control loop variable

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -485,9 +485,9 @@ func podListForEachNode(cs clientset.Interface) map[string][]*v1.Pod {
 	if err != nil {
 		framework.Failf("Expect error of invalid, got : %v", err)
 	}
-	for _, pod := range allPods.Items {
+	for i, pod := range allPods.Items {
 		nodeName := pod.Spec.NodeName
-		nodeNameToPodList[nodeName] = append(nodeNameToPodList[nodeName], &pod)
+		nodeNameToPodList[nodeName] = append(nodeNameToPodList[nodeName], &allPods.Items[i])
 	}
 	return nodeNameToPodList
 }


### PR DESCRIPTION
Otherwise, nodeNameToPodList[nodeName] list will have all its references
identical (corresponding to the control variable reference).
Thus, making all the pods in the list identical.

Backporting https://github.com/kubernetes/kubernetes/pull/105205
