### PR TITLE
Bug 2051985: UPSTREAM: <carry>: An APIRequestCount without dots in the name can cause a panic

### DIFF
--- a/openshift-kube-apiserver/admission/customresourcevalidation/apirequestcount/validate_apirequestcount.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/apirequestcount/validate_apirequestcount.go
@@ -1,0 +1,108 @@
+package apirequestcount
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	apiv1 "github.com/openshift/api/apiserver/v1"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+)
+
+const PluginName = "config.openshift.io/ValidateAPIRequestCount"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return newValidateAPIRequestCount()
+	})
+}
+
+func newValidateAPIRequestCount() (admission.Interface, error) {
+	return customresourcevalidation.NewValidator(
+		map[schema.GroupResource]bool{
+			apiv1.GroupVersion.WithResource("apirequestcounts").GroupResource(): true,
+		},
+		map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+			apiv1.GroupVersion.WithKind("APIRequestCount"): apiRequestCountV1{},
+		})
+}
+
+type apiRequestCountV1 struct {
+}
+
+func toAPIRequestCountV1(uncastObj runtime.Object) (*apiv1.APIRequestCount, field.ErrorList) {
+	obj, ok := uncastObj.(*apiv1.APIRequestCount)
+	if !ok {
+		return nil, field.ErrorList{
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"APIRequestCount"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"apiserver.openshift.io/v1"}),
+		}
+	}
+
+	return obj, nil
+}
+
+func (a apiRequestCountV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIRequestCountV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	errs = append(errs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, requireNameGVR, field.NewPath("metadata"))...)
+	return errs
+}
+
+// requireNameGVR is a name validation function that requires the name to be of the form 'resource.version.group'.
+func requireNameGVR(name string, _ bool) []string {
+	if _, err := NameToResource(name); err != nil {
+		return []string{err.Error()}
+	}
+	return nil
+}
+
+// NameToResource parses a name of the form 'resource.version.group'.
+func NameToResource(name string) (schema.GroupVersionResource, error) {
+	segments := strings.SplitN(name, ".", 3)
+	result := schema.GroupVersionResource{Resource: segments[0]}
+	switch len(segments) {
+	case 3:
+		result.Group = segments[2]
+		fallthrough
+	case 2:
+		result.Version = segments[1]
+	default:
+		return schema.GroupVersionResource{}, fmt.Errorf("apirequestcount %s: name must be of the form 'resource.version.group'", name)
+	}
+	return result, nil
+}
+
+func (a apiRequestCountV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIRequestCountV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAPIRequestCountV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	return errs
+}
+
+func (a apiRequestCountV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIRequestCountV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAPIRequestCountV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	return errs
+}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/apirequestcount/validate_apirequestcount_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/apirequestcount/validate_apirequestcount_test.go
@@ -1,0 +1,34 @@
+package apirequestcount
+
+import (
+	"testing"
+
+	apiv1 "github.com/openshift/api/apiserver/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApiRequestCountV1_ValidateCreate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		errExpected bool
+	}{
+		{"nogood", true},
+		{"resource.version", false},
+		{"resource.groupnonsense", false},
+		{"resource.version.group", false},
+		{"resource.version.group.with.dots", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := apiRequestCountV1{}.ValidateCreate(&apiv1.APIRequestCount{ObjectMeta: metav1.ObjectMeta{Name: tc.name}})
+			if tc.errExpected != (len(errs) != 0) {
+				s := "did not expect "
+				if tc.errExpected {
+					s = "expected "
+				}
+				t.Errorf("%serrors, but got %d errors: %v", s, len(errs), errs)
+			}
+		})
+	}
+
+}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/attributes.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/attributes.go
@@ -5,6 +5,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 
+	apiv1 "github.com/openshift/api/apiserver/v1"
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -52,4 +53,5 @@ func init() {
 	utilruntime.Must(quotav1.Install(supportedObjectsScheme))
 	utilruntime.Must(securityv1.Install(supportedObjectsScheme))
 	utilruntime.Must(authorizationv1.Install(supportedObjectsScheme))
+	utilruntime.Must(apiv1.Install(supportedObjectsScheme))
 }

--- a/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -2,6 +2,7 @@ package customresourcevalidationregistration
 
 import (
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apirequestcount"
 
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/authentication"
@@ -36,6 +37,7 @@ var AllCustomResourceValidators = []string{
 	securitycontextconstraints.PluginName,
 	rolebindingrestriction.PluginName,
 	network.PluginName,
+	apirequestcount.PluginName,
 
 	// the kubecontrollermanager operator resource has to exist in order to run deployments to deploy admission webhooks.
 	kubecontrollermanager.PluginName,
@@ -66,6 +68,8 @@ func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	rolebindingrestriction.Register(plugins)
 	// This plugin validates the network.config.openshift.io object for service node port range changes
 	network.Register(plugins)
+	// This plugin validates the apiserver.openshift.io/v1 APIRequestCount resources.
+	apirequestcount.Register(plugins)
 	// this one is special because we don't work without it.
 	securitycontextconstraints.RegisterDefaulting(plugins)
 }

--- a/openshift-kube-apiserver/filters/deprecatedapirequest_filter.go
+++ b/openshift-kube-apiserver/filters/deprecatedapirequest_filter.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest"
 )
@@ -14,7 +13,7 @@ func WithDeprecatedApiRequestLogging(handler http.Handler, controller deprecated
 	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer handler.ServeHTTP(w, req)
 		info, ok := request.RequestInfoFrom(req.Context())
-		if !ok {
+		if !ok || !info.IsResourceRequest {
 			return
 		}
 		timestamp, ok := request.ReceivedTimestampFrom(req.Context())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

apiserver panic on restart if user manually creates an apirequestcount resource with an invalid name.

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2051985

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
