### PR TITLE
UPSTREAM: 113799: tests: network: Prefer internal IPs first

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -115,6 +115,11 @@ func EndpointsUseHostNetwork(config *NetworkingTestConfig) {
 	config.EndpointsHostNetwork = true
 }
 
+// PreferExternalAddresses prefer node External Addresses for the tests
+func PreferExternalAddresses(config *NetworkingTestConfig) {
+	config.PreferExternalAddresses = true
+}
+
 // NewNetworkingTestConfig creates and sets up a new test config helper.
 func NewNetworkingTestConfig(f *framework.Framework, setters ...Option) *NetworkingTestConfig {
 	// default options
@@ -203,6 +208,8 @@ type NetworkingTestConfig struct {
 	// The kubernetes namespace within which all resources for this
 	// config are created
 	Namespace string
+	// Whether to prefer node External Addresses for the tests
+	PreferExternalAddresses bool
 }
 
 // NetexecDialResponse represents the response returned by the `netexec` subcommand of `agnhost`
@@ -815,13 +822,17 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 		family = v1.IPv6Protocol
 		secondaryFamily = v1.IPv4Protocol
 	}
-	// Get Node IPs from the cluster, ExternalIPs take precedence
-	config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, family)
+	if config.PreferExternalAddresses {
+		// Get Node IPs from the cluster, ExternalIPs take precedence
+		config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, family)
+	}
 	if config.NodeIP == "" {
 		config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, family)
 	}
 	if config.DualStackEnabled {
-		config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
+		if config.PreferExternalAddresses {
+			config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
+		}
 		if config.SecondaryNodeIP == "" {
 			config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, secondaryFamily)
 		}


### PR DESCRIPTION
Many clusters block direct requests from internal resources to the nodes external IPs as best practice. All accesses from internal resources that want to access resources running on nodes go through load balancers, nodes being on private or public subnets. Let's prefer internal IPs first, so the tests can work even when there are security group rules present blocking requests to the external IPs.

We should not require ExternalIP for Conformance, but should keep testing ExternalIPs in sig network.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
