### PR TITLE
UPSTREAM: 109931: fix: exclude non-ready nodes and deleted nodes from azure load balancers

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1125,11 +1125,8 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 							return nil, err
 						}
-
-						// If a node is not supposed to be included in the LB, it
-						// would not be in the `nodes` slice. We need to check the nodes that
-						// have been added to the LB's backendpool, find the unwanted ones and
-						// delete them from the pool.
+						// If the node appears in the local cache of nodes to exclude,
+						// delete it from the load balancer backend pool.
 						shouldExcludeLoadBalancer, err := az.ShouldNodeExcludedFromLoadBalancer(nodeName)
 						if err != nil {
 							klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)


### PR DESCRIPTION
With this PR, we align the code with what has been merged upstream for the future 1.25 (https://github.com/kubernetes/kubernetes/pull/108284), whose backport to 1.24 is currently being reviewed: https://github.com/kubernetes/kubernetes/pull/109931.

The original patch (a59fd947cb4249fd2621ec2529f96e0f22b038cd) ~is being reverted~ wasn't included in the 4.11 rebase, so we might as well skip it and use this PR to take the exact changes that got merged upstream.

There is a minor change with respect to the ~existing~ original patch from last Feburary: as requested by Azure folks in the original upstream PR, we inspect node taints when deciding whether to exclude a node from the load balancer:
```
case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
			// excluded from load balancers regardless of their state, so as to reduce the number of
			// VMSS API calls and not provoke VMScaleSetActiveModelsCountLimitReached.
			// (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/851)
			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name) 

```

Make sure that nodes that are not in the ready state and are not newly created (i.e. not having the "node.cloudprovider.kubernetes.io/uninitialized" taint) get removed from load balancers.
Also remove nodes that are being deleted from the cluster.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 9aef7d710ddff278e82e74eea86db5261b7fbaa6)

/kind bug
/kind regression

```release-note
NONE
```