### PR TITLE
Bug 2104928: UPSTREAM: 109932: fix: exclude non-ready nodes and deleted nodes from azure load balancers

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1125,11 +1125,8 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 							return nil, err
 						}
-
-						// If a node is not supposed to be included in the LB, it
-						// would not be in the `nodes` slice. We need to check the nodes that
-						// have been added to the LB's backendpool, find the unwanted ones and
-						// delete them from the pool.
+						// If the node appears in the local cache of nodes to exclude,
+						// delete it from the load balancer backend pool.
 						shouldExcludeLoadBalancer, err := az.ShouldNodeExcludedFromLoadBalancer(nodeName)
 						if err != nil {
 							klog.Errorf("ShouldNodeExcludedFromLoadBalancer(%s) failed with error: %v", nodeName, err)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -3248,13 +3248,12 @@ func TestUpdateNodeCaches(t *testing.T) {
 			Name: "prevNode",
 		},
 	}
-	// node is deleted from the cluster
+
 	az.updateNodeCaches(&prevNode, nil)
 	assert.Equal(t, 0, len(az.nodeZones[zone]))
 	assert.Equal(t, 0, len(az.nodeResourceGroups))
 	assert.Equal(t, 0, len(az.unmanagedNodes))
-	// deleted node should be excluded from load balancer
-	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
+	assert.Equal(t, 0, len(az.excludeLoadBalancerNodes))
 	assert.Equal(t, 0, len(az.nodeNames))
 
 	newNode := v1.Node{
@@ -3268,12 +3267,12 @@ func TestUpdateNodeCaches(t *testing.T) {
 			Name: "newNode",
 		},
 	}
-	// new node is added to the cluster
+
 	az.updateNodeCaches(nil, &newNode)
 	assert.Equal(t, 1, len(az.nodeZones[zone]))
 	assert.Equal(t, 1, len(az.nodeResourceGroups))
 	assert.Equal(t, 1, len(az.unmanagedNodes))
-	assert.Equal(t, 2, len(az.excludeLoadBalancerNodes))
+	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
 	assert.Equal(t, 1, len(az.nodeNames))
 }
 
@@ -3310,48 +3309,6 @@ func TestUpdateNodeCacheExcludeLoadBalancer(t *testing.T) {
 	}
 	az.updateNodeCaches(&prevNode, &newNode)
 	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
-
-	// non-ready node should be excluded
-	az.unmanagedNodes = sets.NewString()
-	az.excludeLoadBalancerNodes = sets.NewString()
-	az.nodeNames = sets.NewString()
-	nonReadyNode := v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				v1.LabelTopologyZone: zone,
-			},
-			Name: "aNode",
-		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
-				},
-			},
-		},
-	}
-	az.updateNodeCaches(nil, &nonReadyNode)
-	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
-	// node becomes ready
-	readyNode := v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				v1.LabelTopologyZone: zone,
-			},
-			Name: "aNode",
-		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
-				},
-			},
-		},
-	}
-	az.updateNodeCaches(&nonReadyNode, &readyNode)
-	assert.Equal(t, 0, len(az.excludeLoadBalancerNodes))
 
 }
 


### PR DESCRIPTION
With this PR, we align the code with what has been merged upstream for the future 1.25 (https://github.com/kubernetes/kubernetes/pull/108284), whose backport to 1.23 has merged ~is currently being reviewed~: https://github.com/kubernetes/kubernetes/pull/109932.

There are two commits:
* one reverts the previous patch (a59fd947cb4249fd2621ec2529f96e0f22b038cd)
* one adds the exact changes that got merged upstream. **(clean cherry pick)**

There is a minor change with respect to the current downstream patch: as requested by Azure folks in the original upstream PR, we inspect node taints when deciding whether to exclude a node from the load balancer:
```
case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
			// excluded from load balancers regardless of their state, so as to reduce the number of
			// VMSS API calls and not provoke VMScaleSetActiveModelsCountLimitReached.
			// (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/851)
			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name) 

```

Make sure that nodes that are not in the ready state and are not newly created (i.e. not having the "node.cloudprovider.kubernetes.io/uninitialized" taint) get removed from load balancers.
Also remove nodes that are being deleted from the cluster.

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
(cherry picked from commit 9aef7d710ddff278e82e74eea86db5261b7fbaa6)

/kind bug
/kind regression

```release-note
NONE
```