### PR TITLE
UPSTREAM: <carry>: additional rebase commit checks

### DIFF
--- a/REBASE.openshift.md
+++ b/REBASE.openshift.md
@@ -309,6 +309,21 @@ podman run -it --rm -v $( pwd ):/go/k8s.io/kubernetes:Z --workdir=/go/k8s.io/kub
     exhibiting test failure. If in doubt, ask for help!
 - Verify the code with `make verify`
 
+## Important Reviewer Considerations
+
+The rebases have to merge from the latest OCP release to the very last supported, for example from 4.9 all the way down to 4.6.
+It can happen that one of the earlier releases (eg 4.7) might be further ahead than the other rebases. This means that a
+customer upgrading a cluster from the ahead version (4.7) could regress on the missing fixes in later releases (4.8, 4.9 etc).
+
+There is a prow check in the `verify-commits` job that will test that commits in the current PR are also present in (n+2) branches ahead.
+This might have several false-positives due to the upstream release process, but it can be a helpful indicator that this PR is sane.
+The output of the tool can be found in the stdout log of the prow job, usually found in the artifacts `artifacts/test/artifacts/logs/scripts.log` path.
+
+Another check that should be done by the reviewer is the upstream release date check where you ensure that the rebase versions are
+close together in their release dates. Check out the respective rebases that are being proposed and cross-reference them 
+with the [k/k release page](https://kubernetes.io/releases/). k/k z releases come once around the middle of a month, so 
+if the upstream version release dates are further apart than 2-3 weeks leave make a remark about this and request an update.
+
 ## Reacting to new commits
 
 Inevitably, a rebase will take long enough that new commits will end up being

--- a/openshift-hack/commitchecker/commitchecker.go
+++ b/openshift-hack/commitchecker/commitchecker.go
@@ -8,8 +8,11 @@ import (
 
 func main() {
 	var start, end string
+	var enableRebaseCheck bool
+
 	flag.StringVar(&start, "start", "master", "The start of the revision range for analysis")
 	flag.StringVar(&end, "end", "HEAD", "The end of the revision range for analysis")
+	flag.BoolVar(&enableRebaseCheck, "check-rebase", false, "enables additional safety checks for rebases")
 	flag.Parse()
 
 	commits, err := CommitsBetween(start, end)
@@ -26,6 +29,13 @@ func main() {
 	for _, validate := range AllCommitValidators {
 		for _, commit := range commits {
 			errs = append(errs, validate(commit)...)
+		}
+	}
+
+	if enableRebaseCheck {
+		errs := ValidateReleaseBranchConsistency(commits)
+		for _, err := range errs {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n\n", err)
 		}
 	}
 


### PR DESCRIPTION
This PR updates the verify-commit binary to output an error in case we're missing a commit in any of the following (n+2) release branches. This helps us to understand if we're merging a fix that isn't present in later versions of OCP yet - which might cause regression problems in cluster upgrades.