### PR TITLE
UPSTREAM: <carry>: Ensure balanced brackets in annotated test names

### DIFF
--- a/openshift-hack/e2e/annotate/annotate_test.go
+++ b/openshift-hack/e2e/annotate/annotate_test.go
@@ -1,0 +1,55 @@
+package annotate
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func Test_checkBalancedBrackets(t *testing.T) {
+	tests := []struct {
+		testCase string
+		testName string
+		wantErr  bool
+	}{
+		{
+			testCase: "balanced brackets succeeds",
+			testName: "[sig-storage] Test that storage [apigroup:storage.openshift.io] actually works [Driver:azure][Serial][Late]",
+			wantErr:  false,
+		},
+		{
+			testCase: "unbalanced brackets errors",
+			testName: "[sig-storage] Test that storage [apigroup:storage.openshift.io actually works [Driver:azure][Serial][Late]",
+			wantErr:  true,
+		},
+		{
+			testCase: "start with close bracket errors",
+			testName: "[sig-storage] test with a random bracket ]",
+			wantErr:  true,
+		},
+		{
+			testCase: "multiple unbalanced brackets errors",
+			testName: "[sig-storage Test that storage [apigroup:storage.openshift.io actually works [Driver:azure]",
+			wantErr:  true,
+		},
+		{
+			testCase: "balanced deeply nested brackets succeeds",
+			testName: "[[[[[[some weird test with deeply nested brackets]]]]]]",
+			wantErr:  false,
+		},
+		{
+			testCase: "unbalanced deeply nested brackets errors",
+			testName: "[[[[[[some weird test with deeply nested brackets]]]]]",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testCase, func(t *testing.T) {
+			if err := checkBalancedBrackets(tt.testName); (err != nil) != tt.wantErr {
+				t.Errorf("checkBalancedBrackets() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err != nil {
+				fmt.Fprintf(os.Stderr, "checkBalancedBrackets() success, found expected err = \n%s\n", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
We recently started marking tests with apigroups, and in one case we missed the closing bracket on the annotation resulting in the test being erroneously skipped. See https://github.com/openshift/origin/pull/27525

This adds a check in the annotation generation, and errors when brackets are unbalanced.

```
Example:
$ ./hack/verify-generated.sh
FAILURE after 12.870s: hack/verify-generated.sh:13: executing '/home/stbenjam/go/src/github.com/openshift/origin/hack/update-generated.sh' expecting success: the command returned the wrong error code
Standard output from the command:
Nov  4 14:11:25.026: INFO: Enabling in-tree volume drivers
Nov  4 14:11:25.026: INFO: Warning: deprecated ENABLE_STORAGE_GCE_PD_DRIVER used. This will be removed in a future release. Use --enabled-volume-drivers=gcepd instead
Nov  4 14:11:25.026: INFO: Enabled gcepd and windows-gcepd in-tree volume drivers

Standard error from the command:
failed: unbalanced brackets in test name:
[Top Level] [sig-scheduling][Early] The openshift-console console pods [apigroup:console.openshift.io should be scheduled on different nodes
                                                                       ^
```
