### PR TITLE
Bug 2073153: golang toolchain unsupported parsers tag

### DIFF
--- a/openshift-hack/test-go.sh
+++ b/openshift-hack/test-go.sh
@@ -10,7 +10,7 @@ export KUBERNETES_SERVICE_HOST=
 export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_RACE=-race
-export KUBE_TEST_ARGS='-p 8'
+export KUBE_TEST_ARGS='-p 8 -tags=unsupportedGolang116OnlyUseDeprecatedParseIPv4'
 export KUBE_TIMEOUT='--timeout=360s'
 
 make test

--- a/openshift-hack/test-integration.sh
+++ b/openshift-hack/test-integration.sh
@@ -13,7 +13,7 @@ export KUBERNETES_SERVICE_HOST=
 export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_RACE=-race
-export KUBE_TEST_ARGS='-p 8'
+export KUBE_TEST_ARGS='-p 8 -tags=unsupportedGolang116OnlyUseDeprecatedParseIPv4'
 export LOG_LEVEL=4
 export PATH
 


### PR DESCRIPTION
When adding the test to verify the IPs with leading zeros,  https://github.com/openshift/kubernetes/pull/1173

only the Dockerfile that builds the apiserver images was modified, but it turns out that we have to pass those tags to the golang version used to run the tests