### PR TITLE
OCPBUGS-3093: Tag AWS security groups at creation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -3364,6 +3364,21 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		createRequest.VpcId = &c.vpcID
 		createRequest.GroupName = &name
 		createRequest.Description = &description
+		tags := c.tagging.buildTags(ResourceLifecycleOwned, additionalTags)
+		var awsTags []*ec2.Tag
+		for k, v := range tags {
+			tag := &ec2.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			}
+			awsTags = append(awsTags, tag)
+		}
+		createRequest.TagSpecifications = []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String(ec2.ResourceTypeSecurityGroup),
+				Tags:         awsTags,
+			},
+		}
 
 		createResponse, err := c.ec2.CreateSecurityGroup(createRequest)
 		if err != nil {
@@ -3389,14 +3404,6 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 		return "", fmt.Errorf("created security group, but id was not returned: %s", name)
 	}
 
-	err := c.tagging.createTags(c.ec2, groupID, ResourceLifecycleOwned, additionalTags)
-	if err != nil {
-		// If we retry, ensureClusterTags will recover from this - it
-		// will add the missing tags.  We could delete the security
-		// group here, but that doesn't feel like the right thing, as
-		// the caller is likely to retry the create
-		return "", fmt.Errorf("error tagging security group: %q", err)
-	}
 	return groupID, nil
 }
 


### PR DESCRIPTION
This reintroduces the change #1340 which was reverted in #1401.

The previous PR had an issue where newly created NLB services would not register tags correctly. This code was broken in the upstream provider but was then fixed. That fix is slightly incorrect, so this PR includes the changes from https://github.com/kubernetes/cloud-provider-aws/pull/293 but also https://github.com/kubernetes/cloud-provider-aws/pull/527 which should prevent the bug from being reintroduced.