### PR TITLE
openshift-hack: Add Dockerfile.new targeting `rhel-coreos-8`

### DIFF
--- a/openshift-hack/images/os/Dockerfile.new
+++ b/openshift-hack/images/os/Dockerfile.new
@@ -1,0 +1,11 @@
+# This uses the new rhel-coreos-8 base image
+# https://github.com/openshift/enhancements/blob/master/enhancements/ocp-coreos-layering/ocp-coreos-layering.md
+FROM centos:stream9 as build
+# Sadly rpm-ostree in rhel8 right now doesn't support e.g. `rpm-ostree upgrade openshift-hyperkube`
+# in a container https://github.com/coreos/rpm-ostree/issues/4034
+RUN dnf -y install dnf-utils && dnf download openshift-hyperkube
+
+# This must be replaced by the CI job, but see also https://issues.redhat.com/browse/ART-4352
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos-8
+COPY --from=build /*.rpm /
+RUN rpm -Uvh /*.rpm && rm -f /*.rpm


### PR DESCRIPTION
https://issues.redhat.com/browse/MCO-377

As part of https://github.com/openshift/enhancements/blob/master/enhancements/ocp-coreos-layering/ocp-coreos-layering.md we are introducing a new base image, and the CI here needs to learn to also inject the new kubelet binary on top of it.

But notice how much saner and nicer this new flow is!

Once we drop the old `machine-os-content`, then we can drop the old `Dockerfile` here too.