### PR TITLE
[4.9] Bug 2022740: UPSTREAM: 106259: Don't guess SELinux support on error

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -276,7 +276,8 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 
 	c.supportsSELinux, err = c.kubeVolHost.GetHostUtil().GetSELinuxSupport(dir)
 	if err != nil {
-		klog.V(2).Info(log("error checking for SELinux support: %s", err))
+		// The volume is mounted. Return UncertainProgressError, so kubelet will unmount it when user deletes the pod.
+		return volumetypes.NewUncertainProgressError(fmt.Sprintf("error checking for SELinux support: %s", err))
 	}
 
 	if !driverSupportsCSIVolumeMountGroup && c.supportsFSGroup(fsType, mounterArgs.FsGroup, c.fsGroupPolicy) {

--- a/pkg/volume/util/hostutil/fake_hostutil.go
+++ b/pkg/volume/util/hostutil/fake_hostutil.go
@@ -108,7 +108,7 @@ func (hu *FakeHostUtil) GetOwner(pathname string) (int64, int64, error) {
 // GetSELinuxSupport tests if pathname is on a mount that supports SELinux.
 // Not implemented for testing
 func (hu *FakeHostUtil) GetSELinuxSupport(pathname string) (bool, error) {
-	return false, errors.New("GetSELinuxSupport not implemented")
+	return false, nil
 }
 
 // GetMode returns permissions of pathname.

--- a/pkg/volume/util/hostutil/hostutil_linux.go
+++ b/pkg/volume/util/hostutil/hostutil_linux.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/mount-utils"
 	utilpath "k8s.io/utils/path"
 )
@@ -229,8 +230,16 @@ func DoMakeRShared(path string, mountInfoFilename string) error {
 	return nil
 }
 
+// selinux.SELinuxEnabled implementation for unit tests
+type seLinuxEnabledFunc func() bool
+
 // GetSELinux is common implementation of GetSELinuxSupport on Linux.
-func GetSELinux(path string, mountInfoFilename string) (bool, error) {
+func GetSELinux(path string, mountInfoFilename string, selinuxEnabled seLinuxEnabledFunc) (bool, error) {
+	// Skip /proc/mounts parsing if SELinux is disabled.
+	if !selinuxEnabled() {
+		return false, nil
+	}
+
 	info, err := findMountInfo(path, mountInfoFilename)
 	if err != nil {
 		return false, err
@@ -253,7 +262,7 @@ func GetSELinux(path string, mountInfoFilename string) (bool, error) {
 // GetSELinuxSupport returns true if given path is on a mount that supports
 // SELinux.
 func (hu *HostUtil) GetSELinuxSupport(pathname string) (bool, error) {
-	return GetSELinux(pathname, procMountInfoPath)
+	return GetSELinux(pathname, procMountInfoPath, selinux.SELinuxEnabled)
 }
 
 // GetOwner returns the integer ID for the user and group of the given path

--- a/pkg/volume/util/hostutil/hostutil_linux_test.go
+++ b/pkg/volume/util/hostutil/hostutil_linux_test.go
@@ -156,27 +156,37 @@ func TestGetSELinuxSupport(t *testing.T) {
 	tests := []struct {
 		name           string
 		mountPoint     string
+		selinuxEnabled bool
 		expectedResult bool
 	}{
 		{
+			"ext4 on / with disabled SELinux",
+			"/",
+			false,
+			false,
+		},
+		{
 			"ext4 on /",
 			"/",
+			true,
 			true,
 		},
 		{
 			"tmpfs on /var/lib/bar",
 			"/var/lib/bar",
+			true,
 			false,
 		},
 		{
 			"nfsv4",
 			"/media/nfs_vol",
+			true,
 			false,
 		},
 	}
 
 	for _, test := range tests {
-		out, err := GetSELinux(test.mountPoint, filename)
+		out, err := GetSELinux(test.mountPoint, filename, func() bool { return test.selinuxEnabled })
 		if err != nil {
 			t.Errorf("Test %s failed with error: %s", test.name, err)
 		}


### PR DESCRIPTION
When GetSELinuxSupport() fails, don't assume a mounted filesystem does not support SELinux at all. Try again instead in the next SetUp retry.

cc @openshift/storage 