### PR TITLE
[release-4.12] OCPBUGS-161: kubelet: Force deleted pods can fail to move out of terminating

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -188,10 +188,11 @@ func newNamedPod(uid, namespace, name string, isStatic bool) *v1.Pod {
 
 // syncPodRecord is a record of a sync pod call
 type syncPodRecord struct {
-	name       string
-	updateType kubetypes.SyncPodType
-	runningPod *kubecontainer.Pod
-	terminated bool
+	name        string
+	updateType  kubetypes.SyncPodType
+	runningPod  *kubecontainer.Pod
+	terminated  bool
+	gracePeriod *int64
 }
 
 type FakeQueueItem struct {
@@ -269,9 +270,10 @@ func createPodWorkers() (*podWorkers, map[types.UID][]syncPodRecord) {
 				lock.Lock()
 				defer lock.Unlock()
 				processed[pod.UID] = append(processed[pod.UID], syncPodRecord{
-					name:       pod.Name,
-					updateType: kubetypes.SyncPodKill,
-					runningPod: runningPod,
+					name:        pod.Name,
+					updateType:  kubetypes.SyncPodKill,
+					runningPod:  runningPod,
+					gracePeriod: gracePeriod,
 				})
 			}()
 			return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

If a CRI error occurs during the terminating phase after a pod is force deleted (API or static) then the housekeeping loop will not deliver updates to the pod worker which prevents the pod's state machine from progressing. The pod will remain in the terminating phase but no further attempts to terminate or cleanup will occur until the kubelet is restarted.

Alter the housekeeping loop to always deliver updates to the pod worker when a pod is no longer in the config list, but only request aggressive termination when the pod is unknown to the pod worker, is not yet started, or has already terminated.


#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes/kubernetes/pull/113145
Manual cherry-pick of 45f626378b8c59fe4a83394e0c0e01b67f12cd33
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Force deleted pods may fail to terminate until the kubelet is restarted when the container runtime returns an error during termination.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
