### PR TITLE
Bug 2040338: UPSTREAM: <carry>: remove egressnetworkpolicies from gc ignored resources

### DIFF
--- a/cmd/kube-controller-manager/app/patch_gc.go
+++ b/cmd/kube-controller-manager/app/patch_gc.go
@@ -13,7 +13,6 @@ func applyOpenShiftGCConfig(controllerManager *config.Config) error {
 		// explicitly disabled from GC for now - not enough value to track them
 		gcconfig.GroupResource{Group: "authorization.openshift.io", Resource: "rolebindingrestrictions"},
 		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "clusternetworks"},
-		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "egressnetworkpolicies"},
 		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "hostsubnets"},
 		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "netnamespaces"},
 		gcconfig.GroupResource{Group: "oauth.openshift.io", Resource: "oauthclientauthorizations"},


### PR DESCRIPTION
egressnetworkpolicies should not be in garbage collector ignored
resources, so users can delete them using "--cascade=foreground" flag.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit d54a57289e82fe86eadb3666fc64d5324a2df49c)
