### PR TITLE
Bug 1939552: unstable CustomResourcePublishOpenAPI tests

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -514,7 +514,7 @@ func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, grou
 
 func setupCRDAndVerifySchemaWithOptions(f *framework.Framework, schema, expect []byte, groupSuffix string, versions []string, options ...crd.Option) (tCRD *crd.TestCrd, err error) {
 	defer func() {
-		if err == nil {
+		if err != nil {
 			framework.Logf("sleeping 45 seconds before running the actual tests, we hope that during all API servers converge during that window, see %q for more", "https://github.com/kubernetes/kubernetes/pull/90452")
 			time.Sleep(time.Second * 45)
 		}


### PR DESCRIPTION
We should put the test into sleep only when `waitForDefinition` fails.
A failure means that an API server the test hit hasn't observed the change yet.
In that case, we will sleep for 45 seconds and hope it will catch up.

The original PR had the fix: https://github.com/openshift/origin/pull/24920
It got lost during subsequent rebases.

As a result CRD related tests fail frequently in [CI](https://search.ci.openshift.org/?search=CustomResourcePublishOpenAPI+&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)