### PR TITLE
Branch SDN-4.10-1.24.4: Do not force DNS service endpoints to be local when endpoint isnt ready

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1011,7 +1011,7 @@ func (proxier *Proxier) syncProxyRules() {
 		// implemented and the DNS operator is updated to use it.
 		if svcNameString == "openshift-dns/dns-default:dns" {
 			for _, ep := range allEndpoints {
-				if ep.GetIsLocal() {
+				if ep.GetIsLocal() && ep.IsReady() {
 					klog.V(4).Infof("Found a local endpoint %q for service %q; preferring the local endpoint and ignoring %d other endpoints", ep.String(), svcNameString, len(allEndpoints)-1)
 					allEndpoints = []proxy.Endpoint{ep}
 					break


### PR DESCRIPTION
Currently, we direct DNS traffic to local even if the endpoint is not ready. This is not prefer local
functionality.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

