### PR TITLE
Bug 2044824: UPSTREAM: 107786: Ensure the execHostnameTest() compares hostnames

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2214,8 +2214,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 		node0 := nodes.Items[0]
 		node1 := nodes.Items[1]
-		// split node name to ensure only hostname (and not FQDN) is compared with return from agnhost's /hostname endpoint.
-		node0Hostname := strings.Split(node0.Name, ".")[0]
+
 		serviceName := "svc-itp"
 		ns := f.Namespace.Name
 		servicePort := 80
@@ -2266,7 +2265,7 @@ var _ = common.SIGDescribe("Services", func() {
 		for i := 0; i < 5; i++ {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
 			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod0, serviceAddress, node0Hostname)
+			execHostnameTest(*pausePod0, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)
@@ -2295,7 +2294,7 @@ var _ = common.SIGDescribe("Services", func() {
 		for i := 0; i < 5; i++ {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
 			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod2, serviceAddress, node0Hostname)
+			execHostnameTest(*pausePod2, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -143,6 +143,8 @@ func execSourceIPTest(sourcePod v1.Pod, targetAddr string) (string, string) {
 
 // execHostnameTest executes curl to access "/hostname" endpoint on target address
 // from given Pod to check the hostname of the target destination.
+// It also converts FQDNs to hostnames, so if an FQDN is passed as
+// targetHostname only the hostname part will be considered for comparison.
 func execHostnameTest(sourcePod v1.Pod, targetAddr, targetHostname string) {
 	var (
 		err     error
@@ -166,8 +168,12 @@ func execHostnameTest(sourcePod v1.Pod, targetAddr, targetHostname string) {
 		break
 	}
 
+	// Ensure we're comparing hostnames and not FQDNs
+	targetHostname = strings.Split(targetHostname, ".")[0]
+	hostname := strings.TrimSpace(strings.Split(stdout, ".")[0])
+
 	framework.ExpectNoError(err)
-	framework.ExpectEqual(strings.TrimSpace(stdout), targetHostname)
+	framework.ExpectEqual(hostname, targetHostname)
 }
 
 // createSecondNodePortService creates a service with the same selector as config.NodePortService and same HTTP Port


### PR DESCRIPTION
This reverts commit 752a532c3d0819759f98821a94f26193b494c3d5.

We do not have guarantee that the agnhost's `/hostname` endpoint returns
a hostname and not an FQDN. We also do not have guarantee a hostname
gets passed to the execHostnameTest() function for comparison.

So make sure we're comparing hostnames in execHostnameTest().