### PR TITLE
Bug 2055687: UPSTREAM: 108132: Fix incorrect parameters in EndpointsEqualBeyondHash

### DIFF
--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -281,11 +281,11 @@ func (sl portsInOrder) Less(i, j int) bool {
 // but excludes equality checks that would have already been covered with
 // endpoint hashing (see hashEndpoint func for more info).
 func EndpointsEqualBeyondHash(ep1, ep2 *discovery.Endpoint) bool {
-	if stringPtrChanged(ep1.NodeName, ep1.NodeName) {
+	if stringPtrChanged(ep1.NodeName, ep2.NodeName) {
 		return false
 	}
 
-	if stringPtrChanged(ep1.Zone, ep1.Zone) {
+	if stringPtrChanged(ep1.Zone, ep2.Zone) {
 		return false
 	}
 


### PR DESCRIPTION
   The endpoint slice controller does not compare correctly the fields
    NodeName and Zone on the Endpoint Slices, causing that changes on those
    fields only, doesn't trigger an update.


/kind bug
