### PR TITLE
[WIP] Revert "Bug 2000216: Image policy should mutate DeploymentConfigs, StatefulSets, and new CronJobs"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/opencontainers/runc v1.0.2
 	github.com/opencontainers/selinux v1.8.2
 	github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e
-	github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823
+	github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775
 	github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7
 	github.com/openshift/library-go v0.0.0-20210909124717-1c18e732a117
 	github.com/pkg/errors v0.9.1
@@ -393,7 +393,7 @@ replace (
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.8.2
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e
-	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823
+	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775
 	github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210909124717-1c18e732a117

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/opencontainers/selinux v1.8.2 h1:c4ca10UMgRcvZ6h0K4HtS15UaVSBEaE+iln2
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e h1:XsxFkPW2fgme9OyWC8jhGdrbQlA8CMesDsMFbVZfWLI=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823 h1:we4feEhcXg5RaA/YkN7csvBDC+RSAVCvHySYXBnxWpQ=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775 h1:fNz1iZjs6SKMBk5hjogzHycSCWtHnCGxR5i4eYICSLg=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7 h1:iKVU5Tga76kiCWpq9giPi0TfI/gZcFoYb7/x+1SkgwM=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -421,7 +421,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -472,7 +472,7 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e h1:XsxFkPW2fgme9OyWC8jhGdrbQlA8CMesDsMFbVZfWLI=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -465,7 +465,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -439,7 +439,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -462,7 +462,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/controller-manager/go.sum
+++ b/staging/src/k8s.io/controller-manager/go.sum
@@ -550,7 +550,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -463,7 +463,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -460,7 +460,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -454,7 +454,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
-github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
+github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775/go.mod h1:zl9Q7KxHokDX4mc8NEeYlSnrHkAsKAzptlQESi/jNJw=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1/defaults.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1/defaults.go
@@ -25,7 +25,6 @@ func SetDefaults_ImagePolicyConfig(obj *ImagePolicyConfig) {
 		obj.ResolutionRules = []ImageResolutionPolicyRule{
 			{TargetResource: metav1.GroupResource{Group: "", Resource: "pods"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "", Resource: "replicationcontrollers"}, LocalNames: true},
-			{TargetResource: metav1.GroupResource{Group: "apps.openshift.io", Resource: "deploymentconfigs"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "daemonsets"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "deployments"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "statefulsets"}, LocalNames: true},

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagepolicy.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagepolicy.go
@@ -488,6 +488,8 @@ var skipImageRewriteOnUpdate = map[metav1.GroupResource]struct{}{
 	{Group: "batch", Resource: "jobs"}: {},
 	// Build specs are immutable, they cannot be updated.
 	{Group: "build.openshift.io", Resource: "builds"}: {},
+	// TODO: remove when statefulsets allow spec.template updates in 3.7
+	{Group: "apps", Resource: "statefulsets"}: {},
 }
 
 // RewriteImagePullSpec applies to implicit rewrite attributes and local resources as well as if the policy requires it.

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators/pods.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators/pods.go
@@ -97,8 +97,6 @@ func GetPodSpecV1(obj runtime.Object) (*corev1.PodSpec, *field.Path, error) {
 
 	case *batchv1beta1.CronJob:
 		return &r.Spec.JobTemplate.Spec.Template.Spec, field.NewPath("spec", "jobTemplate", "spec", "template", "spec"), nil
-	case *batchv1.CronJob:
-		return &r.Spec.JobTemplate.Spec.Template.Spec, field.NewPath("spec", "jobTemplate", "spec", "template", "spec"), nil
 
 	case *batchv1beta1.JobTemplate:
 		return &r.Template.Spec.Template.Spec, field.NewPath("template", "spec", "template", "spec"), nil
@@ -153,8 +151,6 @@ func GetTemplateMetaObject(obj runtime.Object) (metav1.Object, bool) {
 		return &r.Spec.Template.ObjectMeta, true
 
 	case *batchv1beta1.CronJob:
-		return &r.Spec.JobTemplate.Spec.Template.ObjectMeta, true
-	case *batchv1.CronJob:
 		return &r.Spec.JobTemplate.Spec.Template.ObjectMeta, true
 
 	case *batchv1beta1.JobTemplate:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -673,7 +673,7 @@ github.com/openshift/api/security
 github.com/openshift/api/security/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823 => github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823
+# github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775 => github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775
 ## explicit
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1
@@ -2806,7 +2806,7 @@ sigs.k8s.io/yaml
 # github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 # github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.8.2
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20210913115639-4809c1ef6b8e
-# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20211029110727-d0db65ce4823
+# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20211021140628-7d7260431775
 # github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210909124717-1c18e732a117


### PR DESCRIPTION
Reverts openshift/kubernetes#1014

Starting with 4.10.0-0.nightly-2021-11-03-064540, we are failing release payload acceptance on SDN upgrades.  [Out of all the  PR's](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2021-11-03-064540) this looks like possibly the most relevant. Reverting to test the hunch.

I'm not entirely clear what's wrong, but upgrades are failing with `the \"master\" pool should be updated before the CVO reports available at the new version` and authentication operator failing to upgrade.

Example failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade/1455719487931158528

The timeline I can piece together from the above looks like this:

@ 03:36:09, etcd reported unhealthy members: ip-10-0-169-115.us-west-1.compute.internal , which is a master

@ 03:36:27 Node ip-10-0-169-115.us-west-1.compute.internal status is now: NodeSchedulable

@ 03:36:33 Status for clusteroperator/openshift-apiserver changed: Degraded message changed from "APIServerDeploymentDegraded: 1 of 3 requested instances are unavailable for apiserver.openshift-apiserver

@ 03:36:33 Created container oauth-apiserver on the ip-10-0-169-115 master

@ 03:36:36 master was updating after cluster version reached level: the "master" pool should be updated before the CVO reports available at the new version

