### PR TITLE
[release 4.11] Bug 2117424: UPSTREAM: <carry>: Remove reserved CPUs from default set

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/pkg/kubelet/managed"
 )
 
 const (
@@ -173,6 +174,10 @@ func (p *staticPolicy) validateState(s state.State) error {
 		// state is empty initialize
 		allCPUs := p.topology.CPUDetails.CPUs()
 		s.SetDefaultCPUSet(allCPUs)
+		if managed.IsEnabled() {
+			defaultCpus := s.GetDefaultCPUSet().Difference(p.reserved)
+			s.SetDefaultCPUSet(defaultCpus)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Remove reserved CPUs from default set when workload partitioning is
enabled.

Co-Authored-By: Brent Rowsell <browsell@redhat.com>
Signed-off-by: Don Penney <dpenney@redhat.com>
(cherry picked from commit 33a5804a3957641da6b1cac07e2b9436f161d60c)

Cherry-pick of PR [1925](https://github.com/openshift/kubernetes/pull/1295)
