### PR TITLE
[WIP] Dockerfile: update to use fedora 36

### DIFF
--- a/openshift-hack/images/os/Dockerfile
+++ b/openshift-hack/images/os/Dockerfile
@@ -1,11 +1,9 @@
-# fedora:29 is an image built within the release scripts:
-# https://github.com/openshift/release/blob/b45a09d248b8cdb8fe3bf5f3cfa0b4fee57d04c8/ci-operator/config/openshift/kubernetes/openshift-kubernetes-release-4.10.yaml#L63-L65
-FROM fedora:29 AS build
+FROM quay.io/fedora/fedora:36 AS build
 
 # the registry is defined here:
 # https://github.com/openshift/release/blob/b45a09d248b8cdb8fe3bf5f3cfa0b4fee57d04c8/ci-operator/config/openshift/kubernetes/openshift-kubernetes-release-4.10.yaml#L68
-COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content /srv/ /srv/
-COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content /extensions/ /extensions/
+COPY --from=registry.ci.openshift.org/ocp/4.12:machine-os-content /srv/ /srv/
+COPY --from=registry.ci.openshift.org/ocp/4.12:machine-os-content /extensions/ /extensions/
 WORKDIR /
 COPY install.sh .
 RUN ./install.sh

--- a/openshift-hack/images/os/install.sh
+++ b/openshift-hack/images/os/install.sh
@@ -10,7 +10,7 @@ mkdir /tmp/working && cd /tmp/working
 rpm-ostree db list --repo /srv/repo $commit > /tmp/packages
 
 PACKAGES=(openshift-hyperkube)
-yumdownloader -y --disablerepo=* --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}"
+yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms "${PACKAGES[@]}"
 if ! grep -q cri-o /tmp/packages; then
   yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms cri-o cri-tools
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[Test started failing](https://github.com/openshift/kubernetes/pull/1363#issuecomment-1246148007) when building machine-os-content bc they were referencing Fedora 29 which is EOL. Use F36 instead (which some other operators are also using).

**Update**:
Was successfully picked into the [k8s bump PR](https://github.com/openshift/kubernetes/pull/1360) and failures related to machine-os-content builds in affected tests stopped.

```docs

```
