### PR TITLE
Bug 2086519: UPSTREAM: <carry>: e2e-framework: don't autosync PodSecurity labels

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -536,6 +536,9 @@ func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (
 		enforceLevel = f.NamespacePodSecurityEnforceLevel
 	}
 	labels[admissionapi.EnforceLevelLabel] = string(enforceLevel)
+	// turn off the OpenShift label syncer so that it does not attempt to sync
+	// the PodSecurity admission labels
+	labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 
 	ns, err := createTestingNS(baseName, f.ClientSet, labels)
 	// check ns instead of err to see if it's nil as we may


### PR DESCRIPTION
In the tests, we oftentimes create pods directly by the administrative user and so their SCC-related privileges are being used to create the pods. The PSa label syncher however works by introspecting SAs in each namespace, and since the SAs in the direct pod creation use-cases don't have the SCC-related privileges, the labelsyncer evaluates these namespaces as "restricted" because only the "restricted-v2" SCC is ever assigned in the namespaces. This breaks tests where pods are created directly.

/assign @s-urbaniak 
/cc @deads2k 