### PR TITLE
Bug 2039377: UPSTREAM: 89885: SQUASH: Retry fetching clouds.conf

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -46,9 +46,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/retry"
 	cloudprovider "k8s.io/cloud-provider"
 	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog/v2"
@@ -279,7 +281,22 @@ func (os *OpenStack) setConfigFromSecret() error {
 		return fmt.Errorf("secret lister is not initialized")
 	}
 
-	secret, err := os.secretLister.Secrets(os.secretNamespace).Get(os.secretName)
+	var secret *v1.Secret
+	err := retry.OnError(
+		wait.Backoff{
+			Duration: time.Second,
+			Factor:   1.5,
+			Jitter:   1,
+			Steps:    10,
+		},
+		func(_ error) bool {
+			return true
+		},
+		func() (err error) {
+			secret, err = os.secretLister.Secrets(os.secretNamespace).Get(os.secretName)
+			return err
+		},
+	)
 	if err != nil {
 		klog.Errorf("cannot get secret %s in namespace %s. error: %q", os.secretName, os.secretNamespace, err)
 		return err


### PR DESCRIPTION
The OpenStack secret is not guaranteed to be present at the time
kube-controller-manager is initialised.