### PR TITLE
OCPBUGS-647: SDN branch: Fix Prefer local endpoints for cluster DNS service

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1412,6 +1412,186 @@ COMMIT
 	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
 }
 
+func TestOpenShiftDNSHack(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.10"
+	svcPort := 53
+	podPort := 5353
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("openshift-dns", "dns-default"),
+		Port:           "dns",
+		Protocol:       v1.ProtocolUDP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				// This endpoint is ignored because it's remote
+				Addresses: []string{"10.180.0.2"},
+				NodeName:  utilpointer.StringPtr("node2"),
+			}, {
+				Addresses: []string{"10.180.0.1"},
+				NodeName:  utilpointer.StringPtr(testHostname),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     utilpointer.StringPtr(svcPortName.Port),
+				Port:     utilpointer.Int32(int32(podPort)),
+				Protocol: &svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	// Deal with UDP conntrack stuff
+	fakeExec := fp.exec.(*fakeexec.FakeExec)
+	fakeExec.LookPathFunc = func(cmd string) (string, error) { return cmd, nil }
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			func() ([]byte, []byte, error) { return []byte("1 flow entries have been deleted"), nil, nil },
+		},
+	}
+	fakeExec.CommandScript = []fakeexec.FakeCommandAction{
+		func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+	}
+
+	fp.syncProxyRules()
+
+	expected := `
+*filter
+:KUBE-EXTERNAL-SERVICES - [0:0]
+:KUBE-FORWARD - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-SERVICES - [0:0]
+-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark 0x4000/0x4000 -j ACCEPT
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+COMMIT
+*nat
+:KUBE-MARK-MASQ - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-POSTROUTING - [0:0]
+:KUBE-SEP-DYOI7QYSVZXR6VUA - [0:0]
+:KUBE-SERVICES - [0:0]
+:KUBE-SVC-BGNS3J6UB7MMLVDO - [0:0]
+-A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
+-A KUBE-SERVICES -m comment --comment "openshift-dns/dns-default:dns cluster IP" -m udp -p udp -d 172.30.0.10 --dport 53 -j KUBE-SVC-BGNS3J6UB7MMLVDO
+-A KUBE-MARK-MASQ -j MARK --or-mark 0x4000
+-A KUBE-POSTROUTING -m mark ! --mark 0x4000/0x4000 -j RETURN
+-A KUBE-POSTROUTING -j MARK --xor-mark 0x4000
+-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -j MASQUERADE
+-A KUBE-SEP-DYOI7QYSVZXR6VUA -m comment --comment openshift-dns/dns-default:dns -s 10.180.0.1 -j KUBE-MARK-MASQ
+-A KUBE-SEP-DYOI7QYSVZXR6VUA -m comment --comment openshift-dns/dns-default:dns -m udp -p udp -j DNAT --to-destination 10.180.0.1:5353
+-A KUBE-SVC-BGNS3J6UB7MMLVDO -m comment --comment "openshift-dns/dns-default:dns cluster IP" -m udp -p udp -d 172.30.0.10 --dport 53 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
+-A KUBE-SVC-BGNS3J6UB7MMLVDO -m comment --comment openshift-dns/dns-default:dns -j KUBE-SEP-DYOI7QYSVZXR6VUA
+COMMIT
+`
+	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
+}
+
+func TestOpenShiftDNSHackFallback(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.10"
+	svcPort := 53
+	podPort := 5353
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("openshift-dns", "dns-default"),
+		Port:           "dns",
+		Protocol:       v1.ProtocolUDP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			// Both endpoints are used because neither is local
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"10.180.1.2"},
+				NodeName:  utilpointer.StringPtr("node2"),
+			}, {
+				Addresses: []string{"10.180.2.3"},
+				NodeName:  utilpointer.StringPtr("node3"),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     utilpointer.StringPtr(svcPortName.Port),
+				Port:     utilpointer.Int32(int32(podPort)),
+				Protocol: &svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	// Deal with UDP conntrack stuff
+	fakeExec := fp.exec.(*fakeexec.FakeExec)
+	fakeExec.LookPathFunc = func(cmd string) (string, error) { return cmd, nil }
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			func() ([]byte, []byte, error) { return []byte("1 flow entries have been deleted"), nil, nil },
+		},
+	}
+	fakeExec.CommandScript = []fakeexec.FakeCommandAction{
+		func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+	}
+
+	fp.syncProxyRules()
+
+	expected := `
+*filter
+:KUBE-EXTERNAL-SERVICES - [0:0]
+:KUBE-FORWARD - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-SERVICES - [0:0]
+-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark 0x4000/0x4000 -j ACCEPT
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+COMMIT
+*nat
+:KUBE-MARK-MASQ - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-POSTROUTING - [0:0]
+:KUBE-SEP-HBTKKYYQD5LT7Q5V - [0:0]
+:KUBE-SEP-UJYYVAPCRGSFEWJK - [0:0]
+:KUBE-SERVICES - [0:0]
+:KUBE-SVC-BGNS3J6UB7MMLVDO - [0:0]
+-A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
+-A KUBE-SERVICES -m comment --comment "openshift-dns/dns-default:dns cluster IP" -m udp -p udp -d 172.30.0.10 --dport 53 -j KUBE-SVC-BGNS3J6UB7MMLVDO
+-A KUBE-MARK-MASQ -j MARK --or-mark 0x4000
+-A KUBE-POSTROUTING -m mark ! --mark 0x4000/0x4000 -j RETURN
+-A KUBE-POSTROUTING -j MARK --xor-mark 0x4000
+-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -j MASQUERADE
+-A KUBE-SEP-HBTKKYYQD5LT7Q5V -m comment --comment openshift-dns/dns-default:dns -s 10.180.1.2 -j KUBE-MARK-MASQ
+-A KUBE-SEP-HBTKKYYQD5LT7Q5V -m comment --comment openshift-dns/dns-default:dns -m udp -p udp -j DNAT --to-destination 10.180.1.2:5353
+-A KUBE-SEP-UJYYVAPCRGSFEWJK -m comment --comment openshift-dns/dns-default:dns -s 10.180.2.3 -j KUBE-MARK-MASQ
+-A KUBE-SEP-UJYYVAPCRGSFEWJK -m comment --comment openshift-dns/dns-default:dns -m udp -p udp -j DNAT --to-destination 10.180.2.3:5353
+-A KUBE-SVC-BGNS3J6UB7MMLVDO -m comment --comment "openshift-dns/dns-default:dns cluster IP" -m udp -p udp -d 172.30.0.10 --dport 53 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
+-A KUBE-SVC-BGNS3J6UB7MMLVDO -m comment --comment openshift-dns/dns-default:dns -m statistic --mode random --probability 0.5000000000 -j KUBE-SEP-HBTKKYYQD5LT7Q5V
+-A KUBE-SVC-BGNS3J6UB7MMLVDO -m comment --comment openshift-dns/dns-default:dns -j KUBE-SEP-UJYYVAPCRGSFEWJK
+COMMIT
+`
+	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
+}
+
 func TestLoadBalancer(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2337,6 +2337,123 @@ COMMIT
 	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
 }
 
+func TestOnlyLocalWithFallback(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.41"
+	svcPort := 80
+	svcNodePort := 3001
+	svcHealthCheckNodePort := 30000
+	svcLBIP := "1.2.3.4"
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+	svcSessionAffinityTimeout := int32(10800)
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.ObjectMeta.Annotations = map[string]string{
+				localWithFallbackAnnotation: "",
+			}
+			svc.Spec.Type = "LoadBalancer"
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+				NodePort: int32(svcNodePort),
+			}}
+			svc.Spec.HealthCheckNodePort = int32(svcHealthCheckNodePort)
+			svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{
+				IP: svcLBIP,
+			}}
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &svcSessionAffinityTimeout},
+			}
+		}),
+	)
+
+	epIP1 := "10.180.0.1"
+	epIP2 := "10.180.2.1"
+	tcpProtocol := v1.ProtocolTCP
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{epIP1},
+				NodeName:  utilpointer.StringPtr("host1"),
+			}, {
+				Addresses: []string{epIP2},
+				NodeName:  utilpointer.StringPtr("host2"),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     utilpointer.StringPtr(svcPortName.Port),
+				Port:     utilpointer.Int32(int32(svcPort)),
+				Protocol: &tcpProtocol,
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	expected := `
+*filter
+:KUBE-EXTERNAL-SERVICES - [0:0]
+:KUBE-FORWARD - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-SERVICES - [0:0]
+-A KUBE-NODEPORTS -m comment --comment "ns1/svc1:p80 health check node port" -m tcp -p tcp --dport 30000 -j ACCEPT
+-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark 0x4000/0x4000 -j ACCEPT
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+COMMIT
+*nat
+:KUBE-FW-XPGD46QRK7WJZT7O - [0:0]
+:KUBE-MARK-MASQ - [0:0]
+:KUBE-NODEPORTS - [0:0]
+:KUBE-POSTROUTING - [0:0]
+:KUBE-SEP-SXIVWICOYRO3J4NJ - [0:0]
+:KUBE-SEP-ZX7GRIZKSNUQ3LAJ - [0:0]
+:KUBE-SERVICES - [0:0]
+:KUBE-SVC-XPGD46QRK7WJZT7O - [0:0]
+:KUBE-XLB-XPGD46QRK7WJZT7O - [0:0]
+-A KUBE-NODEPORTS -m comment --comment ns1/svc1:p80 -m tcp -p tcp --dport 3001 -s 127.0.0.0/8 -j KUBE-MARK-MASQ
+-A KUBE-NODEPORTS -m comment --comment ns1/svc1:p80 -m tcp -p tcp --dport 3001 -j KUBE-XLB-XPGD46QRK7WJZT7O
+-A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
+-A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 172.30.0.41 --dport 80 -j KUBE-SVC-XPGD46QRK7WJZT7O
+-A KUBE-SERVICES -m comment --comment "ns1/svc1:p80 loadbalancer IP" -m tcp -p tcp -d 1.2.3.4 --dport 80 -j KUBE-FW-XPGD46QRK7WJZT7O
+-A KUBE-FW-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 loadbalancer IP" -j KUBE-XLB-XPGD46QRK7WJZT7O
+-A KUBE-FW-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 loadbalancer IP" -j KUBE-MARK-DROP
+-A KUBE-MARK-MASQ -j MARK --or-mark 0x4000
+-A KUBE-POSTROUTING -m mark ! --mark 0x4000/0x4000 -j RETURN
+-A KUBE-POSTROUTING -j MARK --xor-mark 0x4000
+-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -j MASQUERADE
+-A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -s 10.180.0.1 -j KUBE-MARK-MASQ
+-A KUBE-SEP-SXIVWICOYRO3J4NJ -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-SXIVWICOYRO3J4NJ --set -m tcp -p tcp -j DNAT --to-destination 10.180.0.1:80
+-A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -s 10.180.2.1 -j KUBE-MARK-MASQ
+-A KUBE-SEP-ZX7GRIZKSNUQ3LAJ -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-ZX7GRIZKSNUQ3LAJ --set -m tcp -p tcp -j DNAT --to-destination 10.180.2.1:80
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment "ns1/svc1:p80 cluster IP" -m tcp -p tcp -d 172.30.0.41 --dport 80 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-SXIVWICOYRO3J4NJ --rcheck --seconds 10800 --reap -j KUBE-SEP-SXIVWICOYRO3J4NJ
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-ZX7GRIZKSNUQ3LAJ --rcheck --seconds 10800 --reap -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m statistic --mode random --probability 0.5000000000 -j KUBE-SEP-SXIVWICOYRO3J4NJ
+-A KUBE-SVC-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "Redirect pods trying to reach external loadbalancer VIP to clusterIP" -s 10.0.0.0/24 -j KUBE-SVC-XPGD46QRK7WJZT7O
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "masquerade LOCAL traffic for ns1/svc1:p80 LB IP" -m addrtype --src-type LOCAL -j KUBE-MARK-MASQ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "route LOCAL traffic for ns1/svc1:p80 LB IP to service chain" -m addrtype --src-type LOCAL -j KUBE-SVC-XPGD46QRK7WJZT7O
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment "local-with-fallback NAT" -j KUBE-MARK-MASQ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-SXIVWICOYRO3J4NJ --rcheck --seconds 10800 --reap -j KUBE-SEP-SXIVWICOYRO3J4NJ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m recent --name KUBE-SEP-ZX7GRIZKSNUQ3LAJ --rcheck --seconds 10800 --reap -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -m statistic --mode random --probability 0.5000000000 -j KUBE-SEP-SXIVWICOYRO3J4NJ
+-A KUBE-XLB-XPGD46QRK7WJZT7O -m comment --comment ns1/svc1:p80 -j KUBE-SEP-ZX7GRIZKSNUQ3LAJ
+COMMIT
+`
+	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
+}
+
 func TestOnlyLocalNodePortsNoClusterCIDR(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)


### PR DESCRIPTION
Carry "Prefer local endpoint for cluster DNS service"
(54dc363) was incorrectly applied which did not restrict
DNS calls to a local endpoint.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @danwinship 

