### PR TITLE
UPSTREAM: <carry>: Fix sync of PV deletion in PV controller

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -111,7 +111,7 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWorkAfter(controller.volumeQueue, obj, 21*time.Second) },
+			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
 		},
 	)
 	controller.volumeLister = p.VolumeInformer.Lister()


### PR DESCRIPTION
Always queue PV deletion events immediately, without any wait. It does not
affect dynamic de-provisioning / deletion of volumes, it's done on PVC
deletion.

This de-flakes unit tests, which expect that PV deletion is processed without
waiting too much.

This updates carry patch [b24f93e](https://github.com/openshift/kubernetes/pull/1062). It still waits for 21 seconds after *PVC*
deletion!
UPSTREAM: <carry>: delay queuing deletion for PV to allow nodes some time to unmount


Sample failures:

```
--- FAIL: TestControllerSync (92.32s)
    framework_test.go:202: Event "Warning ClaimLost" not emitted
    framework_test.go:640: Test "5-7 - delete volume event makes claim lost, delete claim event will not report metric": events do not match

--- FAIL: TestControllerSync (92.32s)
    pv_controller_test.go:370: Failed to run test 5-4 - delete volume: timed out waiting for the condition
    framework_test.go:632: Test "5-4 - delete volume": Claim check failed [A-expected, B-got result]:   map[string]*v1.PersistentVolumeClaim{
                "claim5-4": &{
                        TypeMeta:   {},
                        ObjectMeta: {Name: "claim5-4", Namespace: "default", SelfLink: "/api/v1/namespaces/default/persistentvolumeclaims/claim5-4", UID: "uid5-4", ...},
                        Spec:       {AccessModes: {"ReadWriteOnce", "ReadOnlyMany"}, Resources: {Requests: {s"storage": {i: {...}, s: "1Gi", Format: "BinarySI"}}}, VolumeName: "volume5-4", VolumeMode: &"Filesystem", ...},
                        Status: v1.PersistentVolumeClaimStatus{
        -                       Phase:       "Lost",
        +                       Phase:       "Bound",
        -                       AccessModes: nil,
        +                       AccessModes: []v1.PersistentVolumeAccessMode{"ReadWriteOnce", "ReadOnlyMany"},
        -                       Capacity:    nil,
        +                       Capacity: v1.ResourceList{
        +                               s"storage": {i: resource.int64Amount{value: 1073741824}, s: "1Gi", Format: "BinarySI"},
        +                       },
                                Conditions: nil,
                        },
                },
          }
```