### PR TITLE
SDN 4.11 kubernetes 1.23.0 rebase

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,30 +1,17 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - abhat
+  - danwinship
+  - dcbw
+  - JacobTanenbaum
+  - squeed
+  - tssurya
+approvers:
+  - abhat
+  - danwinship
+  - dcbw
+  - knobunc
+  - squeed
 
-filters:
-  ".*":
-    # Downstream reviewers, don't have to match those in OWNERS
-    reviewers:
-    - deads2k
-    - sttts
-    - soltysh
-    - mfojtik
-    - marun
-
-    # Approvers are limited to the team that manages rebases and pays the price for carries that are introduced
-    approvers:
-    - deads2k
-    - sttts
-    - soltysh
-    - mfojtik
-    - marun
-
-  "^\\.go.(mod|sum)$":
-    labels:
-    - "vendor-update"
-  "^vendor/.*":
-    labels:
-    - "vendor-update"
-  "^staging/.*":
-    labels:
-    - "vendor-update"
-component: kube-apiserver
+# Bugzilla info
+component: Networking
+subcomponent: openshift-sdn

--- a/cmd/kube-proxy/app/server_openshift.go
+++ b/cmd/kube-proxy/app/server_openshift.go
@@ -1,0 +1,9 @@
+package app
+
+import (
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+)
+
+func (o *Options) GetConfig() *kubeproxyconfig.KubeProxyConfiguration {
+	return o.config
+}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1076,6 +1076,20 @@ func (proxier *Proxier) syncProxyRules() {
 			proxier.natRules.Write(args)
 		}
 
+		// Prefer local endpoint for the DNS service.
+		// Fixes <https://bugzilla.redhat.com/show_bug.cgi?id=1919737>.
+		// TODO: Delete this if-block once internal traffic policy is
+		// implemented and the DNS operator is updated to use it.
+		if svcNameString == "openshift-dns/dns-default:dns" {
+			for _, ep := range allEndpoints {
+				if ep.GetIsLocal() {
+					klog.V(4).Infof("Found a local endpoint %q for service %q; preferring the local endpoint and ignoring %d other endpoints", ep.String(), svcNameString, len(allEndpoints) - 1)
+					allEndpoints = []proxy.Endpoint{ep}
+					break
+				}
+			}
+		}
+
 		svcChain := svcInfo.servicePortChainName
 		if hasEndpoints {
 			// Create the per-service chain, retaining counters if possible.

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -121,7 +121,11 @@ type serviceInfo struct {
 	servicePortChainName     utiliptables.Chain
 	serviceFirewallChainName utiliptables.Chain
 	serviceLBChainName       utiliptables.Chain
+
+	localWithFallback bool
 }
+
+const localWithFallbackAnnotation = "traffic-policy.network.alpha.openshift.io/local-with-fallback"
 
 // returns a new proxy.ServicePort which abstracts a serviceInfo
 func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo) proxy.ServicePort {
@@ -135,6 +139,14 @@ func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.B
 	info.servicePortChainName = servicePortChainName(info.serviceNameString, protocol)
 	info.serviceFirewallChainName = serviceFirewallChainName(info.serviceNameString, protocol)
 	info.serviceLBChainName = serviceLBChainName(info.serviceNameString, protocol)
+
+	if _, set := service.Annotations[localWithFallbackAnnotation]; set {
+		if info.NodeLocalExternal() {
+			info.localWithFallback = true
+		} else {
+			klog.Warningf("Ignoring annotation %q on Service %s which does not have Local ExternalTrafficPolicy", localWithFallbackAnnotation, svcName)
+		}
+	}
 
 	return info
 }
@@ -1418,6 +1430,20 @@ func (proxier *Proxier) syncProxyRules() {
 			"-m", "addrtype", "--src-type", "LOCAL", "-j", string(svcChain))
 
 		numLocalEndpoints := len(localEndpointChains)
+
+		// If "local-with-fallback" is in effect and there are no local endpoints,
+		// then NAT the traffic and forward to a remote endpoint
+		if numLocalEndpoints == 0 && svcInfo.localWithFallback {
+			proxier.natRules.Write(
+				"-A", string(svcXlbChain),
+				"-m", "comment", "--comment", `"local-with-fallback NAT"`,
+				"-j", string(KubeMarkMasqChain),
+			)
+
+			localEndpointChains = readyEndpointChains
+			numLocalEndpoints = len(localEndpointChains)
+		}
+
 		if numLocalEndpoints == 0 {
 			// Blackhole all traffic since there are no local endpoints
 			args = append(args[:0],

--- a/pkg/proxy/iptables/proxier_openshift.go
+++ b/pkg/proxy/iptables/proxier_openshift.go
@@ -1,0 +1,15 @@
+package iptables
+
+// Some extra hacking for openshift-specific stuff
+
+import (
+	"k8s.io/kubernetes/pkg/util/async"
+)
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/pkg/proxy/iptables/proxier_openshift.go
+++ b/pkg/proxy/iptables/proxier_openshift.go
@@ -13,3 +13,7 @@ func (p *Proxier) SyncProxyRules() {
 func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
 	p.syncRunner = b
 }
+
+func (p *Proxier) ReloadIPTables() {
+	// Ignore this; the iptables proxier has its own iptables.Monitor
+}

--- a/pkg/proxy/userspace/proxier_openshift.go
+++ b/pkg/proxy/userspace/proxier_openshift.go
@@ -1,0 +1,13 @@
+package userspace
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/pkg/proxy/userspace/proxier_openshift.go
+++ b/pkg/proxy/userspace/proxier_openshift.go
@@ -11,3 +11,8 @@ func (p *Proxier) SyncProxyRules() {
 func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
 	p.syncRunner = b
 }
+
+func (p *Proxier) ReloadIPTables() {
+	p.forceReload = true
+	p.syncProxyRules()
+}


### PR DESCRIPTION
### **Carried the following commits from the previous rebase branch "sdn-4.10-kubernetes-1.22.0-rc.0":**
userspace: Don't sync every iptables rule on every service change
UPSTREAM: <carry>: implement "local-with-fallback" external traffic policy
UPSTREAM: <carry>: Prefer local endpoint for cluster DNS service
UPSTREAM: <carry>: Allow overriding/hooking into kube-proxy
UPSTREAM: <carry>: add DOWNSTREAM_OWNERS

Note: Need to understand if the first commit above needs to be dropped or carried or renamed if we are keeping it.

### **Two commits needed modification:** 

**UPSTREAM: <carry>: implement "local-with-fallback" external traffic policy**
Edit was made on "If local-with-fallback... " code block. I needed to change the write function. I also changed the name of endpointChains -> readyEndpointChains.

**UPSTREAM: <carry>: add DOWNSTREAM_OWNERS**
Edit was made to remove Alexander from reviewer.






