### PR TITLE
UPSTREAM: <carry>: allow annotating with a specific suite

### DIFF
--- a/openshift-hack/e2e/annotate/annotate.go
+++ b/openshift-hack/e2e/annotate/annotate.go
@@ -206,7 +206,8 @@ func (r *ginkgoTestRenamer) generateRename(name string, node types.TestSpec) {
 		}
 	}
 
-	if !r.excludedTestsFilter.MatchString(newName) {
+	// Append suite name to test, if it doesn't already have one
+	if !r.excludedTestsFilter.MatchString(newName) && !strings.Contains(newName, "[Suite:") {
 		isSerial := strings.Contains(newName, "[Serial]")
 		isConformance := strings.Contains(newName, "[Conformance]")
 		switch {


### PR DESCRIPTION
If a test specifies a suite, don't append another one to it. We want the ability to add tests to a particular suite without automatically being added to parallel conformance.
