### PR TITLE
Enable "[sig-network] should distribute endpoints evenly" test

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -1253,7 +1253,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] [Feature:PerformanceDNS][Serial] Should answer DNS query for maximum number of services per cluster": "Should answer DNS query for maximum number of services per cluster [Slow] [Suite:k8s]",
 
-	"[Top Level] [sig-network] [Feature:Topology Hints] should distribute endpoints evenly": "should distribute endpoints evenly [Disabled:SpecialConfig] [Suite:k8s]",
+	"[Top Level] [sig-network] [Feature:Topology Hints] should distribute endpoints evenly": "should distribute endpoints evenly [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined": "can disable an AppArmor profile, using unconfined [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -45,9 +45,6 @@ var (
 			`Advanced Audit should audit API calls`, // expects to be able to call /logs
 
 			`Firewall rule should have correct firewall rules for e2e cluster`, // Upstream-install specific
-
-			// https://bugzilla.redhat.com/show_bug.cgi?id=2079958
-			`\[sig-network\] \[Feature:Topology Hints\] should distribute endpoints evenly`,
 		},
 		// tests that are known broken and need to be fixed upstream or in openshift
 		// always add an issue here
@@ -108,8 +105,6 @@ var (
 			`Netpol \[LinuxOnly\] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy`,
 			`Netpol \[LinuxOnly\] NetworkPolicy between server and client using UDP should enforce policy based on Ports`,
 			`Netpol \[LinuxOnly\] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector`,
-
-			`Topology Hints should distribute endpoints evenly`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
Enable "[sig-network] [Feature:Topology Hints] should distribute endpoints evenly" test since the fix for https://bugzilla.redhat.com/show_bug.cgi?id=2079958 merged.

Signed-off-by: Patryk Diak <pdiak@redhat.com>