### PR TITLE
Bug 2040715: upstream 108149: do not return early in the node informer when there is no change

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -749,10 +749,6 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
-			if newNode.Labels[v1.LabelTopologyZone] ==
-				prevNode.Labels[v1.LabelTopologyZone] {
-				return
-			}
 			az.updateNodeCaches(prevNode, newNode)
 		},
 		DeleteFunc: func(obj interface{}) {


### PR DESCRIPTION
... in the topology label.

(cherry picked from commit https://github.com/openshift/kubernetes/commit/82852c0a7c402c10cab18f219ca6eee1cd56c98d)

This is part of the solution for BZ 2040715.
