### PR TITLE
UPSTREAM: <carry>: Update kubensenter to use exec instead of subprocess

### DIFF
--- a/openshift-hack/images/hyperkube/kubensenter
+++ b/openshift-hack/images/hyperkube/kubensenter
@@ -81,9 +81,12 @@ kubensenter() {
         # - If $@ is non-empty, nsenter effectively runs `exec "$@"`
         # - If $@ is empty, nsenter spawns a new shell
     fi
+    # Using 'exec' is important here; Without it, systemd may have trouble
+    # seeing the underlying process especially if it's using 'Type=notify'
+    # semantics.
     # shellcheck disable=SC2086
     # ^- Intentionally collapse $nsarg if not set (and we've already shell-quoted it above if we did set it)
-    nsenter $nsarg "$@"
+    exec nsenter $nsarg "$@"
 }
 
 main() {

--- a/openshift-hack/kubensenter.env
+++ b/openshift-hack/kubensenter.env
@@ -5,7 +5,7 @@ REPO="github.com/containers/kubensmnt"
 
 # The specific commit or tag of the kubensenter script
 # Note: Should be an explicit tag or commit SHA - Setting to a branch name will cause unexpected verification failures in the future.
-COMMIT=v1.1.2 # (4e4391c60521aead9bf0c9b4b33cd51566d80113)
+COMMIT=v1.2.0 # (36e5652992df9a3d4abc3d8f02a33c2e364efda9)
 
 # The branch name or tag glob to resolve when 'update-kubensenter.sh --to-latest' is run:
 # - If this resolves to a branch, COMMIT will be set to the latest commit hash on that branch.
@@ -13,4 +13,4 @@ COMMIT=v1.1.2 # (4e4391c60521aead9bf0c9b4b33cd51566d80113)
 # - May contain a glob expression such as "v1.1.*" that would match any of the following:
 #     v1.1.0 v1.1.3 v1.1.22-rc1"
 #TARGET="main"
-TARGET="v1.1.*"
+TARGET="v1.2.*"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Because kubelet relies on systemd's Type=notify mechanism, we don't need
or want kubensenter to keep itself in the process tree. exec is best.

#### Special notes for your reviewer:

See discussion here for more context, if needed: https://github.com/openshift/machine-config-operator/pull/3274#discussion_r952662191

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
