### PR TITLE
add the ability to run the kube-apiserver with a second port that ser…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -98,6 +98,9 @@ type Config struct {
 	// SecureServing is required to serve https
 	SecureServing *SecureServingInfo
 
+	// ReadyOnlySecureServing is like SecureServing, but until the server has been ready at least once this returns a 503
+	ReadyOnlySecureServing *SecureServingInfo
+
 	// Authentication is the configuration for authentication
 	Authentication AuthenticationInfo
 
@@ -690,11 +693,12 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		listedPathProvider: apiServerHandler,
 
-		minRequestTimeout:     time.Duration(c.MinRequestTimeout) * time.Second,
-		ShutdownTimeout:       c.RequestTimeout,
-		ShutdownDelayDuration: c.ShutdownDelayDuration,
-		SecureServingInfo:     c.SecureServing,
-		ExternalAddress:       c.ExternalAddress,
+		minRequestTimeout:          time.Duration(c.MinRequestTimeout) * time.Second,
+		ShutdownTimeout:            c.RequestTimeout,
+		ShutdownDelayDuration:      c.ShutdownDelayDuration,
+		SecureServingInfo:          c.SecureServing,
+		ReadyOnlySecureServingInfo: c.ReadyOnlySecureServing,
+		ExternalAddress:            c.ExternalAddress,
 
 		openAPIConfig:           c.OpenAPIConfig,
 		openAPIV3Config:         c.OpenAPIV3Config,

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -116,6 +116,9 @@ type GenericAPIServer struct {
 	// SecureServingInfo holds configuration of the TLS server.
 	SecureServingInfo *SecureServingInfo
 
+	// ReadyOnlySecureServingInfo is like SecureServingInfo, for the readyOnly handler
+	ReadyOnlySecureServingInfo *SecureServingInfo
+
 	// ExternalAddress is the address (hostname or IP and port) that should be used in
 	// external (public internet) URLs for this GenericAPIServer.
 	ExternalAddress string
@@ -535,7 +538,7 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 // NonBlockingRun spawns the secure http server. An error is
 // returned if the secure port cannot be listened on.
 // The returned channel is closed when the (asynchronous) termination is finished.
-func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}, shutdownTimeout time.Duration) (<-chan struct{}, <-chan struct{}, error) {
+func (s preparedGenericAPIServer) nonBlockingRun(stopCh <-chan struct{}, shutdownTimeout time.Duration) (<-chan struct{}, <-chan struct{}, error) {
 	// Use an stop channel to allow graceful shutdown without dropping audit events
 	// after http server shutdown.
 	auditStopCh := make(chan struct{})

--- a/staging/src/k8s.io/apiserver/pkg/server/options/patch_serving_readyport.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/patch_serving_readyport.go
@@ -1,0 +1,39 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apiserver/pkg/server"
+)
+
+// this file allows us to configure a second kube-apiserver port using the "normal" tls configuration.
+
+func (s *SecureServingOptions) AddReadyOnlyFlags(fs *pflag.FlagSet) {
+	fs.IPVar(&s.ReadyOnlyBindAddress, "ready-only-bind-address", s.ReadyOnlyBindAddress, ""+
+		"The IP address on which to listen for the --secure-port port. The "+
+		"associated interface(s) must be reachable by the rest of the cluster, and by CLI/web "+
+		"clients. If blank or an unspecified address (0.0.0.0 or ::), all interfaces will be used.")
+
+	desc := "The port on which to serve HTTPS with authentication and authorization."
+	if s.Required {
+		desc += " It cannot be switched off with 0."
+	} else {
+		desc += " If 0, don't serve HTTPS at all."
+	}
+	fs.IntVar(&s.ReadyOnlyBindPort, "ready-only-secure-port", s.ReadyOnlyBindPort, desc)
+}
+
+func (s *SecureServingOptions) ApplyReadyOnlyTo(config **server.SecureServingInfo) error {
+	if s.Listener != nil {
+		return fmt.Errorf("cannot ApplyReadyOnlyTo with a listener set")
+	}
+	realBindAddress := s.BindAddress
+	realBindPort := s.BindPort
+	defer func() {
+		s.BindAddress = realBindAddress
+		s.BindPort = realBindPort
+	}()
+
+	return s.ApplyTo(config)
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -115,6 +115,9 @@ func (o *RecommendedOptions) ApplyTo(config *server.RecommendedConfig) error {
 	if err := o.SecureServing.ApplyTo(&config.Config.SecureServing, &config.Config.LoopbackClientConfig); err != nil {
 		return err
 	}
+	if err := o.SecureServing.ApplyReadyOnlyTo(&config.Config.ReadyOnlySecureServing); err != nil {
+		return err
+	}
 	if err := o.Authentication.ApplyTo(&config.Config.Authentication, config.SecureServing, config.OpenAPIConfig); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -38,6 +38,10 @@ import (
 )
 
 type SecureServingOptions struct {
+	ReadyOnlyBindAddress net.IP
+	// ReadyOnlyBindPort is like BindPort, but wires to a handler that returns a 503 until the server is ready ONCE.
+	ReadyOnlyBindPort int
+
 	BindAddress net.IP
 	// BindPort is ignored when Listener is set, will serve https even with 0.
 	BindPort int

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
@@ -21,8 +21,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
-	goatomic "sync/atomic"
+	"time"
 
 	"go.uber.org/atomic"
 
@@ -43,15 +42,6 @@ type terminationLoggingListener struct {
 	net.Listener
 	lateStopCh <-chan struct{}
 }
-
-type eventfFunc func(eventType, reason, messageFmt string, args ...interface{})
-
-var (
-	lateConnectionRemoteAddrsLock sync.RWMutex
-	lateConnectionRemoteAddrs     = map[string]bool{}
-
-	unexpectedRequestsEventf goatomic.Value
-)
 
 func (l *terminationLoggingListener) Accept() (net.Conn, error) {
 	c, err := l.Listener.Accept()
@@ -155,4 +145,43 @@ func isLocal(req *http.Request) bool {
 
 func isKubeApiserverLoopBack(req *http.Request) bool {
 	return strings.HasPrefix(req.UserAgent(), "kube-apiserver/")
+}
+
+// NonBlockingRun spawns the secure http server. An error is
+// returned if the secure port cannot be listened on.
+// The returned channel is closed when the (asynchronous) termination is finished.
+func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}, shutdownTimeout time.Duration) (<-chan struct{}, <-chan struct{}, error) {
+	normalStoppedCh, normalListenerStoppedCh, err := s.nonBlockingRun(stopCh, shutdownTimeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.ReadyOnlySecureServingInfo == nil || s.Handler == nil {
+		return normalStoppedCh, normalListenerStoppedCh, nil
+	}
+
+	// prepend a handler that returns 503 until we have been ready at least once.
+	readyOnlyHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-s.lifecycleSignals.HasBeenReady.Signaled():
+			s.Handler.ServeHTTP(w, req)
+			return
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("kube-apiserver has not been ready yet"))
+			return
+		}
+	})
+
+	internalStopCh := make(chan struct{})
+	// we ignore the channels that indicate clean shutdown from the readyOnly server.
+	// This likely makes the shutdown unclean, so we should ONLY use this for microshift.
+	_, _, err = s.ReadyOnlySecureServingInfo.Serve(readyOnlyHandler, shutdownTimeout, internalStopCh)
+	if err != nil {
+		close(internalStopCh)
+		// This is still going to leak the nonBlockingRun call from above.
+		// Hopefully this exits the process and we try again after reporting a good error message.
+		return nil, nil, err
+	}
+
+	return normalStoppedCh, normalListenerStoppedCh, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_readyhandler.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_readyhandler.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"net"
+	"sync"
+	goatomic "sync/atomic"
+)
+
+// readyOnlyLoggingListener wraps the given listener to mark late connections
+// as such, identified by the remote address. In parallel, we have a filter that
+// logs bad requests through these connections. We need this filter to get
+// access to the http path in order to filter out healthz or readyz probes that
+// are allowed at any point during readyOnly.
+//
+// Connections are late after the lateStopCh has been closed.
+type readyOnlyLoggingListener struct {
+	net.Listener
+	lateStopCh <-chan struct{}
+}
+
+type eventfFunc func(eventType, reason, messageFmt string, args ...interface{})
+
+var (
+	lateConnectionRemoteAddrsLock sync.RWMutex
+	lateConnectionRemoteAddrs     = map[string]bool{}
+
+	unexpectedRequestsEventf goatomic.Value
+)
+
+func (l *readyOnlyLoggingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-l.lateStopCh:
+		lateConnectionRemoteAddrsLock.Lock()
+		defer lateConnectionRemoteAddrsLock.Unlock()
+		lateConnectionRemoteAddrs[c.RemoteAddr().String()] = true
+	default:
+	}
+
+	return c, nil
+}


### PR DESCRIPTION
…ves 503 until the server is ready at least once

The idea is that by passing --ready-only-bind-address and --ready-only-secure-port, we can have microshift expose an endpoint that serves a 503 until the server has been ready and after that serves like normal with the complete filter chain.  This leaves the --bind-address and --secure-port as controlling the "normal" endpoint which is accessed via loopback.

If used, we would have the normal bind-address and secure-port wired to localhost only and a *different* port than anything we normally expose. This allows loopback functionality to work and initialize the cluster and it allows for localhost debugging when the server fails to go ready.

Every other endpoint will use the --ready-only-secure-port so that it can only access a kube-apiserver *after* it has been ready.  Doing this will protect clients from getting inaccurate results while the kube-apiserver is starting.  This does not (currently) stop serving when readyz goes false long enough, but it could be added.

The other front running alternative is create and manage an ha proxy instance.  The apiserver team will own either solution or the fallout of doing nothing.

/assign @dgrisonnet 

/hold for discussion.