### PR TITLE
UPSTREAM: <carry>: add ratcheting validation for ingress.status.componentroute

### DIFF
--- a/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -2,7 +2,6 @@ package customresourcevalidationregistration
 
 import (
 	"k8s.io/apiserver/pkg/admission"
-
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/authentication"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/clusterresourcequota"
@@ -11,6 +10,7 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/dns"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/features"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/image"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/ingress"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/kubecontrollermanager"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/network"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/oauth"
@@ -28,6 +28,7 @@ var AllCustomResourceValidators = []string{
 	console.PluginName,
 	dns.PluginName,
 	image.PluginName,
+	ingress.PluginName,
 	oauth.PluginName,
 	project.PluginName,
 	config.PluginName,
@@ -51,6 +52,7 @@ func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	console.Register(plugins)
 	dns.Register(plugins)
 	image.Register(plugins)
+	ingress.Register(plugins)
 	oauth.Register(plugins)
 	project.Register(plugins)
 	config.Register(plugins)

--- a/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress.go
@@ -1,0 +1,150 @@
+package ingress
+
+import (
+	"fmt"
+	"io"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/route/routeapihelpers"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+)
+
+const PluginName = "config.openshift.io/ValidateIngress"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				configv1.Resource("ingresses"): true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				configv1.GroupVersion.WithKind("Ingress"): ingressV1{},
+			})
+	})
+}
+
+func toIngressV1(uncastObj runtime.Object) (*configv1.Ingress, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*configv1.Ingress)
+	if !ok {
+		return nil, append(allErrs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"Ingress"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"config.openshift.io/v1"}))
+	}
+
+	return obj, nil
+}
+
+type ingressV1 struct {
+}
+
+func validateIngressSpecCreate(spec configv1.IngressSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// on create, we use the tightest validation
+	for i, currRoute := range spec.ComponentRoutes {
+		allErrs = append(allErrs,
+			routeapihelpers.ValidateHost(
+				string(currRoute.Hostname),
+				"",
+				field.NewPath("spec.componentRoutes").Index(i).Child("hostname"),
+			)...)
+	}
+
+	return allErrs
+}
+
+func validateIngressSpecUpdate(spec, oldSpec configv1.IngressSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// on update, if the componentroute.hostname has changed, we use the tightest validation.
+	// if the componentroute.hostname has not changed, we do not enforce new validation.
+	// empty hostnames always produce an error.  See unit test.
+	for i, currRoute := range spec.ComponentRoutes {
+		currFieldPath := field.NewPath("spec.componentRoutes").Index(i).Child("hostname")
+		currRouteHostnameErrors := routeapihelpers.ValidateHost(
+			string(currRoute.Hostname),
+			"",
+			currFieldPath,
+		)
+		if len(currRouteHostnameErrors) == 0 {
+			continue
+		}
+		if len(currRoute.Hostname) == 0 {
+			allErrs = append(allErrs, currRouteHostnameErrors...)
+			continue
+		}
+
+		previousRouteHostName := configv1.Hostname("")
+		for _, oldRoute := range oldSpec.ComponentRoutes {
+			if oldRoute.Name == currRoute.Name && oldRoute.Namespace == currRoute.Namespace {
+				previousRouteHostName = oldRoute.Hostname
+				break
+			}
+		}
+		// we don't enforce new validation rules if the hostname has not changed
+		if previousRouteHostName == currRoute.Hostname {
+			continue
+		}
+
+		// if the hostname has changed, then the new route must pass new validation.
+		allErrs = append(allErrs, currRouteHostnameErrors...)
+	}
+
+	return allErrs
+}
+
+func (ingressV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, allErrs := toIngressV1(uncastObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, validateIngressSpecCreate(obj.Spec)...)
+
+	return allErrs
+}
+
+func (ingressV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, allErrs := toIngressV1(uncastObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	oldObj, allErrs := toIngressV1(uncastOldObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, validateIngressSpecUpdate(obj.Spec, oldObj.Spec)...)
+
+	return allErrs
+}
+
+func (ingressV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toIngressV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toIngressV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// TODO validate the obj.  remember that status validation should *never* fail on spec validation errors.
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+
+	return errs
+}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress_test.go
@@ -161,3 +161,181 @@ func TestValidateUpdateSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateUpdateStatus(t *testing.T) {
+	tests := []struct {
+		name                string
+		defaultHostname     string
+		oldDefaultHostname  string
+		currentHostnames    []configv1.Hostname
+		oldCurrentHostnames []configv1.Hostname
+		noPrevious          bool
+		expectedErr         string
+	}{
+		{
+			name:               "defaultHostname: no change",
+			defaultHostname:    "111!!! invalid I think",
+			oldDefaultHostname: "111!!! invalid I think",
+			expectedErr:        ``,
+		},
+		{
+			name:               "defaultHostname: change from invalid to valid",
+			defaultHostname:    "host.com",
+			oldDefaultHostname: "host",
+			expectedErr:        ``,
+		},
+		{
+			name:               "defaultHostname: change from valid to used-to-be-valid",
+			defaultHostname:    "host",
+			oldDefaultHostname: "host.com",
+			expectedErr:        `status.componentRoutes[0].defaultHostname: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].defaultHostname: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:               "defaultHostname: change from not-valid to still-not-valid",
+			defaultHostname:    "hoststillfails",
+			oldDefaultHostname: "host",
+			expectedErr:        `status.componentRoutes[0].defaultHostname: Invalid value: "hoststillfails": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].defaultHostname: Invalid value: "hoststillfails": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:               "defaultHostname: no previous value and illegal",
+			defaultHostname:    "host",
+			oldDefaultHostname: "nohost",
+			noPrevious:         true,
+			expectedErr:        `status.componentRoutes[0].defaultHostname: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].defaultHostname: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:               "defaultHostname: no previous value and legal",
+			defaultHostname:    "host.com",
+			oldDefaultHostname: "nohost",
+			noPrevious:         true,
+			expectedErr:        ``,
+		},
+		{
+			name:               "defaultHostname: no previous value to empty, empty is illegal",
+			defaultHostname:    "",
+			oldDefaultHostname: "nohost",
+			noPrevious:         true,
+			expectedErr:        `status.componentRoutes[0].defaultHostname: Invalid value: "": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].defaultHostname: Required value]`,
+		},
+
+		{
+			name:                "currentHostnames: no change",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("111!!! invalid I think")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("111!!! invalid I think")},
+			expectedErr:         ``,
+		},
+		{
+			name:                "currentHostnames: change from invalid to valid",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host.com")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("host")},
+			expectedErr:         ``,
+		},
+		{
+			name:                "currentHostnames: change from valid to used-to-be-valid",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("host.com")},
+			expectedErr:         `status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:                "currentHostnames: change from not-valid to still-not-valid",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("hoststillfails")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("host")},
+			expectedErr:         `status.componentRoutes[0].currentHostnames[0]: Invalid value: "hoststillfails": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[0]: Invalid value: "hoststillfails": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:                "currentHostnames: no previous value and illegal",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("nohost")},
+			noPrevious:          true,
+			expectedErr:         `status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:                "currentHostnames: no previous value and legal",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host.com")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("nohost")},
+			noPrevious:          true,
+			expectedErr:         ``,
+		},
+		{
+			name:                "currentHostnames: no previous value to empty, empty is illegal",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("nohost")},
+			noPrevious:          true,
+			expectedErr:         `status.componentRoutes[0].currentHostnames[0]: Invalid value: "": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[0]: Required value]`,
+		},
+		{
+			name:                "currentHostnames: add new legal value with illegal value remaining",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host.com"), configv1.Hostname("111!!! invalid I think")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("111!!! invalid I think")},
+			expectedErr:         ``,
+		},
+		{
+			name:                "currentHostnames: add new illegal value with illegal value remaining",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("host"), configv1.Hostname("111!!! invalid I think")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("111!!! invalid I think")},
+			expectedErr:         `status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[0]: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:                "currentHostnames: add new illegal value to the end with illegal value remaining",
+			defaultHostname:     "host.com",
+			currentHostnames:    []configv1.Hostname{configv1.Hostname("111!!! invalid I think"), configv1.Hostname("host")},
+			oldCurrentHostnames: []configv1.Hostname{configv1.Hostname("111!!! invalid I think")},
+			expectedErr:         `status.componentRoutes[0].currentHostnames[1]: Invalid value: "host": host must conform to DNS 1123 naming conventions: [status.componentRoutes[0].currentHostnames[1]: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldName := "match"
+			if tc.noPrevious {
+				oldName = "no-match"
+			}
+			actual := validateIngressStatusUpdate(
+				configv1.IngressStatus{
+					ComponentRoutes: []configv1.ComponentRouteStatus{
+						{
+							Name:             "match",
+							DefaultHostname:  configv1.Hostname(tc.defaultHostname),
+							CurrentHostnames: tc.currentHostnames,
+						},
+					},
+				},
+				configv1.IngressStatus{
+					ComponentRoutes: []configv1.ComponentRouteStatus{
+						{
+							Name:             oldName,
+							DefaultHostname:  configv1.Hostname(tc.oldDefaultHostname),
+							CurrentHostnames: tc.oldCurrentHostnames,
+						},
+					},
+				})
+
+			switch {
+			case len(actual) == 0 && len(tc.expectedErr) == 0:
+			case len(actual) == 0 && len(tc.expectedErr) != 0:
+				t.Fatalf("didn't get expected error: %v", tc.expectedErr)
+			case len(actual) != 0 && len(tc.expectedErr) == 0:
+				t.Fatalf("unexpected error: %v", actual)
+			case len(actual) != 0 && len(tc.expectedErr) != 0:
+				found := false
+				for _, actualErr := range actual {
+					found = found || strings.Contains(actualErr.Error(), tc.expectedErr)
+				}
+				if !found {
+					t.Fatalf("got %q, expected %q", actual, tc.expectedErr)
+				}
+			default:
+			}
+
+		})
+	}
+}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/ingress/validate_ingress_test.go
@@ -1,0 +1,163 @@
+package ingress
+
+import (
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestValidateCreateSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		hostname    string
+		expectedErr string
+	}{
+		{
+			name:        "empty",
+			hostname:    "",
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Required value]`,
+		},
+		{
+			name:        "new validation fails",
+			hostname:    "host",
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "host": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:        "new validation passes",
+			hostname:    "host.com",
+			expectedErr: ``,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := validateIngressSpecCreate(
+				configv1.IngressSpec{
+					ComponentRoutes: []configv1.ComponentRouteSpec{
+						{
+							Hostname: configv1.Hostname(tc.hostname),
+						},
+					},
+				},
+			)
+			switch {
+			case len(actual) == 0 && len(tc.expectedErr) == 0:
+			case len(actual) == 0 && len(tc.expectedErr) != 0:
+				t.Fatalf("didn't get expected error: %v", tc.expectedErr)
+			case len(actual) != 0 && len(tc.expectedErr) == 0:
+				t.Fatalf("unexpected error: %v", actual)
+			case len(actual) != 0 && len(tc.expectedErr) != 0:
+				found := false
+				for _, actualErr := range actual {
+					found = found || strings.Contains(actualErr.Error(), tc.expectedErr)
+				}
+				if !found {
+					t.Fatalf("got %q, expected %q", actual, tc.expectedErr)
+				}
+			default:
+			}
+
+		})
+	}
+}
+
+func TestValidateUpdateSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		hostname    string
+		oldHostname string
+		noPrevious  bool
+		expectedErr string
+	}{
+		{
+			name:        "no change",
+			hostname:    "111!!! invalid I think",
+			oldHostname: "111!!! invalid I think",
+			expectedErr: ``,
+		},
+		{
+			name:        "change from invalid to valid",
+			hostname:    "host.com",
+			oldHostname: "host",
+			expectedErr: ``,
+		},
+		{
+			name:        "change from valid to used-to-be-valid",
+			hostname:    "host",
+			oldHostname: "host.com",
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "host": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:        "change from not-valid to still-not-valid",
+			hostname:    "hoststillfails",
+			oldHostname: "host",
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "hoststillfails": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Invalid value: "hoststillfails": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:        "no previous value and illegal",
+			hostname:    "host",
+			oldHostname: "nohost",
+			noPrevious:  true,
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "host": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Invalid value: "host": should be a domain with at least two segments separated by dots]`,
+		},
+		{
+			name:        "no previous value and legal",
+			hostname:    "host.com",
+			oldHostname: "nohost",
+			noPrevious:  true,
+			expectedErr: ``,
+		},
+		{
+			name:        "no previous value to empty, empty is illegal",
+			hostname:    "",
+			oldHostname: "nohost",
+			noPrevious:  true,
+			expectedErr: `spec.componentRoutes[0].hostname: Invalid value: "": host must conform to DNS 1123 naming conventions: [spec.componentRoutes[0].hostname: Required value]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldName := "match"
+			if tc.noPrevious {
+				oldName = "no-match"
+			}
+			actual := validateIngressSpecUpdate(
+				configv1.IngressSpec{
+					ComponentRoutes: []configv1.ComponentRouteSpec{
+						{
+							Name:     "match",
+							Hostname: configv1.Hostname(tc.hostname),
+						},
+					},
+				},
+				configv1.IngressSpec{
+					ComponentRoutes: []configv1.ComponentRouteSpec{
+						{
+							Name:     oldName,
+							Hostname: configv1.Hostname(tc.oldHostname),
+						},
+					},
+				})
+
+			switch {
+			case len(actual) == 0 && len(tc.expectedErr) == 0:
+			case len(actual) == 0 && len(tc.expectedErr) != 0:
+				t.Fatalf("didn't get expected error: %v", tc.expectedErr)
+			case len(actual) != 0 && len(tc.expectedErr) == 0:
+				t.Fatalf("unexpected error: %v", actual)
+			case len(actual) != 0 && len(tc.expectedErr) != 0:
+				found := false
+				for _, actualErr := range actual {
+					found = found || strings.Contains(actualErr.Error(), tc.expectedErr)
+				}
+				if !found {
+					t.Fatalf("got %q, expected %q", actual, tc.expectedErr)
+				}
+			default:
+			}
+
+		})
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/route/routeapihelpers/routeapihelpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/route/routeapihelpers/routeapihelpers.go
@@ -1,0 +1,73 @@
+// Package routeapihelpers contains utilities for handling OpenShift route objects.
+package routeapihelpers
+
+import (
+	"fmt"
+	"net/url"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// IngressURI calculates an admitted ingress URI.
+// If 'host' is nonempty, only the ingress for that host is considered.
+// If 'host' is empty, the first admitted ingress is used.
+func IngressURI(route *routev1.Route, host string) (*url.URL, *routev1.RouteIngress, error) {
+	scheme := "http"
+	if route.Spec.TLS != nil {
+		scheme = "https"
+	}
+
+	for _, ingress := range route.Status.Ingress {
+		if host == "" || host == ingress.Host {
+			uri := &url.URL{
+				Scheme: scheme,
+				Host:   ingress.Host,
+			}
+
+			for _, condition := range ingress.Conditions {
+				if condition.Type == routev1.RouteAdmitted && condition.Status == corev1.ConditionTrue {
+					return uri, &ingress, nil
+				}
+			}
+
+			if host == ingress.Host {
+				return uri, &ingress, fmt.Errorf("ingress for host %s in route %s in namespace %s is not admitted", host, route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+			}
+		}
+	}
+
+	if host == "" {
+		return nil, nil, fmt.Errorf("no admitted ingress for route %s in namespace %s", route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+	}
+	return nil, nil, fmt.Errorf("no ingress for host %s in route %s in namespace %s", host, route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+}
+
+// ValidateHost checks that a route's host name satisfies DNS requirements, with
+// the assumption that the caller has already checked for an empty host name.
+// Unless the allowNonCompliant annotation is set to true, host name must have
+// at least two labels, with each label no more than 63 characters from the set of
+// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric
+// character. A trailing dot is allowed. The total host name length must be no more
+// than 253 characters.
+// If allowNonCompliant is set to true, it uses a smaller set of conditions from
+// IsDNS1123Subdomain, e.g. character set as described above, and total host name
+// length must be no more than 253 characters.
+func ValidateHost(host string, allowNonCompliant string, hostPath *field.Path) field.ErrorList {
+	result := field.ErrorList{}
+
+	if allowNonCompliant == "true" {
+		errs := kvalidation.IsDNS1123Subdomain(host)
+		if len(errs) != 0 {
+			result = append(result, field.Invalid(hostPath, host, fmt.Sprintf("host must conform to DNS naming conventions: %v", errs)))
+		}
+	} else {
+		errs := kvalidation.IsFullyQualifiedDomainName(hostPath, host)
+		if len(errs) != 0 {
+			result = append(result, field.Invalid(hostPath, host, fmt.Sprintf("host must conform to DNS 1123 naming conventions: %v", errs)))
+		}
+	}
+	return result
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -851,6 +851,7 @@ github.com/openshift/library-go/pkg/network
 github.com/openshift/library-go/pkg/oauth/oauthdiscovery
 github.com/openshift/library-go/pkg/quota/clusterquotamapping
 github.com/openshift/library-go/pkg/quota/quotautil
+github.com/openshift/library-go/pkg/route/routeapihelpers
 github.com/openshift/library-go/pkg/security/ldaputil
 github.com/openshift/library-go/pkg/security/uid
 # github.com/peterbourgon/diskv v2.0.1+incompatible => github.com/peterbourgon/diskv v2.0.1+incompatible


### PR DESCRIPTION
follow on to https://github.com/openshift/kubernetes/pull/1216 that covers ingress.status

The technique for allowing existing bad values to stay is slightly difference since they can logically appear anywhere in the slice.