### PR TITLE
Fix the mutated PodSpec extractor for warns if no SCC matches

### DIFF
--- a/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
+++ b/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
@@ -96,7 +96,7 @@ func (s *SCCMutatingPodSpecExtractor) ExtractPodSpec(obj runtime.Object) (*metav
 		klog.ErrorS(err, "failed to mutate object for PSA using SCC")
 		utilruntime.HandleError(fmt.Errorf("failed to mutate object for PSA using SCC: %w", err))
 		// TODO remove this failure we're causing when SCC fails, but for now we actually need to see our test fail because that was almost really bad.
-		return podTemplateMeta, originalPodSpec, err
+		return podTemplateMeta, originalPodSpec, nil
 	}
 
 	if err := v1.Convert_core_Pod_To_v1_Pod(internalPod, pod, nil); err != nil {


### PR DESCRIPTION
If we propagate SCC admission error during pod extraction to PodSecurity admission, the latter will log the error instead of continuing with unmutated pod spec, and so we will not get a validation error in either the audit logs or as a warning.

Related code:
https://github.com/openshift/kubernetes/blob/b4e019f9bb91fb6733c6fdb342a78021d8d01f3e/vendor/k8s.io/pod-security-admission/admission/admission.go#L434-L443

/cc @deads2k @ibihim 