### PR TITLE
UPSTREAM: <carry>: make the PSA workload admission warnings honor the…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/opencontainers/runc v1.1.3
 	github.com/opencontainers/selinux v1.10.0
 	github.com/openshift/api v0.0.0-20221116145627-676ae1a3836c
-	github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c
+	github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
 	github.com/openshift/library-go v0.0.0-20221101142545-76526edf66e8
 	github.com/pkg/errors v0.9.1
@@ -494,7 +494,7 @@ replace (
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.0
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20221116145627-676ae1a3836c
-	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c
+	github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412
 	github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221101142545-76526edf66e8

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK9
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift/api v0.0.0-20221116145627-676ae1a3836c h1:10jzfr/RunDLd39JKGW4/Y0t5l68rD1qV/UN8JJEy+k=
 github.com/openshift/api v0.0.0-20221116145627-676ae1a3836c/go.mod h1:OW9hi5XDXOQWm/kRqUww6RVxZSf0nqrS4heerSmHBC4=
-github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c h1:Wf/+w/6F/F3GnT/dBKvez6W4JlxRJ2JprzwsFIS27Bo=
-github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c/go.mod h1:Rf4eEydKLk+BkXhb2oSxNJWWOdI/2XrU6Z9+Jn4AD6Q=
+github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412 h1:QFvuS4fnh+5//Yqkvxth26rZTYKUEfvYn6Tn6wUUbLM=
+github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412/go.mod h1:Rf4eEydKLk+BkXhb2oSxNJWWOdI/2XrU6Z9+Jn4AD6Q=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
 github.com/openshift/library-go v0.0.0-20221101142545-76526edf66e8 h1:KJdLbBWfSFSpWpCkTwBB71NNmISB/d4jpBYtHu1Vrhs=

--- a/openshift-kube-apiserver/enablement/intialization.go
+++ b/openshift-kube-apiserver/enablement/intialization.go
@@ -4,9 +4,12 @@ import (
 	"io/ioutil"
 	"path"
 
+	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
+
 	configv1 "github.com/openshift/api/config/v1"
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -74,6 +77,8 @@ func ForceGlobalInitializationForOpenShift() {
 		},
 	})
 
+	podsecurity.SCCMutatingPodSpecExtractorInstance.SetSCCAdmission(SCCAdmissionPlugin)
+
 	// add permissions we require on our kube-apiserver
 	// TODO, we should scrub these out
 	bootstrappolicy.ClusterRoles = bootstrappolicy.OpenshiftClusterRoles
@@ -83,3 +88,5 @@ func ForceGlobalInitializationForOpenShift() {
 	// SkipSystemMastersAuthorizer disable implicitly added system/master authz, and turn it into another authz mode "SystemMasters", to be added via authorization-mode
 	server.SkipSystemMastersAuthorizer()
 }
+
+var SCCAdmissionPlugin = sccadmission.NewConstraint()

--- a/openshift-kube-apiserver/enablement/intialization.go
+++ b/openshift-kube-apiserver/enablement/intialization.go
@@ -4,8 +4,6 @@ import (
 	"io/ioutil"
 	"path"
 
-	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
-
 	configv1 "github.com/openshift/api/config/v1"
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -21,6 +19,7 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/configdefault"
 	"k8s.io/kubernetes/pkg/capabilities"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 )
 

--- a/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -78,6 +78,12 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
 	)
+
+	// This is needed in order to have the correct initializers for the SCC admission plugin which is used to mutate
+	// PodSpecs for PodSpec-y workload objects in the pod security admission plugin.
+	enablement.SCCAdmissionPlugin.SetAuthorizer(genericConfig.Authorization.Authorizer)
+	enablement.SCCAdmissionPlugin.SetSecurityInformers(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints())
+	enablement.SCCAdmissionPlugin.SetExternalKubeInformerFactory(kubeInformers)
 	// END ADMISSION
 
 	// HANDLER CHAIN (with oauth server and web console)

--- a/plugin/pkg/admission/security/podsecurity/admission.go
+++ b/plugin/pkg/admission/security/podsecurity/admission.go
@@ -114,7 +114,7 @@ func newPlugin(reader io.Reader) (*Plugin, error) {
 			Configuration:    config,
 			Evaluator:        evaluator,
 			Metrics:          getDefaultRecorder(),
-			PodSpecExtractor: podsecurityadmission.DefaultPodSpecExtractor{},
+			PodSpecExtractor: SCCMutatingPodSpecExtractorInstance,
 		},
 	}, nil
 }

--- a/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
+++ b/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
@@ -1,0 +1,107 @@
+package podsecurity
+
+import (
+	"context"
+	"fmt"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/apis/core"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	podsecurityadmission "k8s.io/pod-security-admission/admission"
+)
+
+type SCCMutatingPodSpecExtractor struct {
+	sccAdmission admission.MutationInterface
+	delegate     podsecurityadmission.PodSpecExtractor
+}
+
+var SCCMutatingPodSpecExtractorInstance = &SCCMutatingPodSpecExtractor{
+	delegate: podsecurityadmission.DefaultPodSpecExtractor{},
+}
+
+func (s *SCCMutatingPodSpecExtractor) SetSCCAdmission(sccAdmission admission.MutationInterface) {
+	s.sccAdmission = sccAdmission
+}
+
+func (s *SCCMutatingPodSpecExtractor) HasPodSpec(gr schema.GroupResource) bool {
+	return s.delegate.HasPodSpec(gr)
+}
+
+func (s *SCCMutatingPodSpecExtractor) ExtractPodSpec(obj runtime.Object) (*metav1.ObjectMeta, *corev1.PodSpec, error) {
+	if s.sccAdmission == nil {
+		return s.delegate.ExtractPodSpec(obj)
+	}
+
+	switch obj := obj.(type) {
+	case *corev1.Pod:
+		return s.delegate.ExtractPodSpec(obj)
+	}
+
+	podTemplateMeta, originalPodSpec, err := s.delegate.ExtractPodSpec(obj)
+	if err != nil {
+		return podTemplateMeta, originalPodSpec, err
+	}
+	if originalPodSpec == nil {
+		return nil, nil, nil
+	}
+	objectMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return podTemplateMeta, originalPodSpec, fmt.Errorf("unable to get metadata for SCC mutation: %w", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: *podTemplateMeta.DeepCopy(),
+		Spec:       *originalPodSpec.DeepCopy(),
+	}
+	if len(pod.Namespace) == 0 {
+		pod.Namespace = objectMeta.GetNamespace()
+	}
+	if len(pod.Name) == 0 {
+		pod.Name = "pod-for-container-named-" + objectMeta.GetName()
+	}
+	internalPod := &core.Pod{}
+	if err := v1.Convert_v1_Pod_To_core_Pod(pod, internalPod, nil); err != nil {
+		return nil, nil, err
+	}
+
+	admissionAttributes := admission.NewAttributesRecord(
+		internalPod,
+		nil,
+		corev1.SchemeGroupVersion.WithKind("Pod"),
+		pod.Namespace,
+		pod.Name,
+		corev1.SchemeGroupVersion.WithResource("pods"),
+		"",
+		admission.Create,
+		nil,
+		false,
+		&user.DefaultInfo{
+			Name:   serviceaccount.MakeUsername(pod.Namespace, pod.Spec.ServiceAccountName),
+			UID:    "",
+			Groups: append([]string{user.AllAuthenticated}, serviceaccount.MakeGroupNames(pod.Namespace)...),
+			Extra:  nil,
+		})
+	if err := s.sccAdmission.Admit(context.Background(), admissionAttributes, nil); err != nil {
+		// don't fail the request, just warn if SCC will fail
+		klog.ErrorS(err, "failed to mutate object for PSA using SCC")
+		utilruntime.HandleError(fmt.Errorf("failed to mutate object for PSA using SCC: %w", err))
+		// TODO remove this failure we're causing when SCC fails, but for now we actually need to see our test fail because that was almost really bad.
+		return podTemplateMeta, originalPodSpec, err
+	}
+
+	if err := v1.Convert_core_Pod_To_v1_Pod(internalPod, pod, nil); err != nil {
+		return nil, nil, err
+	}
+
+	return podTemplateMeta, &pod.Spec, nil
+}

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
@@ -20,7 +19,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
@@ -28,11 +28,10 @@ import (
 	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 
 	securityv1 "github.com/openshift/api/security/v1"
-	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
-	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
-
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
 	sccsort "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util/sort"
+	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
+	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
 )
 
 const PluginName = "security.openshift.io/SecurityContextConstraint"
@@ -46,16 +45,16 @@ func Register(plugins *admission.Plugins) {
 
 type constraint struct {
 	*admission.Handler
-	client     kubernetes.Interface
-	sccLister  securityv1listers.SecurityContextConstraintsLister
-	sccSynced  cache.InformerSynced
-	authorizer authorizer.Authorizer
+	sccLister       securityv1listers.SecurityContextConstraintsLister
+	namespaceLister corev1listers.NamespaceLister
+	listersSynced   []cache.InformerSynced
+	authorizer      authorizer.Authorizer
 }
 
 var (
 	_ = initializer.WantsAuthorizer(&constraint{})
-	_ = initializer.WantsExternalKubeClientSet(&constraint{})
 	_ = WantsSecurityInformer(&constraint{})
+	_ = initializer.WantsExternalKubeInformerFactory(&constraint{})
 	_ = admission.ValidationInterface(&constraint{})
 	_ = admission.MutationInterface(&constraint{})
 )
@@ -168,12 +167,21 @@ func requireStandardSCCs(sccs []*securityv1.SecurityContextConstraints, err erro
 	return fmt.Errorf("securitycontextconstraints.security.openshift.io cache is missing %v", strings.Join(missingSCCs.List(), ", "))
 }
 
+func (c *constraint) areListersSynced() bool {
+	for _, syncFunc := range c.listersSynced {
+		if !syncFunc() {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *constraint) computeSecurityContext(ctx context.Context, a admission.Attributes, pod *coreapi.Pod, specMutationAllowed bool, validatedSCCHint string) (*coreapi.Pod, string, field.ErrorList, error) {
 	// get all constraints that are usable by the user
 	klog.V(4).Infof("getting security context constraints for pod %s (generate: %s) in namespace %s with user info %v", pod.Name, pod.GenerateName, a.GetNamespace(), a.GetUserInfo())
 
 	err := wait.PollImmediateWithContext(ctx, 1*time.Second, 10*time.Second, func(context.Context) (bool, error) {
-		return c.sccSynced(), nil
+		return c.areListersSynced(), nil
 	})
 	if err != nil {
 		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("securitycontextconstraints.security.openshift.io cache is not synchronized"))
@@ -226,7 +234,7 @@ func (c *constraint) computeSecurityContext(ctx context.Context, a admission.Att
 		return i < j
 	})
 
-	providers, errs := sccmatching.CreateProvidersFromConstraints(ctx, a.GetNamespace(), constraints, c.client)
+	providers, errs := sccmatching.CreateProvidersFromConstraints(ctx, a.GetNamespace(), constraints, c.namespaceLister)
 	logProviders(pod, providers, errs)
 	if len(errs) > 0 {
 		return nil, "", nil, kutilerrors.NewAggregate(errs)
@@ -441,11 +449,12 @@ func shouldIgnore(a admission.Attributes) (bool, error) {
 // SetSecurityInformers implements WantsSecurityInformer interface for constraint.
 func (c *constraint) SetSecurityInformers(informers securityv1informer.SecurityContextConstraintsInformer) {
 	c.sccLister = informers.Lister()
-	c.sccSynced = informers.Informer().HasSynced
+	c.listersSynced = append(c.listersSynced, informers.Informer().HasSynced)
 }
 
-func (c *constraint) SetExternalKubeClientSet(client kubernetes.Interface) {
-	c.client = client
+func (c *constraint) SetExternalKubeInformerFactory(informers informers.SharedInformerFactory) {
+	c.namespaceLister = informers.Core().V1().Namespaces().Lister()
+	c.listersSynced = append(c.listersSynced, informers.Core().V1().Namespaces().Informer().HasSynced)
 }
 
 func (c *constraint) SetAuthorizer(authorizer authorizer.Authorizer) {
@@ -457,11 +466,11 @@ func (c *constraint) ValidateInitialization() error {
 	if c.sccLister == nil {
 		return fmt.Errorf("%s requires an sccLister", PluginName)
 	}
-	if c.sccSynced == nil {
+	if c.listersSynced == nil {
 		return fmt.Errorf("%s requires an sccSynced", PluginName)
 	}
-	if c.client == nil {
-		return fmt.Errorf("%s requires a client", PluginName)
+	if c.namespaceLister == nil {
+		return fmt.Errorf("%s requires a namespaceLister", PluginName)
 	}
 	if c.authorizer == nil {
 		return fmt.Errorf("%s requires an authorizer", PluginName)

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/scc_exec.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission/scc_exec.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 	coreapiv1conversions "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -87,7 +88,10 @@ func NewSCCExecRestrictions() *sccExecRestrictions {
 
 func (d *sccExecRestrictions) SetExternalKubeClientSet(c kubernetes.Interface) {
 	d.client = c
-	d.constraintAdmission.SetExternalKubeClientSet(c)
+}
+
+func (d *sccExecRestrictions) SetExternalKubeInformerFactory(informers informers.SharedInformerFactory) {
+	d.constraintAdmission.SetExternalKubeInformerFactory(informers)
 }
 
 func (d *sccExecRestrictions) SetSecurityInformers(informers securityv1informers.SecurityContextConstraintsInformer) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -737,7 +737,7 @@ github.com/openshift/api/security
 github.com/openshift/api/security/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c => github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c
+# github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412 => github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412
 ## explicit; go 1.18
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1
@@ -3004,7 +3004,7 @@ sigs.k8s.io/yaml
 # github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 # github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.0
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20221116145627-676ae1a3836c
-# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20221017210321-925452e8316c
+# github.com/openshift/apiserver-library-go => github.com/openshift/apiserver-library-go v0.0.0-20221118165437-6006085c7412
 # github.com/openshift/build-machinery-go => github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221101142545-76526edf66e8


### PR DESCRIPTION
… changes that SCC will eventually make to the pod

This way if a user creates a deployment that has a podspec which requires defaults that are set during SCC admission, the PSA admission plugin will avoid issuing warnings to users that their deployment has a problem.  This is down to the fact that we mutate pods and all pod mutators would have this problem.

/assign @stlaz @ibihim 
/cc @bparees 