### PR TITLE
Bug 2018516: 4.9: hardcode Dockerfile to 1.22.1

### DIFF
--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
-RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination' && \
+RUN KUBE_GIT_VERSION=v1.22.1 make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination' && \
     mkdir -p /tmp/build && \
     cp openshift-hack/images/hyperkube/hyperkube /tmp/build && \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination} \


### PR DESCRIPTION
To stop the bleeding.