### PR TITLE
Bug 2041583: UPSTREAM: <carry>: set correctly static pods CPUs when workload partitioning is disabled

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -396,6 +396,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 	failure = []reconciledContainer{}
 
 	m.removeStaleState()
+	workloadEnabled := managed.IsEnabled()
 	for _, pod := range m.activePods() {
 		pstatus, ok := m.podStatusProvider.GetPodStatus(pod.UID)
 		if !ok {
@@ -403,7 +404,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 			failure = append(failure, reconciledContainer{pod.Name, "", ""})
 			continue
 		}
-		if enabled, _, _ := managed.IsPodManaged(pod); enabled {
+		if enabled, _, _ := managed.IsPodManaged(pod); workloadEnabled && enabled {
 			klog.V(4).InfoS("[cpumanager] reconcileState: skipping pod; pod is managed (pod: %s)", pod.Name)
 			continue
 		}

--- a/pkg/kubelet/managed/managed.go
+++ b/pkg/kubelet/managed/managed.go
@@ -62,8 +62,8 @@ func IsEnabled() bool {
 	return pinnedManagementEnabled
 }
 
-/// IsPodManaged returns true and the name of the workload if enabled.
-/// returns true, workload name, and the annotation payload.
+// IsPodManaged returns true and the name of the workload if enabled.
+// returns true, workload name, and the annotation payload.
 func IsPodManaged(pod *v1.Pod) (bool, string, string) {
 	if pod.ObjectMeta.Annotations == nil {
 		return false, "", ""


### PR DESCRIPTION
Do not skip updating static pods cpuset under the CPU manager when the pod has workload annotation, but the workload partitioning is disabled.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>