### PR TITLE
Add kubensenter to the openshift RPM

### DIFF
--- a/hack/make-rules/update.sh
+++ b/hack/make-rules/update.sh
@@ -45,6 +45,7 @@ fi
 
 # Skip bazel since it's not used downstream
 BASH_TARGETS="
+	update-kubensenter
 	update-test-annotations
 	update-generated-protobuf
 	update-codegen

--- a/hack/update-kubensenter.sh
+++ b/hack/update-kubensenter.sh
@@ -1,0 +1,1 @@
+../openshift-hack/update-kubensenter.sh

--- a/hack/verify-kubensenter.sh
+++ b/hack/verify-kubensenter.sh
@@ -1,0 +1,1 @@
+../openshift-hack/verify-kubensenter.sh

--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -3,7 +3,7 @@ WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
 RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination' && \
     mkdir -p /tmp/build && \
-    cp openshift-hack/images/hyperkube/hyperkube /tmp/build && \
+    cp openshift-hack/images/hyperkube/hyperkube openshift-hack/images/hyperkube/kubensenter /tmp/build && \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination} \
     /tmp/build
 

--- a/openshift-hack/images/hyperkube/kubensenter
+++ b/openshift-hack/images/hyperkube/kubensenter
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# shellcheck disable=SC2016
+usage() {
+    echo "A command line wrapper to run commands or shells inside the"
+    echo "kubens.service mount namespace."
+    echo
+    echo "Usage:"
+    echo "    $(basename "$0") [--verbose|--quiet] [command ...]"
+    echo
+    echo 'Autodetect whether the `kubens.service` has pinned a mount namespace in a'
+    echo 'well-known location, and if so, join it by passing it and the user-specified'
+    echo 'command to nsenter(1). If `kubens.service` has not set up the mount namespace,'
+    echo 'the user-specified command is still executed by nsenter(1) but no namespace is'
+    echo 'entered.'
+    echo
+    echo 'If $KUBENSMNT is set in the environment, skip autodetection and attempt to join'
+    echo 'that mount namespace by passing it and the user-specified command to'
+    echo 'nsenter(1). If the mount namespace is missing or invalid, the command will'
+    echo 'fail.'
+    echo
+    echo 'In either case, if no command is given on the command line, nsenter(1) will'
+    echo 'spawn a new interactive shell which will be inside the mount namespace if'
+    echo 'detected.'
+    exit 1
+}
+
+LOGLEVEL=${KUBENSENTER_LOG:-1}
+_log() {
+    local level=$1; shift
+    if [[ $level -le $LOGLEVEL ]]; then
+        echo "kubensenter: $*" >&2
+    fi
+}
+
+info() {
+    _log 1 "$*"
+}
+
+debug() {
+    _log 2 "$*"
+}
+
+# Returns 0 if the argument given is a mount namespace
+ismnt() {
+    local nsfs
+    nsfs=$(findmnt -o SOURCE -n -t nsfs "$1")
+    [[ $nsfs =~ ^nsfs\[mnt:\[ ]]
+}
+
+# Set KUBENSMNT to the default location that kubens.service uses if KUBENSMNT isn't already set.
+DEFAULT_KUBENSMNT=${DEFAULT_KUBENSMNT:-"/run/kubens/mnt"}
+autodetect() {
+    local default=$DEFAULT_KUBENSMNT
+    if [[ -n $KUBENSMNT ]]; then
+        debug "Autodetect: \$KUBENSMNT already set"
+        return 0
+    fi
+    if [[ ! -e $default ]]; then
+        debug "Autodetect: No mount namespace found at $default"
+        return 1
+    fi
+    if ! ismnt "$default"; then
+        info "Autodetect: Stale or mismatched namespace at $default"
+        return 1
+    fi
+    KUBENSMNT=$default
+    info "Autodetect: kubens.service namespace found at $KUBENSMNT"
+    return 0
+}
+
+# Wrap the user-given command in nsenter, joining the mount namespace set in $KUBENSMNT if set
+kubensenter() {
+    local nsarg
+    if [[ -n $KUBENSMNT ]]; then
+        debug "Joining mount namespace in $KUBENSMNT"
+        nsarg=$(printf -- "--mount=%q" "$KUBENSMNT")
+    else
+        debug "KUBENSMNT not set; running normally"
+        # Intentional fallthrough to run nsenter anyway:
+        # - If $@ is non-empty, nsenter effectively runs `exec "$@"`
+        # - If $@ is empty, nsenter spawns a new shell
+    fi
+    # shellcheck disable=SC2086
+    # ^- Intentionally collapse $nsarg if not set (and we've already shell-quoted it above if we did set it)
+    nsenter $nsarg "$@"
+}
+
+main() {
+    while [[ -n $1 ]]; do
+        case "$1" in
+            -h | --help)
+                usage
+                ;;
+            -v | --verbose)
+                shift
+                ((LOGLEVEL++))
+                ;;
+            -q | --quiet)
+                shift
+                ((LOGLEVEL--))
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    autodetect
+    kubensenter "$@"
+}
+
+# bash modulino
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/openshift-hack/kubensenter.env
+++ b/openshift-hack/kubensenter.env
@@ -1,0 +1,16 @@
+# Configure which version of kubensenter we need to synchronize
+
+# Define the github repo where we should fetch the kubensenter script
+REPO="github.com/containers/kubensmnt"
+
+# The specific commit or tag of the kubensenter script
+# Note: Should be an explicit tag or commit SHA - Setting to a branch name will cause unexpected verification failures in the future.
+COMMIT=v1.1.2 # (4e4391c60521aead9bf0c9b4b33cd51566d80113)
+
+# The branch name or tag glob to resolve when 'update-kubensenter.sh --to-latest' is run:
+# - If this resolves to a branch, COMMIT will be set to the latest commit hash on that branch.
+# - If this resolves to a tag name, COMMIT will be set to that tag.
+# - May contain a glob expression such as "v1.1.*" that would match any of the following:
+#     v1.1.0 v1.1.3 v1.1.22-rc1"
+#TARGET="main"
+TARGET="v1.1.*"

--- a/openshift-hack/update-kubensenter.sh
+++ b/openshift-hack/update-kubensenter.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "$KUBE_ROOT/hack/lib/init.sh"
+
+# Convert a path relative to $KUBE_ROOT to a real path
+localpath() {
+    realpath "$KUBE_ROOT/$1"
+}
+
+# Configuration for fetching this file, relative to this repository root
+ENVFILE=openshift-hack/kubensenter.env
+
+# The source of the file, relative to the remote repository root
+SOURCE=utils/kubensenter/kubensenter
+
+# The destination of the file, relative to this repository root
+DESTINATION=openshift-hack/images/hyperkube/kubensenter
+
+usage() {
+    source_env
+    echo "Usage:"
+    echo "  $0 [--to-latest]"
+    echo
+    echo "Updates the local copy of $DESTINATION as configured in $ENVFILE:"
+    echo "  REPO: $REPO"
+    echo "  COMMIT: $COMMIT"
+    echo
+    echo "Options:"
+    echo "  --to-latest (or env UPDATE_TO_LATEST=1)"
+    echo "    Update $ENVFILE to the latest commit or tag in $REPO configured by the TARGET entry"
+    echo "    (currently \"$TARGET\"), and synchronize to the updated commit."
+    echo "    - If TARGET resolves to a branch, pin to the latest commit hash from that branch"
+    echo "    - If TARGET resolves to a tag, pin to the latest tag that matches that pattern"
+    echo "    - TARGET may be a glob-like expression such as \"v1.1.*\" that would match any of the following:"
+    echo "        v1.1.0 v1.1.3 v1.1.22-rc1"
+    exit 1
+}
+
+source_env() {
+    source "$(localpath "$ENVFILE")"
+    # Intentionally global scope:
+    REPO=${REPO:-"github.com/containers/kubensmnt"}
+    COMMIT=${COMMIT:-"main"}
+    TARGET=${TARGET:-"main"}
+}
+
+edit_envfile() {
+    local envfile=$1
+    local refname=$2
+
+    # Shell-quote refname in case it contains any shell-special characters
+    local newcommit=$(printf 'COMMIT=%q' "$refname")
+    if [[ $# -gt 2 ]]; then
+        shift 2
+        # Add the comment suffix
+        newcommit="$newcommit # $*"
+    fi
+
+    local patch
+    patch=$(printf "%q" "$newcommit")
+    # Note: Using ':' since it is not a valid tag character according to git-check-ref-format(1)
+    sed -i "s:^COMMIT=.*:$patch:" "$envfile"
+}
+
+update_env() {
+    local repouri latest refhash reftype refname
+    source_env
+    repouri=https://$REPO.git
+    echo "Updating to latest $TARGET from $repouri"
+
+    latest=$(git \
+                   -c "versionsort.suffix=-alpha" \
+                   -c "versionsort.suffix=-beta" \
+                   -c "versionsort.suffix=-rc" \
+                 ls-remote \
+                   --heads --tags \
+                   --sort='-version:refname' \
+                   "$repouri" "$TARGET" \
+             | head -n 1)
+    if [[ -z $latest ]]; then
+        echo "ERROR: No matching ref found for $TARGET"
+        return 1
+    fi
+    refhash=$(cut -f1 <<<"$latest")
+    reftype=$(cut -d/ -f2 <<<"$latest")
+    refname=$(cut -d/ -f3 <<<"$latest")
+
+    if [[ $reftype == "tags" ]]; then
+        echo "  Latest tag is $refname ($refhash)"
+        edit_envfile "$ENVFILE" "$refname" "($refhash)"
+    else
+        echo "  Latest on branch $refname is $refhash"
+        edit_envfile "$ENVFILE" "$refhash"
+    fi
+}
+
+do_fetch() {
+    source_env
+    local repohost reponame uri
+    repohost=$(cut -d/ -f1 <<<"$REPO")
+    reponame=${REPO#$repohost/}
+    case $repohost in
+        github.com)
+            uri=https://raw.githubusercontent.com/$reponame/$COMMIT/$SOURCE
+            ;;
+        *)
+            echo "No support for repositories hosted on $repohost"
+            return 2
+            ;;
+    esac
+
+    echo "Fetching $DESTINATION from $uri"
+    curl -fsLo "$(localpath "$DESTINATION")" "$uri"
+}
+
+main() {
+    local to_latest=${UPDATE_TO_LATEST:-}
+    if [[ $# -gt 0 ]]; then
+        if [[ $1 == "--help" || $1 == "-h" ]]; then
+            usage
+        elif [[ $1 == "--to-latest" ]]; then
+            to_latest=1
+        fi
+    fi
+
+    if [[ $to_latest ]]; then
+        update_env
+    fi
+
+    do_fetch
+}
+
+# bash modulino
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/openshift-hack/verify-kubensenter.sh
+++ b/openshift-hack/verify-kubensenter.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+# Update kubensenter and error if a change is detected
+"${KUBE_ROOT}"/hack/update-kubensenter.sh
+git diff --quiet "${KUBE_ROOT}/openshift-hack/images/hyperkube/kubensenter"

--- a/openshift.spec
+++ b/openshift.spec
@@ -116,6 +116,7 @@ do
 done
 
 install -p -m 755 openshift-hack/images/hyperkube/hyperkube %{buildroot}%{_bindir}/hyperkube
+install -p -m 755 openshift-hack/images/hyperkube/kubensenter %{buildroot}%{_bindir}/kubensenter
 
 %files hyperkube
 %license LICENSE
@@ -124,6 +125,7 @@ install -p -m 755 openshift-hack/images/hyperkube/hyperkube %{buildroot}%{_bindi
 %{_bindir}/kube-controller-manager
 %{_bindir}/kube-scheduler
 %{_bindir}/kubelet
+%{_bindir}/kubensenter
 %defattr(-,root,root,0700)
 
 %changelog


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is in support of OpenShift Enhancement openshift/enhancements#1127

To facilitate kubelet entering into a new mount namespace without making changes to kubelet itself (this will be part of an upstream KEP effort in the future), we want to provide a shell script that can be executed around the kubelet invocation that enters the proper mount namespace.  This script is `kubensenter` from https://github.com/containers/kubensmnt/tree/main/utils/kubensenter

In this PR, we use go-vendor-embeding to pull along the script, and just add it as an additional executable in the openshift-hyperkube RPM. The effort to run kubelet inside the namespace by wrapping it inside this script will be part of a separate change in https://github.com/openshift/machine-config-operator

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
