### PR TITLE
Bug 2063414: UPSTREAM: 109441: kubelet: parseResolvConf: Handle "search ."

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -267,7 +267,10 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			// Normalise search fields so the same domain with and without trailing dot will only count once, to avoid hitting search validation limits.
 			searches = []string{}
 			for _, s := range fields[1:] {
-				searches = append(searches, strings.TrimSuffix(s, "."))
+				if s != "." {
+					s = strings.TrimSuffix(s, ".")
+				}
+				searches = append(searches, s)
 			}
 		}
 		if fields[0] == "options" {

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -78,6 +78,7 @@ func TestParseResolvConf(t *testing.T) {
 		{"nameserver 1.2.3.4\nnameserver 5.6.7.8", []string{"1.2.3.4", "5.6.7.8"}, []string{}, []string{}, false},
 		{"nameserver 1.2.3.4 #comment", []string{"1.2.3.4"}, []string{}, []string{}, false},
 		{"search ", []string{}, []string{}, []string{}, false}, // search empty
+		{"search .", []string{}, []string{"."}, []string{}, false},
 		{"search foo", []string{}, []string{"foo"}, []string{}, false},
 		{"search foo bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo. bar", []string{}, []string{"foo", "bar"}, []string{}, false},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

When parsing a `resolv.conf` file that has `search .`, `parseResolvConf` should accept the "." entry verbatim.  Before this change, `parseResolvConf` unconditionally trimmed the "." suffix, which in the case of "." resulted in a "" entry (that is, the empty string).  This empty entry could lead `parseResolvConf` to produce a `resolv.conf` file with `search `.  Resolvers could fail to parse such a `resolv.conf` file from `parseResolvConf`, thus breaking DNS resolution in pods.  After this change, `parseResolvConf` accepts a `resolv.conf` file with `search .` and passes the "." entry through verbatim to produce a valid `resolv.conf` file.  The "." suffix is still trimmed for any entry that does not solely comprise ".".

Follow-up to https://github.com/kubernetes/kubernetes/pull/83069/commits/a215a88d919047360a84d62aae27eb184752bba2.

* `pkg/kubelet/network/dns/dns.go` (`parseResolvConf`): Handle a "." entry in the search path by copying it verbatim.
* `pkg/kubelet/network/dns/dns_test.go` (`TestParseResolvConf`): Add a test case for `search .`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Failures related to `search .` in `resolv.conf` were reported for OKD running on Fedora in <https://bugzilla.redhat.com/show_bug.cgi?id=2063414>.  The issue can be caused by this systemd change: https://github.com/systemd/systemd/pull/17201

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes now correctly handles "search ." in the host's resolv.conf file by preserving the "." entry in the "resolv.conf" that the kubelet writes to pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
