### PR TITLE
UPSTREAM: 109931: fix: exclude non-ready nodes and deleted nodes from azure load balancers

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 	"k8s.io/klog/v2"
 	"k8s.io/legacy-cloud-providers/azure/auth"
 	azcache "k8s.io/legacy-cloud-providers/azure/cache"
@@ -811,13 +812,13 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		managed, ok := prevNode.ObjectMeta.Labels[managedByAzureLabel]
 		isNodeManagedByCloudProvider := !ok || managed != "false"
 
-		// Remove unmanagedNodes cache
+		// Remove from unmanagedNodes cache
 		if !isNodeManagedByCloudProvider {
 			az.unmanagedNodes.Delete(prevNode.ObjectMeta.Name)
 		}
 
+		// if the node is being deleted from the cluster, exclude it from load balancers
 		if newNode == nil {
-			// the node is being deleted from the cluster, exclude it from load balancers
 			az.excludeLoadBalancerNodes.Insert(prevNode.ObjectMeta.Name)
 		}
 	}
@@ -845,21 +846,30 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		managed, ok := newNode.ObjectMeta.Labels[managedByAzureLabel]
 		isNodeManagedByCloudProvider := !ok || managed != "false"
 
-		// update unmanagedNodes cache
+		// Update unmanagedNodes cache
 		if !isNodeManagedByCloudProvider {
 			az.unmanagedNodes.Insert(newNode.ObjectMeta.Name)
 		}
-		// update excludeLoadBalancerNodes cache
+
+		// Update excludeLoadBalancerNodes cache
 		switch {
 		case !isNodeManagedByCloudProvider:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+
 		case hasExcludeBalancerLabel:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
-		case !isNodeReady(newNode):
+
+		case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
+			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
+			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
+			// excluded from load balancers regardless of their state, so as to reduce the number of
+			// VMSS API calls and not provoke VMScaleSetActiveModelsCountLimitReached.
+			// (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/851)
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+
 		default:
 			// Nodes not falling into the three cases above are valid backends and
-			// are removed from excludeLoadBalancerNodes cache.
+			// should not appear in excludeLoadBalancerNodes cache.
 			az.excludeLoadBalancerNodes.Delete(newNode.ObjectMeta.Name)
 		}
 	}
@@ -987,8 +997,6 @@ func (az *Cloud) ShouldNodeExcludedFromLoadBalancer(nodeName string) (bool, erro
 	return az.excludeLoadBalancerNodes.Has(nodeName), nil
 }
 
-// This, along with the few lines that call this function in updateNodeCaches, should be
-// replaced by https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1195 once that merges.
 func isNodeReady(node *v1.Node) bool {
 	for _, cond := range node.Status.Conditions {
 		if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue {
@@ -996,4 +1004,13 @@ func isNodeReady(node *v1.Node) bool {
 		}
 	}
 	return false
+}
+
+func getCloudTaint(taints []v1.Taint) *v1.Taint {
+	for _, taint := range taints {
+		if taint.Key == cloudproviderapi.TaintExternalCloudProvider {
+			return &taint
+		}
+	}
+	return nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1125,11 +1125,8 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 							return nil, err
 						}
-
-						// If a node is not supposed to be included in the LB, it
-						// would not be in the `nodes` slice. We need to check the nodes that
-						// have been added to the LB's backendpool, find the unwanted ones and
-						// delete them from the pool.
+						// If the node appears in the local cache of nodes to exclude,
+						// delete it from the load balancer backend pool.
 						shouldExcludeLoadBalancer, err := az.ShouldNodeExcludedFromLoadBalancer(nodeName)
 						if err != nil {
 							klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)


### PR DESCRIPTION
With this PR, we align the code with what has been merged upstream for the future 1.25 (https://github.com/kubernetes/kubernetes/pull/108284), whose backport to 1.24 is currently being reviewed: https://github.com/kubernetes/kubernetes/pull/109931.

There is a minor change with respect to the existing patch that we approved for master and 4.11 back in february (which is currently being carried over to the 1.24 bump: https://github.com/openshift/kubernetes/pull/1252/commits/c5602511312fc9cf70e0b453dfa470649f0288a2): as requested by Azure folks in the original upstream PR, we inspect node taints when deciding whether to exclude a node from the load balancer:
```
case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
			// excluded from load balancers regardless of their state, so as to reduce the number of
			// VMSS API calls and not provoke VMScaleSetActiveModelsCountLimitReached.
			// (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/851)
			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name) 

```

Make sure that nodes that are not in the ready state and are not newly created (i.e. not having the "node.cloudprovider.kubernetes.io/uninitialized" taint) get removed from load balancers.
Also remove nodes that are being deleted from the cluster.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 9aef7d710ddff278e82e74eea86db5261b7fbaa6)

/kind bug
/kind regression

```release-note
NONE
```