### PR TITLE
Bug 2042493: UPSTREAM: <carry>: Fix conformance and serial tests by stopping node cordoning

### DIFF
--- a/openshift-hack/conformance-k8s.sh
+++ b/openshift-hack/conformance-k8s.sh
@@ -50,8 +50,6 @@ os::log::info "Running Kubernetes conformance suite for ${version}"
 # Disable container security
 oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
 oc adm policy add-scc-to-group anyuid system:authenticated system:serviceaccounts
-# Mark the master nodes as unschedulable so tests ignore them
-oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
 unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"
 # TODO: undo these operations
 

--- a/openshift-hack/test-kubernetes-e2e.sh
+++ b/openshift-hack/test-kubernetes-e2e.sh
@@ -66,8 +66,6 @@ fi
 # Disable container security
 oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
 oc adm policy add-scc-to-group anyuid system:authenticated system:serviceaccounts
-# Mark the master nodes as unschedulable so tests ignore them
-oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
 unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"
 
 test_report_dir="${ARTIFACTS:-/tmp/artifacts}"


### PR DESCRIPTION
Picked from https://github.com/openshift/kubernetes/pull/1126 with fixed commit message so we can unblock this repository 