### PR TITLE
Bug OCPBUGS-4387: kube-proxy: fix duplicate port opening

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -987,6 +987,16 @@ func (proxier *Proxier) syncProxyRules() {
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node ip address matching nodeport cidrs, services with nodeport may not work as intended", "CIDRs", proxier.nodePortAddresses)
 	}
+	// nodeAddresses may contain dual-stack zero-CIDRs if proxier.nodePortAddresses is empty.
+	// Ensure nodeAddresses only contains the addresses for this proxier's IP family.
+	isIPv6 := proxier.iptables.IsIPv6()
+	for addr := range nodeAddresses {
+		if utilproxy.IsZeroCIDR(addr) && isIPv6 == netutils.IsIPv6CIDRString(addr) {
+			// if any of the addresses is zero cidr of this IP family, non-zero IPs can be excluded.
+			nodeAddresses = sets.NewString(addr)
+			break
+		}
+	}
 
 	// Build rules for each service.
 	for svcName, svc := range proxier.serviceMap {
@@ -1478,7 +1488,6 @@ func (proxier *Proxier) syncProxyRules() {
 
 	// Finally, tail-call to the nodeports chain.  This needs to be after all
 	// other service portal rules.
-	isIPv6 := proxier.iptables.IsIPv6()
 	for address := range nodeAddresses {
 		// TODO(thockin, m1093782566): If/when we have dual-stack support we will want to distinguish v4 from v6 zero-CIDRs.
 		if utilproxy.IsZeroCIDR(address) {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1767,7 +1767,15 @@ COMMIT
 -A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
 COMMIT
 `
-
+	assert.Equal(t, []*netutils.LocalPort{
+		{
+			Description: "nodePort for ns1/svc1:p80",
+			IP:          "",
+			IPFamily:    netutils.IPv4,
+			Port:        svcNodePort,
+			Protocol:    netutils.TCP,
+		},
+	}, fp.portMapper.(*fakePortOpener).openPorts)
 	assertIPTablesRulesEqual(t, expected, fp.iptablesData.String())
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/kubernetes/pull/107413, as requested by BZ https://bugzilla.redhat.com/show_bug.cgi?id=2107531

(the changes are already in `release-4.10` branch)

Fixes #OCPBUGS-4387