### PR TITLE
Bug 2022824: Fix the leak of vSphere client sessions

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1491,10 +1491,19 @@ func (v *vSphereDriver) GetDynamicProvisionStorageClass(config *storageframework
 
 func (v *vSphereDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
 	return &storageframework.PerTestConfig{
-		Driver:    v,
-		Prefix:    "vsphere",
-		Framework: f,
-	}, func() {}
+			Driver:    v,
+			Prefix:    "vsphere",
+			Framework: f,
+		}, func() {
+			// Driver Cleanup function
+			// Logout each vSphere client connection to prevent session leakage
+			nodes := vspheretest.GetReadySchedulableNodeInfos()
+			for _, node := range nodes {
+				if node.VSphere.Client != nil {
+					node.VSphere.Client.Logout(context.TODO())
+				}
+			}
+		}
 }
 
 func (v *vSphereDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

Upstream PR: https://github.com/kubernetes/kubernetes/pull/107353

#### What this PR does / why we need it:
Implement the test cleanup callback method to close any open vSphere client connections. Without this cleanup callback vSphere client session are leaked during testing (eventually causing resource exhaustion).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
/sig storage
/sig testing

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where vSphere client connections where not being closed during testing. Leaked vSphere client sessions were causing resource exhaustion during automated testing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
