### PR TITLE
[wip] azure LB fix

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -797,7 +797,7 @@ func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
-		klog.V(4).Infof("It took %v seconds to update load balancer hosts for service %s/%s", latency, service.Namespace, service.Name)
+		klog.V(2).Infof("It took %v seconds to update load balancer hosts for service %s/%s", latency, service.Namespace, service.Name)
 		updateLoadBalancerHostLatency.Observe(latency)
 	}()
 
@@ -817,6 +817,7 @@ func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []
 		// ImplementedElsewhere indicates that the UpdateLoadBalancer is a nop and the
 		// functionality is implemented by a different controller.  In this case, we
 		// return immediately without doing anything.
+		klog.V(2).Infof("[lockedUpdateLoadBalancerHosts] service=%s: controller is implemented elsewhere", service.Name)
 		return nil
 	}
 	// It's only an actual error if the load balancer still exists.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -743,10 +743,12 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
+			klog.Infof("Add called on Azure node informer")
 			node := obj.(*v1.Node)
 			az.updateNodeCaches(nil, node)
 		},
 		UpdateFunc: func(prev, obj interface{}) {
+			klog.Infof("Update called on Azure node informer")
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
 			if newNode.Labels[v1.LabelTopologyZone] ==
@@ -756,6 +758,7 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			az.updateNodeCaches(prevNode, newNode)
 		},
 		DeleteFunc: func(obj interface{}) {
+			klog.Infof("Delete called on Azure node informer")
 			node, isNode := obj.(*v1.Node)
 			// We can get DeletedFinalStateUnknown instead of *v1.Node here
 			// and we need to handle that correctly.
@@ -779,6 +782,7 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 
 // updateNodeCaches updates local cache for node's zones and external resource groups.
 func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
+	klog.Infof("updateNodeCaches start")
 	az.nodeCachesLock.Lock()
 	defer az.nodeCachesLock.Unlock()
 
@@ -814,14 +818,29 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 
 		// Remove from unmanagedNodes cache.
 		managed, ok := prevNode.ObjectMeta.Labels[managedByAzureLabel]
+		klog.V(2).Infof("prevNode=%s, ok=%v, managed=%v",
+			prevNode.ObjectMeta.Name, ok, managed)
+
 		if ok && managed == "false" {
+			klog.V(2).Infof("prevNode=%s, deleting from unmanagedNodes and excludeLoadBalancerNodes",
+				prevNode.ObjectMeta.Name)
+
 			az.unmanagedNodes.Delete(prevNode.ObjectMeta.Name)
 			az.excludeLoadBalancerNodes.Delete(prevNode.ObjectMeta.Name)
+			klog.V(2).Infof("prevNode=%s, now unmanagedNodes=%v  and excludeLoadBalancerNodes=%v",
+				prevNode.ObjectMeta.Name,
+				az.unmanagedNodes,
+				az.excludeLoadBalancerNodes)
+
 		}
 
 		// Remove from excludeLoadBalancerNodes cache.
+		klog.V(2).Infof("prevNode=%s, checking hasExcludeBalancerLabel...", prevNode.ObjectMeta.Name)
 		if _, hasExcludeBalancerLabel := prevNode.ObjectMeta.Labels[v1.LabelNodeExcludeBalancers]; hasExcludeBalancerLabel {
+			klog.V(2).Infof("prevNode=%s, hasExcludeBalancerLabel=true, calling az.excludeLoadBalancerNodes.Delete",
+				prevNode.ObjectMeta.Name)
 			az.excludeLoadBalancerNodes.Delete(prevNode.ObjectMeta.Name)
+
 		}
 	}
 
@@ -846,14 +865,34 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 
 		// Add to unmanagedNodes cache.
 		managed, ok := newNode.ObjectMeta.Labels[managedByAzureLabel]
+		klog.V(2).Infof("newNode=%s, managed=%v, ok=%v",
+			newNode.ObjectMeta.Name, managed, ok)
+
 		if ok && managed == "false" {
+			klog.V(2).Infof("newNode=%s, managed is false...",
+				newNode.ObjectMeta.Name, managed, ok)
+
 			az.unmanagedNodes.Insert(newNode.ObjectMeta.Name)
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+
+			klog.V(2).Infof("newNode=%s, now az.unmanagedNodes=%v, az.excludeLoadBalancerNodes=%v",
+				newNode.ObjectMeta.Name,
+				az.unmanagedNodes,
+				az.excludeLoadBalancerNodes)
+
 		}
 
 		// Add to excludeLoadBalancerNodes cache.
-		if _, hasExcludeBalancerLabel := newNode.ObjectMeta.Labels[v1.LabelNodeExcludeBalancers]; hasExcludeBalancerLabel {
+		_, hasExcludeBalancerLabel := newNode.ObjectMeta.Labels[v1.LabelNodeExcludeBalancers]
+		klog.V(2).Infof("newNode=%s, hasExcludeBalancerLabel=%v...",
+			newNode.ObjectMeta.Name, hasExcludeBalancerLabel)
+
+		if hasExcludeBalancerLabel {
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+			klog.V(2).Infof("newNode=%s, hasExcludeBalancerLabel=true, "+
+				"adding it to az.excludeLoadBalancerNodes, which is now: %v",
+				newNode.ObjectMeta.Name, az.excludeLoadBalancerNodes)
+
 		}
 	}
 }
@@ -961,6 +1000,11 @@ func (az *Cloud) GetUnmanagedNodes() (sets.String, error) {
 
 // ShouldNodeExcludedFromLoadBalancer returns true if node is unmanaged, in external resource group or labeled with "node.kubernetes.io/exclude-from-external-load-balancers".
 func (az *Cloud) ShouldNodeExcludedFromLoadBalancer(nodeName string) (bool, error) {
+	klog.V(2).Infof("ShouldNodeExcludedFromLoadBalancer called on nodeName=%s ",
+		nodeName)
+
+	klog.V(2).Infof("nodeName=%s, checking if az.nodeInformerSynced is nil (%v)",
+		nodeName, az.nodeInformerSynced)
 	// Kubelet won't set az.nodeInformerSynced, always return nil.
 	if az.nodeInformerSynced == nil {
 		return false, nil
@@ -968,14 +1012,26 @@ func (az *Cloud) ShouldNodeExcludedFromLoadBalancer(nodeName string) (bool, erro
 
 	az.nodeCachesLock.RLock()
 	defer az.nodeCachesLock.RUnlock()
+
+	klog.V(2).Infof("nodeName=%s, checking  !az.nodeInformerSynced() (%v)",
+		nodeName, !az.nodeInformerSynced())
+
 	if !az.nodeInformerSynced() {
 		return false, fmt.Errorf("node informer is not synced when trying to fetch node caches")
 	}
+
+	cachedRG_, ok_ := az.nodeResourceGroups[nodeName]
+	cond_ := ok_ && !strings.EqualFold(cachedRG_, az.ResourceGroup)
+	klog.V(2).Infof("nodeName=%s, checking that az.nodeResourceGroups[nodeName] (%v) !=  az.ResourceGroup (%v); cond_=%v",
+		nodeName, cachedRG_, az.ResourceGroup, cond_)
 
 	// Return true if the node is in external resource group.
 	if cachedRG, ok := az.nodeResourceGroups[nodeName]; ok && !strings.EqualFold(cachedRG, az.ResourceGroup) {
 		return true, nil
 	}
+
+	klog.V(2).Infof("nodeName=%s, az.excludeLoadBalancerNodes=%v, node is in it: %v",
+		nodeName, az.excludeLoadBalancerNodes, az.excludeLoadBalancerNodes.Has(nodeName))
 
 	return az.excludeLoadBalancerNodes.Has(nodeName), nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -152,7 +152,7 @@ func (az *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, servic
 	// Return exists = false only if the load balancer and the public IP are not found on Azure
 	if !existsLb && !existsPip {
 		serviceName := getServiceName(service)
-		klog.V(5).Infof("getloadbalancer (cluster:%s) (service:%s) - doesn't exist", clusterName, serviceName)
+		klog.V(2).Infof("getloadbalancer (cluster:%s) (service:%s) - doesn't exist", clusterName, serviceName)
 		return nil, false, nil
 	}
 
@@ -173,7 +173,7 @@ func (az *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, ser
 	// the service may be switched from an internal LB to a public one, or vise versa.
 	// Here we'll firstly ensure service do not lie in the opposite LB.
 	serviceName := getServiceName(service)
-	klog.V(5).Infof("ensureloadbalancer(%s): START clusterName=%q", serviceName, clusterName)
+	klog.V(2).Infof("ensureloadbalancer(%s): START clusterName=%q", serviceName, clusterName)
 
 	mc := metrics.NewMetricContext("services", "ensure_loadbalancer", az.ResourceGroup, az.SubscriptionID, serviceName)
 	isOperationSucceeded := false
@@ -240,7 +240,7 @@ func (az *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, ser
 func (az *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
 	isInternal := requiresInternalLoadBalancer(service)
 	serviceName := getServiceName(service)
-	klog.V(5).Infof("Delete service (%s): START clusterName=%q", serviceName, clusterName)
+	klog.V(2).Infof("Delete service (%s): START clusterName=%q", serviceName, clusterName)
 
 	mc := metrics.NewMetricContext("services", "ensure_loadbalancer_deleted", az.ResourceGroup, az.SubscriptionID, serviceName)
 	isOperationSucceeded := false
@@ -495,11 +495,11 @@ func (az *Cloud) selectLoadBalancer(clusterName string, service *v1.Service, exi
 
 func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.LoadBalancer) (status *v1.LoadBalancerStatus, err error) {
 	if lb == nil {
-		klog.V(10).Info("getServiceLoadBalancerStatus: lb is nil")
+		klog.V(2).Info("getServiceLoadBalancerStatus: lb is nil")
 		return nil, nil
 	}
 	if lb.FrontendIPConfigurations == nil || *lb.FrontendIPConfigurations == nil {
-		klog.V(10).Info("getServiceLoadBalancerStatus: lb.FrontendIPConfigurations is nil")
+		klog.V(2).Info("getServiceLoadBalancerStatus: lb.FrontendIPConfigurations is nil")
 		return nil, nil
 	}
 	isInternal := requiresInternalLoadBalancer(service)
@@ -666,7 +666,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		if strings.EqualFold(getDomainNameLabel(&pip), domainNameLabel) {
 			if existingServiceName, ok := pip.Tags[serviceUsingDNSKey]; ok &&
 				strings.EqualFold(*existingServiceName, serviceName) {
-				klog.V(6).Infof("ensurePublicIPExists for service(%s): pip(%s) - "+
+				klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - "+
 					"the service is using the DNS label on the public IP", serviceName, pipName)
 
 				var rerr *retry.Error
@@ -732,7 +732,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		} else {
 			if pip.PublicIPAddressPropertiesFormat.DNSSettings == nil ||
 				pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel == nil {
-				klog.V(6).Infof("ensurePublicIPExists for service(%s): pip(%s) - no existing DNS label on the public IP, create one", serviceName, pipName)
+				klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - no existing DNS label on the public IP, create one", serviceName, pipName)
 				pip.PublicIPAddressPropertiesFormat.DNSSettings = &network.PublicIPAddressDNSSettings{
 					DomainNameLabel: &domainNameLabel,
 				}
@@ -769,7 +769,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		klog.V(2).Infof("ensure(%s) abort backoff: pip(%s)", serviceName, *pip.Name)
 		return nil, err
 	}
-	klog.V(10).Infof("CreateOrUpdatePIP(%s, %q): end", pipResourceGroup, *pip.Name)
+	klog.V(2).Infof("CreateOrUpdatePIP(%s, %q): end", pipResourceGroup, *pip.Name)
 
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
@@ -1103,6 +1103,12 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	dirtyLb := false
+	klog.V(2).Infof("serviceName=%v, wantLb=%v, isInternal=%v, isBackendPoolPreConfigured=%v, "+
+		"lbName=%v, lbResourceGroup=%v, defaultLBFrontendIPConfigName=%v, defaultLBFrontendIPConfigID=%v, "+
+		"lbBackendPoolName=%v, lbBackendPoolID=%v, lbIdleTimeout=%v, lb=%v",
+		serviceName, wantLb, isInternal, isBackendPoolPreConfigured, lbName,
+		lbResourceGroup, defaultLBFrontendIPConfigName, defaultLBFrontendIPConfigID,
+		lbBackendPoolName, lbBackendPoolID, lbIdleTimeout, lb)
 
 	// Ensure LoadBalancer's Backend Pool Configuration
 	if wantLb {
@@ -1110,18 +1116,28 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		if lb.BackendAddressPools != nil {
 			newBackendPools = *lb.BackendAddressPools
 		}
-
+		klog.V(2).Infof("newBackendPools=%v", newBackendPools)
 		foundBackendPool := false
 		for _, bp := range newBackendPools {
+			klog.V(2).Infof("checking *bp.Name (%v) == lbBackendPoolName (%v)",
+				*bp.Name, lbBackendPoolName)
 			if strings.EqualFold(*bp.Name, lbBackendPoolName) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found wanted backendpool. not adding anything", serviceName, wantLb)
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found wanted backendpool. not adding anything", serviceName, wantLb)
 				foundBackendPool = true
 
 				var backendIPConfigurationsToBeDeleted []network.InterfaceIPConfiguration
+
+				klog.V(2).Infof("checking that bp.BackendAddressPoolPropertiesFormat != nil "+
+					"&& bp.BackendIPConfigurations != nil",
+					bp.BackendAddressPoolPropertiesFormat,
+					bp.BackendIPConfigurations)
+
 				if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
+					klog.V(2).Infof("if condition was true...")
 					for _, ipConf := range *bp.BackendIPConfigurations {
 						ipConfID := to.String(ipConf.ID)
 						nodeName, _, err := az.VMSet.GetNodeNameByIPConfigurationID(ipConfID)
+						klog.V(2).Infof("ipConf=%v, nodeName=%v, err=%v", ipConf, nodeName, err)
 						if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 							return nil, err
 						}
@@ -1131,17 +1147,21 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						// have been added to the LB's backendpool, find the unwanted ones and
 						// delete them from the pool.
 						shouldExcludeLoadBalancer, err := az.ShouldNodeExcludedFromLoadBalancer(nodeName)
+						klog.V(2).Infof("shouldExcludeLoadBalancer=%v", shouldExcludeLoadBalancer)
 						if err != nil {
 							klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)
 							return nil, err
 						}
 						if shouldExcludeLoadBalancer {
-							klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found unwanted node %s, decouple it from the LB", serviceName, wantLb, nodeName)
+							klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found unwanted node %s, decouple it from the LB",
+								serviceName, wantLb, nodeName)
 							// construct a backendPool that only contains the IP config of the node to be deleted
 							backendIPConfigurationsToBeDeleted = append(backendIPConfigurationsToBeDeleted, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfID)})
+							klog.V(2).Infof("backendIPConfigurationsToBeDeleted=%v", backendIPConfigurationsToBeDeleted)
 						}
 					}
 					if len(backendIPConfigurationsToBeDeleted) > 0 {
+						klog.V(2).Infof("backendIPConfigurationsToBeDeleted (%v) > 0", backendIPConfigurationsToBeDeleted)
 						backendpoolToBeDeleted := &[]network.BackendAddressPool{
 							{
 								ID: to.StringPtr(lbBackendPoolID),
@@ -1152,18 +1172,22 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						}
 						vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
 						// decouple the backendPool from the node
+						klog.V(2).Infof("calling EnsureBackendPoolDeleted on (%v, %v, %v, %v, %v) ",
+							service, lbBackendPoolID, vmSetName, backendpoolToBeDeleted, false)
 						err = az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, backendpoolToBeDeleted, false)
 						if err != nil {
 							return nil, err
 						}
 					}
 				}
+				klog.V(2).Infof("break!")
 				break
 			} else {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found other backendpool %s", serviceName, wantLb, *bp.Name)
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found other backendpool %s", serviceName, wantLb, *bp.Name)
 			}
 		}
 		if !foundBackendPool {
+			klog.V(2).Infof("foundBackendPool is false...")
 			if isBackendPoolPreConfigured {
 				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - PreConfiguredBackendPoolLoadBalancerTypes %s has been set but can not find corresponding backend pool, ignoring it",
 					serviceName,
@@ -1175,7 +1199,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 			newBackendPools = append(newBackendPools, network.BackendAddressPool{
 				Name: to.StringPtr(lbBackendPoolName),
 			})
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - adding backendpool", serviceName, wantLb)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - adding backendpool", serviceName, wantLb)
 
 			dirtyLb = true
 			lb.BackendAddressPools = &newBackendPools
@@ -1243,7 +1267,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		}
 
 		if ownedFIPConfig == nil {
-			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config", serviceName, lbName)
+			klog.V(2).Infof("ensure(%s): lb(%s) - creating a new frontend IP config", serviceName, lbName)
 
 			// construct FrontendIPConfigurationPropertiesFormat
 			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
@@ -1339,15 +1363,15 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	for i := len(updatedProbes) - 1; i >= 0; i-- {
 		existingProbe := updatedProbes[i]
 		if az.serviceOwnsRule(service, *existingProbe.Name) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - considering evicting", serviceName, wantLb, *existingProbe.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - considering evicting", serviceName, wantLb, *existingProbe.Name)
 			keepProbe := false
 			if findProbe(expectedProbes, existingProbe) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - keeping", serviceName, wantLb, *existingProbe.Name)
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - keeping", serviceName, wantLb, *existingProbe.Name)
 				keepProbe = true
 			}
 			if !keepProbe {
 				updatedProbes = append(updatedProbes[:i], updatedProbes[i+1:]...)
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - dropping", serviceName, wantLb, *existingProbe.Name)
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - dropping", serviceName, wantLb, *existingProbe.Name)
 				dirtyProbes = true
 			}
 		}
@@ -1356,11 +1380,11 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	for _, expectedProbe := range expectedProbes {
 		foundProbe := false
 		if findProbe(updatedProbes, expectedProbe) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - already exists", serviceName, wantLb, *expectedProbe.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - already exists", serviceName, wantLb, *expectedProbe.Name)
 			foundProbe = true
 		}
 		if !foundProbe {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - adding", serviceName, wantLb, *expectedProbe.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - adding", serviceName, wantLb, *expectedProbe.Name)
 			updatedProbes = append(updatedProbes, expectedProbe)
 			dirtyProbes = true
 		}
@@ -1382,9 +1406,9 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		existingRule := updatedRules[i]
 		if az.serviceOwnsRule(service, *existingRule.Name) {
 			keepRule := false
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
 			if findRule(expectedRules, existingRule, wantLb) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
 				keepRule = true
 			}
 			if !keepRule {
@@ -1398,11 +1422,11 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	for _, expectedRule := range expectedRules {
 		foundRule := false
 		if findRule(updatedRules, expectedRule, wantLb) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
 			foundRule = true
 		}
 		if !foundRule {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) adding", serviceName, wantLb, *expectedRule.Name)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) adding", serviceName, wantLb, *expectedRule.Name)
 			updatedRules = append(updatedRules, expectedRule)
 			dirtyRules = true
 		}
@@ -1431,7 +1455,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 
 				// Remove backend pools from vmSets. This is required for virtual machine scale sets before removing the LB.
 				vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
-				klog.V(10).Infof("EnsureBackendPoolDeleted(%s,%s) for service %s: start", lbBackendPoolID, vmSetName, serviceName)
+				klog.V(2).Infof("EnsureBackendPoolDeleted(%s,%s) for service %s: start", lbBackendPoolID, vmSetName, serviceName)
 				if _, ok := az.VMSet.(*availabilitySet); ok {
 					// do nothing for availability set
 					lb.BackendAddressPools = nil
@@ -1441,7 +1465,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 					klog.Errorf("EnsureBackendPoolDeleted(%s) for service %s failed: %v", lbBackendPoolID, serviceName, err)
 					return nil, err
 				}
-				klog.V(10).Infof("EnsureBackendPoolDeleted(%s) for service %s: end", lbBackendPoolID, serviceName)
+				klog.V(2).Infof("EnsureBackendPoolDeleted(%s) for service %s: end", lbBackendPoolID, serviceName)
 
 				existingLBs, err := az.ListLB(service)
 				if err != nil {
@@ -1458,13 +1482,13 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 				}
 				// Remove the LB if it exists.
 				if foundLB {
-					klog.V(10).Infof("reconcileLoadBalancer: az.DeleteLB(%q): start", lbName)
+					klog.V(2).Infof("reconcileLoadBalancer: az.DeleteLB(%q): start", lbName)
 					err = az.DeleteLB(service, lbName)
 					if err != nil {
 						klog.V(2).Infof("reconcileLoadBalancer for service(%s) abort backoff: lb(%s) - deleting; no remaining frontendIPConfigurations", serviceName, lbName)
 						return nil, err
 					}
-					klog.V(10).Infof("az.DeleteLB(%q): end", lbName)
+					klog.V(2).Infof("az.DeleteLB(%q): end", lbName)
 				}
 			}
 		} else {
@@ -1489,16 +1513,30 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 			}
 		}
 	}
+	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s); wantLb=%v, nodes=%v, isBackendPoolPreConfigured=%v",
+		serviceName, lbName, wantLb, nodes, isBackendPoolPreConfigured)
 
 	if wantLb && nodes != nil && !isBackendPoolPreConfigured {
+		klog.V(2).Infof("reconcileLoadBalancer for service(%s): [IF block] lb(%s); wantLb=%v, isBackendPoolPreConfigured=%v",
+			serviceName, lbName, wantLb, isBackendPoolPreConfigured)
+
 		// Add the machines to the backend pool if they're not already
 		vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
+		klog.V(2).Infof("reconcileLoadBalancer for service(%s): clusterName=%s, vmSetName=%v",
+			serviceName, clusterName, vmSetName)
+
 		// Etag would be changed when updating backend pools, so invalidate lbCache after it.
 		defer az.lbCache.Delete(lbName)
+		klog.V(2).Infof("concileLoadBalancer for service(%s): calling EnsureHostsInPool(); lbBackendPoolID=%v, isInternal=%v",
+			serviceName, lbBackendPoolID, isInternal)
 		err := az.VMSet.EnsureHostsInPool(service, nodes, lbBackendPoolID, vmSetName, isInternal)
+
 		if err != nil {
 			return nil, err
 		}
+		klog.V(2).Infof("concileLoadBalancer for service(%s): called EnsureHostsInPool(); err=%v",
+			serviceName, err)
+
 	}
 
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s) finished", serviceName, lbName)
@@ -1750,7 +1788,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 // This entails adding required, missing SecurityRules and removing stale rules.
 func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service, lbIP *string, wantLb bool) (*network.SecurityGroup, error) {
 	serviceName := getServiceName(service)
-	klog.V(5).Infof("reconcileSecurityGroup(%s): START clusterName=%q", serviceName, clusterName)
+	klog.V(2).Infof("reconcileSecurityGroup(%s): START clusterName=%q", serviceName, clusterName)
 
 	ports := service.Spec.Ports
 	if ports == nil {
@@ -1830,7 +1868,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 
 	for _, r := range expectedSecurityRules {
-		klog.V(10).Infof("Expecting security rule for %s: %s:%s -> %s:%s", service.Name, *r.SourceAddressPrefix, *r.SourcePortRange, *r.DestinationAddressPrefix, *r.DestinationPortRange)
+		klog.V(2).Infof("Expecting security rule for %s: %s:%s -> %s:%s", service.Name, *r.SourceAddressPrefix, *r.SourcePortRange, *r.DestinationAddressPrefix, *r.DestinationPortRange)
 	}
 
 	// update security rules
@@ -1841,7 +1879,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 
 	for _, r := range updatedRules {
-		klog.V(10).Infof("Existing security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
+		klog.V(2).Infof("Existing security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
 	}
 
 	// update security rules: remove unwanted rules that belong privately
@@ -1849,14 +1887,14 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	for i := len(updatedRules) - 1; i >= 0; i-- {
 		existingRule := updatedRules[i]
 		if az.serviceOwnsRule(service, *existingRule.Name) {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
+			klog.V(2).Infof("reconcile(%s)(%t): sg rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
 			keepRule := false
 			if findSecurityRule(expectedSecurityRules, existingRule) {
-				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
+				klog.V(2).Infof("reconcile(%s)(%t): sg rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
 				keepRule = true
 			}
 			if !keepRule {
-				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
+				klog.V(2).Infof("reconcile(%s)(%t): sg rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
 				updatedRules = append(updatedRules[:i], updatedRules[i+1:]...)
 				dirtySg = true
 			}
@@ -1870,17 +1908,17 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 				sharedRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefix)
 				sharedIndex, sharedRule, sharedRuleFound := findSecurityRuleByName(updatedRules, sharedRuleName)
 				if !sharedRuleFound {
-					klog.V(4).Infof("Didn't find shared rule %s for service %s", sharedRuleName, service.Name)
+					klog.V(2).Infof("Didn't find shared rule %s for service %s", sharedRuleName, service.Name)
 					continue
 				}
 				if sharedRule.DestinationAddressPrefixes == nil {
-					klog.V(4).Infof("Didn't find DestinationAddressPrefixes in shared rule for service %s", service.Name)
+					klog.V(2).Infof("Didn't find DestinationAddressPrefixes in shared rule for service %s", service.Name)
 					continue
 				}
 				existingPrefixes := *sharedRule.DestinationAddressPrefixes
 				addressIndex, found := findIndex(existingPrefixes, destinationIPAddress)
 				if !found {
-					klog.V(4).Infof("Didn't find destination address %v in shared rule %s for service %s", destinationIPAddress, sharedRuleName, service.Name)
+					klog.V(2).Infof("Didn't find destination address %v in shared rule %s for service %s", destinationIPAddress, sharedRuleName, service.Name)
 					continue
 				}
 				if len(existingPrefixes) == 1 {
@@ -1910,7 +1948,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	for _, expectedRule := range expectedSecurityRules {
 		foundRule := false
 		if findSecurityRule(updatedRules, expectedRule) {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
+			klog.V(2).Infof("reconcile(%s)(%t): sg rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
 			foundRule = true
 		}
 		if foundRule && allowsConsolidation(expectedRule) {
@@ -1919,7 +1957,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 			dirtySg = true
 		}
 		if !foundRule {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - adding", serviceName, wantLb, *expectedRule.Name)
+			klog.V(2).Infof("reconcile(%s)(%t): sg rule(%s) - adding", serviceName, wantLb, *expectedRule.Name)
 
 			nextAvailablePriority, err := getNextAvailablePriority(updatedRules)
 			if err != nil {
@@ -1933,7 +1971,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 
 	for _, r := range updatedRules {
-		klog.V(10).Infof("Updated security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
+		klog.V(2).Infof("Updated security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
 	}
 
 	changed := az.ensureSecurityGroupTagged(&sg)
@@ -1944,13 +1982,13 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	if dirtySg {
 		sg.SecurityRules = &updatedRules
 		klog.V(2).Infof("reconcileSecurityGroup for service(%s): sg(%s) - updating", serviceName, *sg.Name)
-		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): start", *sg.Name)
+		klog.V(2).Infof("CreateOrUpdateSecurityGroup(%q): start", *sg.Name)
 		err := az.CreateOrUpdateSecurityGroup(sg)
 		if err != nil {
 			klog.V(2).Infof("ensure(%s) abort backoff: sg(%s) - updating", serviceName, *sg.Name)
 			return nil, err
 		}
-		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): end", *sg.Name)
+		klog.V(2).Infof("CreateOrUpdateSecurityGroup(%q): end", *sg.Name)
 		az.nsgCache.Delete(to.String(sg.Name))
 	}
 	return &sg, nil
@@ -2373,12 +2411,12 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 	}
 
 	pipName := to.String(pip.Name)
-	klog.V(10).Infof("DeletePublicIP(%s, %q): start", pipResourceGroup, pipName)
+	klog.V(2).Infof("DeletePublicIP(%s, %q): start", pipResourceGroup, pipName)
 	err := az.DeletePublicIP(service, pipResourceGroup, pipName)
 	if err != nil {
 		return err
 	}
-	klog.V(10).Infof("DeletePublicIP(%s, %q): end", pipResourceGroup, pipName)
+	klog.V(2).Infof("DeletePublicIP(%s, %q): end", pipResourceGroup, pipName)
 
 	return nil
 }
@@ -2685,7 +2723,7 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 				*serviceTagValue += fmt.Sprintf(",%s", serviceName)
 				addedNew = true
 			} else {
-				klog.V(10).Infof("service %s has been bound to the pip already", serviceName)
+				klog.V(2).Infof("service %s has been bound to the pip already", serviceName)
 			}
 		}
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -1017,9 +1017,16 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 		if err != nil {
 			return fmt.Errorf("EnsureBackendPoolDeleted: failed to parse the VMAS ID %s: %v", vmasID, err)
 		}
-		klog.V(2).Infof("EnsureBackendPoolDeleted: node %s, vmasName=%s,  vmSetName=%s", nodeName, vmasName, vmSetName)
-		// Only remove nodes belonging to specified vmSet to basic LB backends.
-		if !strings.EqualFold(vmasName, vmSetName) {
+
+		useStandardLoadBalancer := as.useStandardLoadBalancer()
+		klog.V(2).Infof("EnsureBackendPoolDeleted: node %s, useStandardLoadBalancer=%v, vmasName=%s,  vmSetName=%s", nodeName, useStandardLoadBalancer, vmasName, vmSetName)
+		if useStandardLoadBalancer {
+			// if we are using the standard load balancer, then the availability set will not necessarily match.  We should
+			// honor the node's request to be removed from any load balancer it is attached to.
+
+		} else if !strings.EqualFold(vmasName, vmSetName) {
+			// if we are not using the the standard load balancer, then check to be sure the ndoe belongs to the expected availability set
+			// Only remove nodes belonging to specified vmSet to basic LB backends.
 			klog.V(2).Infof("EnsureBackendPoolDeleted: skipping the node %s belonging to another vm set %s", nodeName, vmasName)
 			continue
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -241,7 +241,7 @@ func (ss *scaleSet) GetPowerStatusByNodeName(name string) (powerState string, er
 	}
 
 	// vm.InstanceView or vm.InstanceView.Statuses are nil when the VM is under deleting.
-	klog.V(3).Infof("InstanceView for node %q is nil, assuming it's stopped", name)
+	klog.V(2).Infof("InstanceView for node %q is nil, assuming it's stopped", name)
 	return vmPowerStateStopped, nil
 }
 
@@ -367,7 +367,7 @@ func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, 
 	// NodeName is not part of providerID for vmss instances.
 	scaleSetName, err := extractScaleSetNameByProviderID(providerID)
 	if err != nil {
-		klog.V(4).Infof("Can not extract scale set name from providerID (%s), assuming it is managed by availability set: %v", providerID, err)
+		klog.V(2).Infof("Can not extract scale set name from providerID (%s), assuming it is managed by availability set: %v", providerID, err)
 		return ss.availabilitySet.GetNodeNameByProviderID(providerID)
 	}
 
@@ -378,7 +378,7 @@ func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, 
 
 	instanceID, err := getLastSegment(providerID, "/")
 	if err != nil {
-		klog.V(4).Infof("Can not extract instanceID from providerID (%s), assuming it is managed by availability set: %v", providerID, err)
+		klog.V(2).Infof("Can not extract instanceID from providerID (%s), assuming it is managed by availability set: %v", providerID, err)
 		return ss.availabilitySet.GetNodeNameByProviderID(providerID)
 	}
 
@@ -643,12 +643,12 @@ func (ss *scaleSet) listScaleSets(resourceGroup string) ([]string, error) {
 	for _, vmss := range allScaleSets {
 		name := *vmss.Name
 		if vmss.Sku != nil && to.Int64(vmss.Sku.Capacity) == 0 {
-			klog.V(3).Infof("Capacity of VMSS %q is 0, skipping", name)
+			klog.V(2).Infof("Capacity of VMSS %q is 0, skipping", name)
 			continue
 		}
 
 		if vmss.VirtualMachineScaleSetProperties == nil || vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
-			klog.V(3).Infof("VMSS %q orchestrationMode is VirtualMachine, skipping", name)
+			klog.V(2).Infof("VMSS %q orchestrationMode is VirtualMachine, skipping", name)
 			continue
 		}
 
@@ -747,6 +747,7 @@ func (ss *scaleSet) getAgentPoolScaleSets(nodes []*v1.Node) (*[]string, error) {
 
 		nodeName := nodes[nx].Name
 		shouldExcludeLoadBalancer, err := ss.ShouldNodeExcludedFromLoadBalancer(nodeName)
+		klog.V(2).Infof("nodeName=%s, shouldExcludeLoadBalancer=%v", nodeName, shouldExcludeLoadBalancer)
 		if err != nil {
 			klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)
 			return nil, err
@@ -761,7 +762,7 @@ func (ss *scaleSet) getAgentPoolScaleSets(nodes []*v1.Node) (*[]string, error) {
 		}
 
 		if ssName == "" {
-			klog.V(3).Infof("Node %q is not belonging to any known scale sets", nodeName)
+			klog.V(2).Infof("Node %q is not belonging to any known scale sets", nodeName)
 			continue
 		}
 
@@ -966,7 +967,7 @@ func (ss *scaleSet) getConfigForScaleSetByIPFamily(config *compute.VirtualMachin
 // EnsureHostInPool ensures the given VM's Primary NIC's Primary IP Configuration is
 // participating in the specified LoadBalancer Backend Pool, which returns (resourceGroup, vmssName, instanceID, vmssVM, error).
 func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetName string, isInternal bool) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
-	klog.V(3).Infof("ensuring node %q of scaleset %q in LB backendpool %q", nodeName, vmSetName, backendPoolID)
+	klog.V(2).Infof("ensuring node %q of scaleset %q in LB backendpool %q", nodeName, vmSetName, backendPoolID)
 	vmName := mapNodeNameToVMName(nodeName)
 	ssName, instanceID, vm, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	if err != nil {
@@ -992,13 +993,13 @@ func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 		needCheck = true
 	}
 	if vmSetName != "" && needCheck && !strings.EqualFold(vmSetName, ssName) {
-		klog.V(3).Infof("EnsureHostInPool skips node %s because it is not in the scaleSet %s", vmName, vmSetName)
+		klog.V(2).Infof("EnsureHostInPool skips node %s because it is not in the scaleSet %s", vmName, vmSetName)
 		return "", "", "", nil, nil
 	}
 
 	// Find primary network interface configuration.
 	if vm.NetworkProfileConfiguration.NetworkInterfaceConfigurations == nil {
-		klog.V(4).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration, of vm %s, probably because the vm's being deleted", vmName)
+		klog.V(2).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration, of vm %s, probably because the vm's being deleted", vmName)
 		return "", "", "", nil, nil
 	}
 
@@ -1061,7 +1062,7 @@ func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 			return "", "", "", nil, err
 		}
 		if !isSameLB {
-			klog.V(4).Infof("Node %q has already been added to LB %q, omit adding it to a new one", nodeName, oldLBName)
+			klog.V(2).Infof("Node %q has already been added to LB %q, omit adding it to a new one", nodeName, oldLBName)
 			return "", "", "", nil, nil
 		}
 	}
@@ -1110,21 +1111,21 @@ func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 			if ss.excludeMasterNodesFromStandardLB() && isMasterNode(node) {
 				continue
 			}
-
 			shouldExcludeLoadBalancer, err := ss.ShouldNodeExcludedFromLoadBalancer(node.Name)
+			klog.V(2).Infof("node=%s, shouldExcludeLoadBalancer=%v", node.Name, shouldExcludeLoadBalancer)
 			if err != nil {
 				klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", node.Name, err)
 				return err
 			}
 			if shouldExcludeLoadBalancer {
-				klog.V(4).Infof("Excluding unmanaged/external-resource-group node %q", node.Name)
+				klog.V(2).Infof("Excluding unmanaged/external-resource-group node %q", node.Name)
 				continue
 			}
 
 			// in this scenario the vmSetName is an empty string and the name of vmss should be obtained from the provider IDs of nodes
 			resourceGroupName, vmssName, err := getVmssAndResourceGroupNameByVMProviderID(node.Spec.ProviderID)
 			if err != nil {
-				klog.V(4).Infof("ensureVMSSInPool: found VMAS node %s, will skip checking and continue", node.Name)
+				klog.V(2).Infof("ensureVMSSInPool: found VMAS node %s, will skip checking and continue", node.Name)
 				continue
 			}
 			// only vmsses in the resource group same as it's in azure config are included
@@ -1146,12 +1147,12 @@ func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 		// When vmss is being deleted, CreateOrUpdate API would report "the vmss is being deleted" error.
 		// Since it is being deleted, we shouldn't send more CreateOrUpdate requests for it.
 		if vmss.ProvisioningState != nil && strings.EqualFold(*vmss.ProvisioningState, virtualMachineScaleSetsDeallocating) {
-			klog.V(3).Infof("ensureVMSSInPool: found vmss %s being deleted, skipping", vmssName)
+			klog.V(2).Infof("ensureVMSSInPool: found vmss %s being deleted, skipping", vmssName)
 			continue
 		}
 
 		if vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations == nil {
-			klog.V(4).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration of vmss %s", vmssName)
+			klog.V(2).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration of vmss %s", vmssName)
 			continue
 		}
 		vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
@@ -1207,7 +1208,7 @@ func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 				return err
 			}
 			if !isSameLB {
-				klog.V(4).Infof("VMSS %q has already been added to LB %q, omit adding it to a new one", vmssName, oldLBName)
+				klog.V(2).Infof("VMSS %q has already been added to LB %q, omit adding it to a new one", vmssName, oldLBName)
 				return nil
 			}
 		}
@@ -1242,6 +1243,9 @@ func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 // EnsureHostsInPool ensures the given Node's primary IP configurations are
 // participating in the specified LoadBalancer Backend Pool.
 func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string, isInternal bool) error {
+	klog.V(2).Infof("EnsureHostsInPool called on service=%s, backendPoolID=%s, vmSetName=%s, isInternal=%v",
+		service, backendPoolID, vmSetName, isInternal)
+
 	mc := metrics.NewMetricContext("services", "vmss_ensure_hosts_in_pool", ss.ResourceGroup, ss.SubscriptionID, service.Name)
 	isOperationSucceeded := false
 	defer func() {
@@ -1253,19 +1257,21 @@ func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, bac
 	errors := make([]error, 0)
 	for _, node := range nodes {
 		localNodeName := node.Name
+		klog.V(2).Infof("EnsureHostsInPool, node=%v", localNodeName)
 
 		if ss.useStandardLoadBalancer() && ss.excludeMasterNodesFromStandardLB() && isMasterNode(node) {
-			klog.V(4).Infof("Excluding master node %q from load balancer backendpool %q", localNodeName, backendPoolID)
+			klog.V(2).Infof("Excluding master node %q from load balancer backendpool %q", localNodeName, backendPoolID)
 			continue
 		}
 
 		shouldExcludeLoadBalancer, err := ss.ShouldNodeExcludedFromLoadBalancer(localNodeName)
+		klog.V(2).Infof("EnsureHostsInPool, node=%s, shouldExcludeLoadBalancer=%v", node.Name, shouldExcludeLoadBalancer)
 		if err != nil {
 			klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", localNodeName, err)
 			return err
 		}
 		if shouldExcludeLoadBalancer {
-			klog.V(4).Infof("Excluding unmanaged/external-resource-group node %q", localNodeName)
+			klog.V(2).Infof("Excluding unmanaged/external-resource-group node %q", localNodeName)
 			continue
 		}
 
@@ -1287,7 +1293,7 @@ func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, bac
 				continue
 			}
 
-			klog.V(3).Infof("EnsureHostsInPool skips node %s because VMAS nodes couldn't be added to basic LB with VMSS backends", localNodeName)
+			klog.V(2).Infof("EnsureHostsInPool skips node %s because VMAS nodes couldn't be added to basic LB with VMSS backends", localNodeName)
 			continue
 		}
 
@@ -1370,7 +1376,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID str
 
 	// Find primary network interface configuration.
 	if vm.NetworkProfileConfiguration.NetworkInterfaceConfigurations == nil {
-		klog.V(4).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration, of vm %s, probably because the vm's being deleted", nodeName)
+		klog.V(2).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration, of vm %s, probably because the vm's being deleted", nodeName)
 		return "", "", "", nil, nil
 	}
 	networkInterfaceConfigurations := *vm.NetworkProfileConfiguration.NetworkInterfaceConfigurations
@@ -1395,7 +1401,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID str
 	for i := len(existingBackendPools) - 1; i >= 0; i-- {
 		curPool := existingBackendPools[i]
 		if strings.EqualFold(backendPoolID, *curPool.ID) {
-			klog.V(10).Infof("ensureBackendPoolDeletedFromNode gets unwanted backend pool %q for node %s", backendPoolID, nodeName)
+			klog.V(2).Infof("ensureBackendPoolDeletedFromNode gets unwanted backend pool %q for node %s", backendPoolID, nodeName)
 			foundPool = true
 			newBackendPools = append(existingBackendPools[:i], existingBackendPools[i+1:]...)
 		}
@@ -1435,7 +1441,7 @@ func (ss *scaleSet) GetNodeNameByIPConfigurationID(ipConfigurationID string) (st
 			return "", "", ErrorNotVmssInstance
 		}
 
-		klog.V(4).Infof("Can not extract scale set name from ipConfigurationID (%s), assuming it is managed by availability set", ipConfigurationID)
+		klog.V(2).Infof("Can not extract scale set name from ipConfigurationID (%s), assuming it is managed by availability set", ipConfigurationID)
 		name, rg, err := ss.availabilitySet.GetNodeNameByIPConfigurationID(ipConfigurationID)
 		if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 			klog.Errorf("GetNodeNameByIPConfigurationID: failed to invoke availabilitySet.GetNodeNameByIPConfigurationID: %s", err.Error())
@@ -1463,7 +1469,7 @@ func (ss *scaleSet) GetNodeNameByIPConfigurationID(ipConfigurationID string) (st
 func getScaleSetAndResourceGroupNameByIPConfigurationID(ipConfigurationID string) (string, string, error) {
 	matches := vmssIPConfigurationRE.FindStringSubmatch(ipConfigurationID)
 	if len(matches) != 4 {
-		klog.V(4).Infof("Can not extract scale set name from ipConfigurationID (%s), assuming it is managed by availability set", ipConfigurationID)
+		klog.V(2).Infof("Can not extract scale set name from ipConfigurationID (%s), assuming it is managed by availability set", ipConfigurationID)
 		return "", "", ErrorNotVmssInstance
 	}
 
@@ -1481,7 +1487,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 			// in this scenario the vmSetName is an empty string and the name of vmss should be obtained from the provider IDs of nodes
 			vmssName, resourceGroupName, err := getScaleSetAndResourceGroupNameByIPConfigurationID(ipConfigurationID)
 			if err != nil {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: found VMAS ipcConfigurationID %s, will skip checking and continue", ipConfigurationID)
+				klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS: found VMAS ipcConfigurationID %s, will skip checking and continue", ipConfigurationID)
 				continue
 			}
 			// only vmsses in the resource group same as it's in azure config are included
@@ -1507,11 +1513,11 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 		// When vmss is being deleted, CreateOrUpdate API would report "the vmss is being deleted" error.
 		// Since it is being deleted, we shouldn't send more CreateOrUpdate requests for it.
 		if vmss.ProvisioningState != nil && strings.EqualFold(*vmss.ProvisioningState, virtualMachineScaleSetsDeallocating) {
-			klog.V(3).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", vmssName)
+			klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", vmssName)
 			continue
 		}
 		if vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations == nil {
-			klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", vmssName)
+			klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", vmssName)
 			continue
 		}
 		vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
@@ -1537,7 +1543,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 		for i := len(loadBalancerBackendAddressPools) - 1; i >= 0; i-- {
 			curPool := loadBalancerBackendAddressPools[i]
 			if strings.EqualFold(backendPoolID, *curPool.ID) {
-				klog.V(10).Infof("ensureBackendPoolDeletedFromVMSS gets unwanted backend pool %q for VMSS %s", backendPoolID, vmssName)
+				klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS gets unwanted backend pool %q for VMSS %s", backendPoolID, vmssName)
 				found = true
 				newBackendPools = append(loadBalancerBackendAddressPools[:i], loadBalancerBackendAddressPools[i+1:]...)
 			}
@@ -1585,6 +1591,9 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 
 // EnsureBackendPoolDeleted ensures the loadBalancer backendAddressPools deleted from the specified nodes.
 func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool, deleteFromVMSet bool) error {
+	klog.V(2).Infof("EnsureBackendPoolDeleted called on service=%v, backendPoolID=%s, "+
+		"vmSetName=%s, backendAddressPools=%v, deleteFromVMSet=%v",
+		service, backendPoolID, vmSetName, backendAddressPools, deleteFromVMSet)
 	// Returns nil if backend address pools already deleted.
 	if backendAddressPools == nil {
 		return nil
@@ -1697,6 +1706,9 @@ func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 
 	// Ensure the backendPoolID is also deleted on VMSS itself.
 	if deleteFromVMSet {
+		klog.V(2).Infof("EnsureBackendPoolDeleted, deleteFromVMSet=true, deleting "+
+			"backendPoolID=%v, vmSetName=%v, ipConfigurationIDs=%v",
+			backendPoolID, vmSetName, ipConfigurationIDs)
 		err := ss.ensureBackendPoolDeletedFromVMSS(service, backendPoolID, vmSetName, ipConfigurationIDs)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -1591,7 +1591,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 
 // EnsureBackendPoolDeleted ensures the loadBalancer backendAddressPools deleted from the specified nodes.
 func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool, deleteFromVMSet bool) error {
-	klog.V(2).Infof("EnsureBackendPoolDeleted called on service=%v, backendPoolID=%s, "+
+	klog.V(2).Infof("(ss *scaleSet) EnsureBackendPoolDeleted called on service=%v, backendPoolID=%s, "+
 		"vmSetName=%s, backendAddressPools=%v, deleteFromVMSet=%v",
 		service, backendPoolID, vmSetName, backendAddressPools, deleteFromVMSet)
 	// Returns nil if backend address pools already deleted.


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/release-1.23/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go#L789-L795
	when `needCheck` == true
	checks that machine.AvailabilitySet.ID == expectedAvailabilitySetID which is "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s"
	the resourceGroup comes from resourcegroup for the node that is looked up from vmName
later on https://github.com/kubernetes/kubernetes/blob/release-1.23/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go#L811 
	we return availabilitySetID = to.String(machine.AvailabilitySet.ID)
in https://github.com/kubernetes/kubernetes/blob/release-1.23/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go#L999
	we extract vmasName from availabilitySetID, which is the resourceGroup from /subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/availabilitySets/(.+)
	if we had `needCheck` from, then this equals the vmSet
	So we are using the standard load balancer: useStandardLoadBalancer

theory: if we are using the standard load balancer, perhaps these availability sets do not match.


/assign @ricky-rav 

/hold