### PR TITLE
Bug 2040533: UPSTREAM: 107695: kubelet: fix podstatus not containing pod full name

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -580,6 +580,7 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 						syncedAt:           now,
 						startedTerminating: true,
 						finished:           true,
+						fullname:           kubecontainer.GetPodFullName(pod),
 					}
 				}
 			}


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/pull/107695

