### PR TITLE
OCPBUGS-2946: Revert: 1340: tag AWS security group at creation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -3364,21 +3364,6 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		createRequest.VpcId = &c.vpcID
 		createRequest.GroupName = &name
 		createRequest.Description = &description
-		tags := c.tagging.buildTags(ResourceLifecycleOwned, additionalTags)
-		var awsTags []*ec2.Tag
-		for k, v := range tags {
-			tag := &ec2.Tag{
-				Key:   aws.String(k),
-				Value: aws.String(v),
-			}
-			awsTags = append(awsTags, tag)
-		}
-		createRequest.TagSpecifications = []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String(ec2.ResourceTypeSecurityGroup),
-				Tags:         awsTags,
-			},
-		}
 
 		createResponse, err := c.ec2.CreateSecurityGroup(createRequest)
 		if err != nil {
@@ -3404,6 +3389,14 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		return "", fmt.Errorf("created security group, but id was not returned: %s", name)
 	}
 
+	err := c.tagging.createTags(c.ec2, groupID, ResourceLifecycleOwned, additionalTags)
+	if err != nil {
+		// If we retry, ensureClusterTags will recover from this - it
+		// will add the missing tags.  We could delete the security
+		// group here, but that doesn't feel like the right thing, as
+		// the caller is likely to retry the create
+		return "", fmt.Errorf("error tagging security group: %q", err)
+	}
 	return groupID, nil
 }
 


### PR DESCRIPTION
Reverts openshift/kubernetes#1340

This PR introduced a regression breaking the registration of NLB targets when creating an NLB backed service.

This bug prevents AWS hypershift clusters from being installed so I've set it as a blocker.

The bug here is that, given the changes introduced, the service gets reconciled on create and skips registering the targets once it has created the target group.

If you edit the service, for example to add a new annotation, the controller goes through the update loop and the targets get registered again.

We need to fix this upstream in the cloud provider codebase and backport the updated fix.

We must revert the fix until we can reintroduce it without reintroducing this bug