### PR TITLE
Bug 2087685: Worker Latency Profiles: Config node object validation for extreme profile transition

### DIFF
--- a/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/image"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/kubecontrollermanager"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/network"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/node"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/oauth"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/project"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/rolebindingrestriction"
@@ -38,6 +39,7 @@ var AllCustomResourceValidators = []string{
 	rolebindingrestriction.PluginName,
 	network.PluginName,
 	apirequestcount.PluginName,
+	node.PluginName,
 
 	// the kubecontrollermanager operator resource has to exist in order to run deployments to deploy admission webhooks.
 	kubecontrollermanager.PluginName,
@@ -70,6 +72,9 @@ func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	network.Register(plugins)
 	// This plugin validates the apiserver.openshift.io/v1 APIRequestCount resources.
 	apirequestcount.Register(plugins)
+	// This plugin validates config.openshift.io/v1/node objects
+	node.Register(plugins)
+
 	// this one is special because we don't work without it.
 	securitycontextconstraints.RegisterDefaulting(plugins)
 }

--- a/openshift-kube-apiserver/admission/customresourcevalidation/node/restrict_extreme_worker_latency_profile.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/node/restrict_extreme_worker_latency_profile.go
@@ -1,0 +1,123 @@
+package node
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+)
+
+var rejectionScenarios = []struct {
+	fromProfile configv1.WorkerLatencyProfileType
+	toProfile   configv1.WorkerLatencyProfileType
+}{
+	{fromProfile: "", toProfile: configv1.LowUpdateSlowReaction},
+	{fromProfile: configv1.LowUpdateSlowReaction, toProfile: ""},
+	{fromProfile: configv1.DefaultUpdateDefaultReaction, toProfile: configv1.LowUpdateSlowReaction},
+	{fromProfile: configv1.LowUpdateSlowReaction, toProfile: configv1.DefaultUpdateDefaultReaction},
+}
+
+const PluginName = "config.openshift.io/RestrictExtremeWorkerLatencyProfile"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				configv1.Resource("nodes"): true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				configv1.GroupVersion.WithKind("Node"): configNodeV1{},
+			})
+	})
+}
+
+func toConfigNodeV1(uncastObj runtime.Object) (*configv1.Node, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*configv1.Node)
+	if !ok {
+		return nil, append(allErrs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"Node"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"config.openshift.io/v1"}))
+	}
+
+	return obj, nil
+}
+
+type configNodeV1 struct{}
+
+func validateConfigNodeForExtremeLatencyProfile(obj, oldObj *configv1.Node) *field.Error {
+	fromProfile := oldObj.Spec.WorkerLatencyProfile
+	toProfile := obj.Spec.WorkerLatencyProfile
+
+	for _, rejectionScenario := range rejectionScenarios {
+		if fromProfile == rejectionScenario.fromProfile && toProfile == rejectionScenario.toProfile {
+			return field.Invalid(field.NewPath("spec", "workerLatencyProfile"), obj.Spec.WorkerLatencyProfile,
+				fmt.Sprintf(
+					"cannot update worker latency profile from %q to %q as extreme profile transition is unsupported, please select any other profile with supported transition such as %q",
+					oldObj.Spec.WorkerLatencyProfile,
+					obj.Spec.WorkerLatencyProfile,
+					configv1.MediumUpdateAverageReaction,
+				),
+			)
+		}
+	}
+	return nil
+}
+
+func (configNodeV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, allErrs := toConfigNodeV1(uncastObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
+
+	return allErrs
+}
+
+func (configNodeV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, allErrs := toConfigNodeV1(uncastObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	oldObj, allErrs := toConfigNodeV1(uncastOldObj)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	if err := validateConfigNodeForExtremeLatencyProfile(obj, oldObj); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	return allErrs
+}
+
+func (configNodeV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toConfigNodeV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toConfigNodeV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// TODO validate the obj.  remember that status validation should *never* fail on spec validation errors.
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+
+	return errs
+}

--- a/openshift-kube-apiserver/admission/customresourcevalidation/node/restrict_extreme_worker_latency_profile_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/node/restrict_extreme_worker_latency_profile_test.go
@@ -1,0 +1,68 @@
+package node
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestValidateConfigNodeForExtremeLatencyProfile(t *testing.T) {
+	testCases := []struct {
+		fromProfile  configv1.WorkerLatencyProfileType
+		toProfile    configv1.WorkerLatencyProfileType
+		shouldReject bool
+	}{
+		// no rejections
+		{fromProfile: "", toProfile: "", shouldReject: false},
+		{fromProfile: "", toProfile: configv1.DefaultUpdateDefaultReaction, shouldReject: false},
+		{fromProfile: "", toProfile: configv1.MediumUpdateAverageReaction, shouldReject: false},
+		{fromProfile: configv1.DefaultUpdateDefaultReaction, toProfile: "", shouldReject: false},
+		{fromProfile: configv1.DefaultUpdateDefaultReaction, toProfile: configv1.DefaultUpdateDefaultReaction, shouldReject: false},
+		{fromProfile: configv1.DefaultUpdateDefaultReaction, toProfile: configv1.MediumUpdateAverageReaction, shouldReject: false},
+		{fromProfile: configv1.MediumUpdateAverageReaction, toProfile: "", shouldReject: false},
+		{fromProfile: configv1.MediumUpdateAverageReaction, toProfile: configv1.DefaultUpdateDefaultReaction, shouldReject: false},
+		{fromProfile: configv1.MediumUpdateAverageReaction, toProfile: configv1.MediumUpdateAverageReaction, shouldReject: false},
+		{fromProfile: configv1.MediumUpdateAverageReaction, toProfile: configv1.LowUpdateSlowReaction, shouldReject: false},
+		{fromProfile: configv1.LowUpdateSlowReaction, toProfile: configv1.MediumUpdateAverageReaction, shouldReject: false},
+		{fromProfile: configv1.LowUpdateSlowReaction, toProfile: configv1.LowUpdateSlowReaction, shouldReject: false},
+
+		// rejections
+		{fromProfile: "", toProfile: configv1.LowUpdateSlowReaction, shouldReject: true},
+		{fromProfile: configv1.DefaultUpdateDefaultReaction, toProfile: configv1.LowUpdateSlowReaction, shouldReject: true},
+		{fromProfile: configv1.LowUpdateSlowReaction, toProfile: "", shouldReject: true},
+		{fromProfile: configv1.LowUpdateSlowReaction, toProfile: configv1.DefaultUpdateDefaultReaction, shouldReject: true},
+	}
+
+	for _, testCase := range testCases {
+		shouldStr := "should not be"
+		if testCase.shouldReject {
+			shouldStr = "should be"
+		}
+		testCaseName := fmt.Sprintf("update from profile %s to %s %s rejected", testCase.fromProfile, testCase.toProfile, shouldStr)
+		t.Run(testCaseName, func(t *testing.T) {
+			// config node objects
+			oldObject := configv1.Node{
+				Spec: configv1.NodeSpec{
+					WorkerLatencyProfile: testCase.fromProfile,
+				},
+			}
+			newObject := configv1.Node{
+				Spec: configv1.NodeSpec{
+					WorkerLatencyProfile: testCase.toProfile,
+				},
+			}
+
+			fieldErr := validateConfigNodeForExtremeLatencyProfile(&oldObject, &newObject)
+			assert.Equal(t, testCase.shouldReject, fieldErr != nil, "latency profile from %q to %q %s rejected", testCase.fromProfile, testCase.toProfile, shouldStr)
+
+			if testCase.shouldReject {
+				assert.Equal(t, "spec.workerLatencyProfile", fieldErr.Field, "field name during for latency profile should be spec.workerLatencyProfile")
+				assert.Contains(t, fieldErr.Detail, testCase.fromProfile, "error message should contain %q", testCase.fromProfile)
+				assert.Contains(t, fieldErr.Detail, testCase.toProfile, "error message should contain %q", testCase.toProfile)
+			}
+		})
+	}
+}


### PR DESCRIPTION

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2087685

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Reject latency profile in nodes.config.openshift.io/v1/cluster object when user tries to update Default <-> Low worker latency profile.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rejecting extreme worker latency profile transition from/to Default <-> LowUpdateSlowReaction profile(s) through admission validation of nodes.config.openshift.io/v1/cluster object
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
1. https://github.com/openshift/enhancements/blob/master/enhancements/worker-latency-profile/worker-latency-profile.md#lowupdateslowreaction---default
2. https://coreos.slack.com/archives/C0392N52Q5P/p1654170194629239?thread_ts=1653567121.768759&cid=C0392N52Q5P
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
