### PR TITLE
UPSTREAM: <carry>: Drop phony build version labels from machine-os-content Dockerfile.

### DIFF
--- a/openshift-hack/images/os/Dockerfile
+++ b/openshift-hack/images/os/Dockerfile
@@ -22,6 +22,3 @@ RUN ./install.sh
 FROM scratch
 COPY --from=build /srv/ /srv/
 COPY --from=build /extensions/ /extensions/
-
-LABEL io.openshift.build.version-display-names="machine-os=rhcos image for testing openshift kubernetes kubelet only- if you see this outside of PR runs for openshift kubernetes- you found an urgent blocker bug"
-LABEL io.openshift.build.versions="machine-os=1.2.3-testing-if-you-see-this-outside-of-PR-runs-for-openshift-kubernetes-you-found-an-urgent-blocker-bug"


### PR DESCRIPTION
/hold
