### PR TITLE
WIP: refactor admission webhooks for extensibility

### DIFF
--- a/openshift-kube-apiserver/admission/admissionenablement/webhookmetrics/decorator.go
+++ b/openshift-kube-apiserver/admission/admissionenablement/webhookmetrics/decorator.go
@@ -1,0 +1,90 @@
+package webhookmetrics
+
+import (
+	"context"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/klog/v2"
+)
+
+var ObserveMutatingWebhookOpenShiftMetrics = mutating.WebhookInvokerDecoratorFunc(func(invoker mutating.WebhookInvoker) mutating.WebhookInvoker {
+	return func(ctx context.Context,
+		hook *admissionregistrationv1.MutatingWebhook,
+		invocation *generic.WebhookInvocation,
+		attr *generic.VersionedAttributes,
+		annotator mutating.WebhookAnnotator,
+		interfaces admission.ObjectInterfaces,
+		round, idx int) (bool, error) {
+
+		t := time.Now()
+		changed, err := invoker(ctx, hook, invocation, attr, annotator, interfaces, round, idx)
+		latency := time.Since(t)
+
+		rejected := err != nil
+		if _, ok := err.(*webhook.ErrCallingWebhook); ok && !(hook.FailurePolicy != nil && *hook.FailurePolicy == admissionregistrationv1.Ignore) {
+			rejected = true
+		}
+
+		// labels for metric
+		labels := []interface{}{
+			"name", hook.Name,
+			"operation", attr.GetOperation(),
+			"type", "mutating",
+			"rejected", rejected,
+			"group", invocation.Resource.Group,
+			"version", invocation.Resource.Version,
+			"resource", invocation.Resource.Resource,
+			"subresource", invocation.Subresource,
+		}
+
+		// TODO observe
+		klog.V(1).InfoS("##### MutatingWebhookInvoked", append(labels, "latency", float64(latency)/float64(time.Second))...)
+
+		return changed, err
+	}
+})
+
+func observeMetrics() {
+
+}
+
+var ObserveValidatingWebhookOpenShiftMetrics = validating.WebhookInvokerDecoratorFunc(func(invoker validating.WebhookInvoker) validating.WebhookInvoker {
+	return func(ctx context.Context,
+		hook *admissionregistrationv1.ValidatingWebhook,
+		invocation *generic.WebhookInvocation,
+		attr *generic.VersionedAttributes,
+	) error {
+
+		t := time.Now()
+		err := invoker(ctx, hook, invocation, attr)
+		latency := time.Since(t)
+
+		rejected := err != nil
+		if _, ok := err.(*webhook.ErrCallingWebhook); ok && !(hook.FailurePolicy != nil && *hook.FailurePolicy == admissionregistrationv1.Ignore) {
+			rejected = true
+		}
+
+		// labels for metric
+		labels := []interface{}{
+			"name", hook.Name,
+			"operation", attr.GetOperation(),
+			"type", "validating",
+			"rejected", rejected,
+			"group", invocation.Resource.Group,
+			"version", invocation.Resource.Version,
+			"resource", invocation.Resource.Resource,
+			"subresource", invocation.Subresource,
+		}
+
+		// TODO observe
+		klog.V(1).InfoS("##### ValidatingWebhookInvoked", append(labels, "latency", float64(latency)/float64(time.Second))...)
+
+		return err
+	}
+})

--- a/openshift-kube-apiserver/admission/admissionenablement/webhookmetrics/initializer.go
+++ b/openshift-kube-apiserver/admission/admissionenablement/webhookmetrics/initializer.go
@@ -1,0 +1,21 @@
+package webhookmetrics
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/initializer"
+)
+
+func NewInitializer() *localInitializer {
+	return &localInitializer{}
+}
+
+type localInitializer struct{}
+
+func (i *localInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(initializer.WantsMutatingWebhookInvokerDecorator); ok {
+		wants.AppendWebhookInvokerDecorator(ObserveMutatingWebhookOpenShiftMetrics)
+	}
+	if wants, ok := plugin.(initializer.WantsValidatingWebhookInvokerDecorator); ok {
+		wants.AppendWebhookInvokerDecorator(ObserveValidatingWebhookOpenShiftMetrics)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/decorator.go
@@ -1,0 +1,27 @@
+package mutating
+
+// A WebhookInvokerDecorator decorates a WebHookInvoker.
+type WebhookInvokerDecorator interface {
+	// Decorate returns a WebhookInvoker wrapped by a decorator.
+	Decorate(invoker WebhookInvoker) WebhookInvoker
+}
+
+// The WebhookInvokerDecoratorFunc type adapts an ordinary function as a WebhookInvokerDecorator.
+type WebhookInvokerDecoratorFunc func(invoker WebhookInvoker) WebhookInvoker
+
+// Decorate returns a WebhookInvoker wrapped by a decorator.
+func (d WebhookInvokerDecoratorFunc) Decorate(invoker WebhookInvoker) WebhookInvoker {
+	return d(invoker)
+}
+
+// WebhookInvokerDecorators presents multiple webhook decorators as one.
+type WebhookInvokerDecorators []WebhookInvokerDecorator
+
+// Decorate returns WebhookInvoker wrapped by multiple webhook decorators.
+func (d WebhookInvokerDecorators) Decorate(invoker WebhookInvoker) WebhookInvoker {
+	decorated := invoker
+	for _, decorator := range d {
+		decorated = decorator.Decorate(decorated)
+	}
+	return decorated
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/decorator_metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/decorator_metrics.go
@@ -1,0 +1,43 @@
+package mutating
+
+import (
+	"context"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apiserver/pkg/admission"
+	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+)
+
+// MetricsDecorator wraps webhook invocations with metric observations.
+var MetricsDecorator = WebhookInvokerDecoratorFunc(func(invoker WebhookInvoker) WebhookInvoker {
+	return func(ctx context.Context, hook *admissionregistrationv1.MutatingWebhook, invocation *generic.WebhookInvocation, attr *generic.VersionedAttributes, annotator WebhookAnnotator, interfaces admission.ObjectInterfaces, round, idx int) (bool, error) {
+		t := time.Now()
+		changed, err := invoker(ctx, hook, invocation, attr, annotator, interfaces, round, idx)
+		ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == admissionregistrationv1.Ignore
+		rejected := false
+		if err != nil {
+			switch err := err.(type) {
+			case *webhookutil.ErrCallingWebhook:
+				if !ignoreClientCallFailures {
+					rejected = true
+					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+				}
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "admit", int(err.Status.ErrStatus.Code))
+			case *webhookutil.ErrWebhookRejection:
+				rejected = true
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "admit", int(err.Status.ErrStatus.Code))
+			default:
+				rejected = true
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "admit", 0)
+			}
+		} else {
+			admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "admit", 200)
+		}
+		return changed, err
+	}
+})

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/decorator.go
@@ -1,0 +1,27 @@
+package validating
+
+// A WebhookInvokerDecorator decorates a WebHookInvoker.
+type WebhookInvokerDecorator interface {
+	// Decorate returns a WebhookInvoker wrapped by a decorator.
+	Decorate(invoker WebhookInvoker) WebhookInvoker
+}
+
+// The WebhookInvokerDecoratorFunc type adapts an ordinary function as a WebhookInvokerDecorator.
+type WebhookInvokerDecoratorFunc func(invoker WebhookInvoker) WebhookInvoker
+
+// Decorate returns a WebhookInvoker wrapped by a decorator.
+func (d WebhookInvokerDecoratorFunc) Decorate(invoker WebhookInvoker) WebhookInvoker {
+	return d(invoker)
+}
+
+// WebhookInvokerDecorators presents multiple webhook decorators as one.
+type WebhookInvokerDecorators []WebhookInvokerDecorator
+
+// Decorate returns WebhookInvoker wrapped by multiple webhook decorators.
+func (d WebhookInvokerDecorators) Decorate(invoker WebhookInvoker) WebhookInvoker {
+	decorated := invoker
+	for _, decorator := range d {
+		decorated = decorator.Decorate(decorated)
+	}
+	return decorated
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/decorator_metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/decorator_metrics.go
@@ -1,0 +1,42 @@
+package validating
+
+import (
+	"context"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+)
+
+// MetricsDecorator wraps webhook invocations with metric observations.
+var MetricsDecorator = WebhookInvokerDecoratorFunc(func(invoker WebhookInvoker) WebhookInvoker {
+	return func(ctx context.Context, hook *admissionregistrationv1.ValidatingWebhook, invocation *generic.WebhookInvocation, attr *generic.VersionedAttributes) error {
+		t := time.Now()
+		err := invoker(ctx, hook, invocation, attr)
+		ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == admissionregistrationv1.Ignore
+		rejected := false
+		if err != nil {
+			switch err := err.(type) {
+			case *webhookutil.ErrCallingWebhook:
+				if !ignoreClientCallFailures {
+					rejected = true
+					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+				}
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "validating", int(err.Status.ErrStatus.Code))
+			case *webhookutil.ErrWebhookRejection:
+				rejected = true
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "validating", int(err.Status.ErrStatus.Code))
+			default:
+				rejected = true
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(attr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
+				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "validating", 0)
+			}
+		} else {
+			admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, attr.Attributes, "validating", 200)
+		}
+		return err
+	}
+})


### PR DESCRIPTION
We need more labels on the webhook latency metrics in order to provided more targeted dashboards and alerts than the existing upstream `apiserver_admission_webhook_admission_duration` metric provides. Since this metric is `stable`, we can't just make changes to it. 

This PR proposes to refactor the admission webhook plugin to extract the actual invocation of the webhook into a `WebhookInvoker`, and then introduce the `WebhookInvokerDecorator` that can wrap a `WebhookInvoker` with additional functionality, such as, in this case, the observation of metrics.

This then enables OpenShift to provide its own `WebhookInvokerDecorators` that observe OpenShift specific metrics: `ObserveMutatingWebhookOpenShiftMetrics` and `ObserveValidatingWebhookOpenShiftMetrics`. The OpenShift decorators are injected via a new admission plugin initializer.

---

I intended to also move the trace and annotation to their own `WebhookInvokerDecorators`, but it would require much more refactoring and I would like to receive some feedback before attempting to further refactor. 

