### PR TITLE
Add a comment about the "API" for bypassing the endpoints admission controller

### DIFF
--- a/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
+++ b/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go
@@ -162,6 +162,10 @@ func (r *restrictedEndpointsAdmission) endpointsFindRestrictedPort(ep *kapi.Endp
 }
 
 func (r *restrictedEndpointsAdmission) endpointsCheckAccess(ctx context.Context, attr admission.Attributes) (bool, error) {
+	// Note that while the "endpoints/restricted" pseudo-resource is not formally
+	// documented anywhere, we have told some customers that they can use this to
+	// un-break third-party software that would otherwise break in the presence of
+	// this admission controller. So this should be considered API.
 	authzAttr := authorizer.AttributesRecord{
 		User:            attr.GetUserInfo(),
 		Verb:            "create",
@@ -235,6 +239,10 @@ func (r *restrictedEndpointsAdmission) sliceFindRestrictedPort(slice *discovery.
 }
 
 func (r *restrictedEndpointsAdmission) sliceCheckAccess(ctx context.Context, attr admission.Attributes) (bool, error) {
+	// Note that while the "endpointslices/restricted" pseudo-resource is not formally
+	// documented anywhere, we have told some customers that they can use this to
+	// un-break third-party software that would otherwise break in the presence of
+	// this admission controller. So this should be considered API.
 	authzAttr := authorizer.AttributesRecord{
 		User:            attr.GetUserInfo(),
 		Verb:            "create",


### PR DESCRIPTION
A customer had a problem with some third-party software that fails in the presence of our RestrictedEndpoints admission controller, and filed [an RFE](https://issues.redhat.com/browse/RFE-2732) requesting a way to bypass it, and I pointed out that you can _already_ bypass it, and they were like "well is that guaranteed to work in the future?", and I said "yes" but figured maybe I should make a note about that so we don't change things in the future thinking it's a purely-internal API.
