### PR TITLE
UPSTREAM: <carry>: kube-apiserver: Prioritize machine API group

### DIFF
--- a/pkg/controlplane/controller/crdregistration/patch.go
+++ b/pkg/controlplane/controller/crdregistration/patch.go
@@ -2,6 +2,8 @@ package crdregistration
 
 func getGroupPriorityMin(group string) int32 {
 	switch group {
+	case "machine.openshift.io":
+		return 1100
 	case "config.openshift.io":
 		return 1100
 	case "operator.openshift.io":


### PR DESCRIPTION
Prioritize machine API group - "machine.openshift.io". When ClusterAPI is installed there is a clash because of the resource names, for example `machineset.cluster.x-k8s.io` clashes with `machineset.machine.openshift.io`. I would like to keep the user experience consistent and make MAPI authoritative.