### PR TITLE
Bug 2000754: UPSTREAM: 104865: e2e iperf2 change threshold to 10MBps = 80 Mbps

### DIFF
--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -39,8 +39,9 @@ import (
 const (
 	// use this timeout for larger clusters
 	largeClusterTimeout = 400 * time.Second
-	// iperf2BaselineBandwidthMegabytesPerSecond sets a baseline for iperf2 bandwidth of 90 MB/s
-	iperf2BaselineBandwidthMegabytesPerSecond = 90
+	// iperf2BaselineBandwidthMegabytesPerSecond sets a baseline for iperf2 bandwidth of 10 MBps = 80 Mbps
+	// this limits is chosen in order to support small devices with 100 mbps cards.
+	iperf2BaselineBandwidthMegabytesPerSecond = 10
 	// iperf2Port selects an arbitrary, unique port to run iperf2's client and server on
 	iperf2Port = 6789
 	// labelKey is used as a key for selectors


### PR DESCRIPTION
Cherry-pick of upstream fix:

> /kind flake
> 
> Network performance tests are implemented in https://github.com/kubernetes/perf-tests/tree/master/network/benchmarks/netperf
> 
> This test is an e2e test, and checks that there is a minimum acceptable BW between nodes.
> Use the minimum ethernet speed of 100Mbps as threshold, since kubernetes these days run in IOT and small devices.
> #### Which issue(s) this PR fixes:
> 
> ```
> NONE
> ```

