### PR TITLE
[release-4.7][ART-3664] Bug 2043804: IPs with leading zeros are still valid in the apiserver

### DIFF
--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -1,7 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
-RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination' && \
+RUN make GOFLAGS='-mod=vendor -p=4 -tags=unsupportedGolang115OnlyUseDeprecatedParseIPv4' \
+         WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination' && \
     mkdir -p /tmp/build && \
     cp openshift-hack/images/hyperkube/hyperkube /tmp/build && \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination} \

--- a/openshift-hack/test-go.sh
+++ b/openshift-hack/test-go.sh
@@ -10,7 +10,7 @@ export KUBERNETES_SERVICE_HOST=
 export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_RACE=-race
-export KUBE_TEST_ARGS='-p 8'
+export KUBE_TEST_ARGS='-p 8 -tags=unsupportedGolang115OnlyUseDeprecatedParseIPv4'
 export KUBE_TIMEOUT='--timeout=360s'
 
 make test

--- a/openshift-hack/test-integration.sh
+++ b/openshift-hack/test-integration.sh
@@ -13,7 +13,7 @@ export KUBERNETES_SERVICE_HOST=
 export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_RACE=-race
-export KUBE_TEST_ARGS='-p 8'
+export KUBE_TEST_ARGS='-p 8 -tags=unsupportedGolang115OnlyUseDeprecatedParseIPv4'
 export LOG_LEVEL=4
 export PATH
 

--- a/test/integration/apiserver/cve_2021_29923_test.go
+++ b/test/integration/apiserver/cve_2021_29923_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func gvr(g, v, r string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
+}
+
+// TestCanaryCVE_2021_29923 tests to make sure that objects that use the golang IP parsers allow IPv4 addresses with leading zeros.
+// Is it possible that exist more fields that can contain IPs, the test consider the most significative.
+// xref: https://issues.k8s.io/100895
+func TestCanaryCVE_2021_29923(t *testing.T) {
+	controlPlaneConfig := framework.NewIntegrationTestMasterConfig()
+	_, server, closeFn := framework.RunAMaster(controlPlaneConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+
+	dynamicClient, err := dynamic.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("unexpected error creating dynamic client: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-cve-2021-29923", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	objects := map[schema.GroupVersionResource]string{
+		// k8s.io/kubernetes/pkg/api/v1
+		gvr("", "v1", "nodes"):     `{"kind": "Node", "apiVersion": "v1", "metadata": {"name": "node1"}, "spec": {"unschedulable": true}, "status": {"addresses":[{"address":"172.18.0.012","type":"InternalIP"}]}}`,
+		gvr("", "v1", "pods"):      `{"kind": "Pod", "apiVersion": "v1", "metadata": {"name": "pod1", "namespace": "test-cve-2021-29923"}, "spec": {"containers": [{"image": "` + "image" + `", "name": "container7", "resources": {"limits": {"cpu": "1M"}, "requests": {"cpu": "1M"}}}]}, "status": {"podIP":"10.244.0.05","podIPs":[{"ip":"10.244.0.05"}]}}`,
+		gvr("", "v1", "services"):  `{"kind": "Service", "apiVersion": "v1", "metadata": {"name": "service1", "namespace": "test-cve-2021-29923"}, "spec": {"clusterIP": "10.0.0.011", "externalIP": "192.168.0.012", "externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
+		gvr("", "v1", "endpoints"): `{"kind": "Endpoints", "apiVersion": "v1", "metadata": {"name": "ep1name", "namespace": "test-cve-2021-29923"}, "subsets": [{"addresses": [{"hostname": "bar-001", "ip": "192.168.3.011"}], "ports": [{"port": 8000}]}]}`,
+		// k8s.io/kubernetes/pkg/apis/networking/v1
+		gvr("networking.k8s.io", "v1", "ingresses"):       `{"kind": "Ingress", "apiVersion": "networking.k8s.io/v1", "metadata": {"name": "ingress3", "namespace": "test-cve-2021-29923"}, "spec": {"defaultBackend": {"service":{"name":"service", "port":{"number": 5000}}}}, "status":{"loadBalancer":{"ingress": [{"ip":"10.0.0.013"}]}}}`,
+		gvr("networking.k8s.io", "v1", "networkpolicies"): `{"kind": "NetworkPolicy", "apiVersion": "networking.k8s.io/v1", "metadata": {"name": "np2", "namespace": "test-cve-2021-29923"}, "spec": {"egress":[{"ports":[{"port":5978,"protocol":"TCP"}],"to":[{"ipBlock":{"cidr":"10.0.012.0/24"}}]}],"ingress":[{"from":[{"ipBlock":{"cidr":"172.017.0.0/16","except":["172.17.001.0/24"]}},{"podSelector":{"matchLabels":{"role":"frontend"}}}],"ports":[{"port":6379,"protocol":"TCP"}]}],"podSelector":{"matchLabels":{"role":"db"}},"policyTypes":["Ingress","Egress"]}}`,
+	}
+
+	for gvr, data := range objects {
+		t.Run(gvr.String(), func(t *testing.T) {
+			obj := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(data), &obj); err != nil {
+				t.Fatal(err)
+			}
+
+			cr := &unstructured.Unstructured{Object: obj}
+
+			_, err := dynamicClient.Resource(gvr).Namespace(cr.GetNamespace()).Create(context.TODO(), cr, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("error creating resource %s with IPs with leading zeros %v", gvr.String(), err)
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
backport of https://github.com/openshift/kubernetes/pull/1173
ref. https://issues.redhat.com/browse/ART-3664