### PR TITLE
[release 4.9] Bug Bug 2106962: UPSTREAM: <carry>: use correct base image for testing

### DIFF
--- a/openshift-hack/images/os/Dockerfile
+++ b/openshift-hack/images/os/Dockerfile
@@ -1,26 +1,18 @@
+# fedora:29 is an image built within the release scripts:
+# https://github.com/openshift/release/blob/b45a09d248b8cdb8fe3bf5f3cfa0b4fee57d04c8/ci-operator/config/openshift/kubernetes/openshift-kubernetes-release-4.10.yaml#L63-L65
 FROM fedora:29 AS build
 
+# the registry is defined here:
+# https://github.com/openshift/release/blob/b45a09d248b8cdb8fe3bf5f3cfa0b4fee57d04c8/ci-operator/config/openshift/kubernetes/openshift-kubernetes-release-4.10.yaml#L68
 COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content /srv/ /srv/
-RUN set -x && yum install -y ostree rpm-ostree yum-utils selinux-policy-targeted && \
-    curl http://base-4-3-rhel8.ocp.svc > /etc/yum.repos.d/rhel8.repo && \
-    commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 ) && \
-    mkdir /tmp/working && cd /tmp/working && \
-    rpm-ostree db list --repo /srv/repo $commit > /tmp/packages && \
-    PACKAGES=(openshift-hyperkube) && \
-    yumdownloader -y --disablerepo=* --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}" && \
-    if ! grep -q cri-o /tmp/packages; then yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms cri-o cri-tools; fi && \
-    if ! grep -q machine-config-daemon /tmp/packages; then yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms machine-config-daemon; fi && \
-    ls /tmp/rpms/ && (cd /tmp/rpms/ && ls ${PACKAGES[@]/%/*}) && \
-    for i in $(find /tmp/rpms/ -name *.rpm); do echo "Extracting $i ..."; rpm2cpio $i | cpio -div; done && \
-    if [[ -d etc ]]; then mv etc usr/; fi && \
-    mkdir -p /tmp/tmprootfs/etc && \
-    ostree --repo=/srv/repo checkout -U $commit --subpath /usr/etc/selinux /tmp/tmprootfs/etc/selinux && \
-    ostree --repo=/srv/repo commit --parent=$commit --tree=ref=$commit --tree=dir=. \
-        --selinux-policy /tmp/tmprootfs \
-        -s "origin-ci-dev overlay RPMs" --branch=origin-ci-dev
+COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content /extensions/ /extensions/
+WORKDIR /
+COPY install.sh .
+RUN ./install.sh
 
 FROM scratch
 COPY --from=build /srv/ /srv/
+COPY --from=build /extensions/ /extensions/
 
-LABEL io.openshift.build.version-display-names="machine-os=rhcos image for testing openshift kubernetes kubelet only- if you see this outside of PR runs for openshift kubernetes- you found an urgent blocker bug" \
-      io.openshift.build.versions="machine-os=1.2.3-testing-if-you-see-this-outside-of-PR-runs-for-openshift-kubernetes-you-found-an-urgent-blocker-bug"
+LABEL io.openshift.build.version-display-names="machine-os=rhcos image for testing openshift kubernetes kubelet only- if you see this outside of PR runs for openshift kubernetes- you found an urgent blocker bug"
+LABEL io.openshift.build.versions="machine-os=1.2.3-testing-if-you-see-this-outside-of-PR-runs-for-openshift-kubernetes-you-found-an-urgent-blocker-bug"

--- a/openshift-hack/images/os/install.sh
+++ b/openshift-hack/images/os/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -xeou pipefail
+
+yum install -y ostree rpm-ostree yum-utils selinux-policy-targeted xfsprogs
+curl http://base-4-9-rhel8.ocp.svc > /etc/yum.repos.d/rhel8.repo
+
+commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 )
+mkdir /tmp/working && cd /tmp/working
+rpm-ostree db list --repo /srv/repo $commit > /tmp/packages
+
+PACKAGES=(openshift-hyperkube)
+yumdownloader -y --disablerepo=* --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}"
+if ! grep -q cri-o /tmp/packages; then
+  yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms cri-o cri-tools
+fi
+
+ls /tmp/rpms/ && (cd /tmp/rpms/ && ls ${PACKAGES[@]/%/*})
+for i in $(find /tmp/rpms/ -name *.rpm); do
+  echo "Extracting $i ..."; rpm2cpio $i | cpio -div
+done
+
+if [[ -d etc ]]; then
+  mv etc usr/
+fi
+
+mkdir -p /tmp/tmprootfs/etc
+
+ostree --repo=/srv/repo checkout \
+  -U $commit \
+  --subpath /usr/etc/selinux \
+  /tmp/tmprootfs/etc/selinux
+
+ostree --repo=/srv/repo commit \
+  --parent=$commit \
+  --tree=ref=$commit \
+  --tree=dir=. \
+  --selinux-policy /tmp/tmprootfs \
+  -s "origin-ci-dev overlay RPMs" \
+  --branch=origin-ci-dev


### PR DESCRIPTION
Use correct base image for testing. Fixes issue that started when [EOL OCP images were removed](https://github.com/openshift/release/pull/28522).