### PR TITLE
OCPBUGS-10048: UPSTREAM: 115328: apiserver: annotate early (server not ready) and late (during shutdown) requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -958,6 +958,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyRuleEvaluator, c.LongRunningFunc)
 	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "audit")
 
+	handler = genericfilters.WithShutdownLateAnnotation(handler, c.lifecycleSignals.ShutdownInitiated, c.ShutdownDelayDuration)
+	handler = genericfilters.WithStartupEarlyAnnotation(handler, c.lifecycleSignals.HasBeenReady)
+
 	failedHandler := genericapifilters.Unauthorized(c.Serializer)
 	failedHandler = genericapifilters.WithFailedAuthenticationAudit(failedHandler, c.AuditBackend, c.AuditPolicyRuleEvaluator)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	clockutils "k8s.io/utils/clock"
+	netutils "k8s.io/utils/net"
+)
+
+type lifecycleEvent interface {
+	// Name returns the name of the signal, useful for logging.
+	Name() string
+
+	// Signaled returns a channel that is closed when the underlying event
+	// has been signaled. Successive calls to Signaled return the same value.
+	Signaled() <-chan struct{}
+
+	// SignaledAt returns the time the event was signaled. If SignaledAt is
+	// invoked before the event is signaled nil will be returned.
+	SignaledAt() *time.Time
+}
+
+type shouldExemptFunc func(*http.Request) bool
+
+var (
+	// the health probes are not annotated by default
+	healthProbes = []string{
+		"/readyz",
+		"/healthz",
+		"/livez",
+	}
+)
+
+func exemptIfHealthProbe(r *http.Request) bool {
+	path := "/" + strings.TrimLeft(r.URL.Path, "/")
+	for _, probe := range healthProbes {
+		if path == probe {
+			return true
+		}
+	}
+	return false
+}
+
+// WithShutdownLateAnnotation, if added to the handler chain, tracks the
+// incoming request(s) after the apiserver has initiated the graceful
+// shutdown, and annoates the audit event for these request(s) with
+// diagnostic information.
+// This enables us to identify the actor(s)/load balancer(s) that are sending
+// requests to the apiserver late during the server termination.
+// It should be placed after (in order of execution) the
+// 'WithAuthentication' filter.
+func WithShutdownLateAnnotation(handler http.Handler, shutdownInitiated lifecycleEvent, delayDuration time.Duration) http.Handler {
+	return withShutdownLateAnnotation(handler, shutdownInitiated, delayDuration, exemptIfHealthProbe, clockutils.RealClock{})
+}
+
+// WithStartupEarlyAnnotation annotates the request with an annotation keyed as
+// 'apiserver.k8s.io/startup' if the request arrives early (the server is not
+// fully initialized yet). It should be placed after (in order of execution)
+// the 'WithAuthentication' filter.
+func WithStartupEarlyAnnotation(handler http.Handler, hasBeenReady lifecycleEvent) http.Handler {
+	return withStartupEarlyAnnotation(handler, hasBeenReady, exemptIfHealthProbe)
+}
+
+func withShutdownLateAnnotation(handler http.Handler, shutdownInitiated lifecycleEvent, delayDuration time.Duration, shouldExemptFn shouldExemptFunc, clock clockutils.PassiveClock) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-shutdownInitiated.Signaled():
+		default:
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		if shouldExemptFn(req) {
+			handler.ServeHTTP(w, req)
+			return
+		}
+		shutdownInitiatedAt := shutdownInitiated.SignaledAt()
+		if shutdownInitiatedAt == nil {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		elapsedSince := clock.Since(*shutdownInitiatedAt)
+		// TODO: 80% is the threshold, if requests arrive after 80% of
+		//  shutdown-delay-duration elapses we annotate the request as late=true.
+		late := lateMsg(delayDuration, elapsedSince, 80)
+
+		// NOTE: some upstream unit tests have authentication disabled and will
+		//  fail if we require the requestor to be present in the request
+		//  context. Fixing those unit tests will increase the chance of merge
+		//  conflict during rebase.
+		// This also implies that this filter must be placed after (in order of
+		// execution) the 'WithAuthentication' filter.
+		self := "self="
+		if requestor, exists := request.UserFrom(req.Context()); exists && requestor != nil {
+			self = fmt.Sprintf("%s%t", self, requestor.GetName() == user.APIServerUser)
+		}
+
+		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/shutdown",
+			fmt.Sprintf("%s %s loopback=%t", late, self, isLoopback(req.RemoteAddr)))
+
+		handler.ServeHTTP(w, req)
+	})
+}
+
+func lateMsg(delayDuration, elapsedSince time.Duration, threshold float64) string {
+	if delayDuration == time.Duration(0) {
+		return fmt.Sprintf("elapsed=%s threshold= late=%t", elapsedSince.Round(time.Second).String(), true)
+	}
+
+	percentElapsed := (float64(elapsedSince) / float64(delayDuration)) * 100
+	return fmt.Sprintf("elapsed=%s threshold=%.2f%% late=%t",
+		elapsedSince.Round(time.Second).String(), percentElapsed, percentElapsed > threshold)
+}
+
+func withStartupEarlyAnnotation(handler http.Handler, hasBeenReady lifecycleEvent, shouldExemptFn shouldExemptFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-hasBeenReady.Signaled():
+			handler.ServeHTTP(w, req)
+			return
+		default:
+		}
+
+		// NOTE: some upstream unit tests have authentication disabled and will
+		//  fail if we require the requestor to be present in the request
+		//  context. Fixing those unit tests will increase the chance of merge
+		//  conflict during rebase.
+		// This also implies that this filter must be placed after (in order of
+		// execution) the 'WithAuthentication' filter.
+		self := "self="
+		if requestor, exists := request.UserFrom(req.Context()); exists && requestor != nil {
+			if requestor.GetName() == user.APIServerUser {
+				handler.ServeHTTP(w, req)
+				return
+			}
+			self = fmt.Sprintf("%s%t", self, false)
+		}
+
+		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/startup",
+			fmt.Sprintf("early=true %s loopback=%t", self, isLoopback(req.RemoteAddr)))
+
+		handler.ServeHTTP(w, req)
+	})
+}
+
+func isLoopback(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// if the address is missing a port, SplitHostPort will return an error
+		// with an empty host, and port value. For such an error, we should
+		// continue and try to parse the original address.
+		host = address
+	}
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	authenticationuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	utilsclock "k8s.io/utils/clock"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestWithShutdownLateAnnotation(t *testing.T) {
+	var (
+		shutdownDelayDuration     = 100 * time.Second
+		signaledAt                = time.Now()
+		elapsedAtWithingThreshold = signaledAt.Add(shutdownDelayDuration - 21*time.Second)
+		elapsedAtBeyondThreshold  = signaledAt.Add(shutdownDelayDuration - 19*time.Second)
+	)
+
+	tests := []struct {
+		name                    string
+		shutdownInitiated       func() lifecycleEvent
+		delayDuration           time.Duration
+		user                    authenticationuser.Info
+		clock                   func() utilsclock.PassiveClock
+		url                     string
+		remoteAddr              string
+		handlerInvoked          int
+		statusCodeExpected      int
+		annotationShouldContain string
+	}{
+		{
+			name: "shutdown is not initiated",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "shutdown initiated, health probes are not annotated",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			url:                "/readyz?verbos=1",
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		// use cases where the request will be annotated
+		{
+			name: "shutdown initiated, no user in request context",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "self= loopback=",
+		},
+		{
+			name: "shutdown initiated, self=true",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.APIServerUser},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "self=true",
+		},
+		{
+			name: "shutdown initiated, self=false",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "self=false",
+		},
+		{
+			name: "shutdown initiated, loopback=true",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:              "127.0.0.1:80",
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "loopback=true",
+		},
+		{
+			name: "shutdown initiated, loopback=false",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:              "www.foo.bar:80",
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "loopback=false",
+		},
+		{
+			name: "shutdown initiated, shutdown delay duration is zero",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			delayDuration: time.Duration(0),
+			clock: func() utilsclock.PassiveClock {
+				return clocktesting.NewFakeClock(elapsedAtWithingThreshold)
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "elapsed=1m19s threshold= late=true",
+		},
+		{
+			name: "shutdown initiated, within 80%",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			delayDuration: shutdownDelayDuration,
+			clock: func() utilsclock.PassiveClock {
+				return clocktesting.NewFakeClock(elapsedAtWithingThreshold)
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "elapsed=1m19s threshold=79.00% late=false self=false loopback=false",
+		},
+		{
+			name: "shutdown initiated, outside 80%",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel(), at: &signaledAt}
+			},
+			delayDuration: shutdownDelayDuration,
+			clock: func() utilsclock.PassiveClock {
+				return clocktesting.NewFakeClock(elapsedAtBeyondThreshold)
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "elapsed=1m21s threshold=81.00% late=true self=false loopback=false",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var handlerInvoked int
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				handlerInvoked++
+				w.WriteHeader(http.StatusOK)
+			})
+
+			event := test.shutdownInitiated()
+			var clock utilsclock.PassiveClock = utilsclock.RealClock{}
+			if test.clock != nil {
+				clock = test.clock()
+			}
+			target := withShutdownLateAnnotation(handler, event, test.delayDuration, exemptIfHealthProbe, clock)
+
+			url := "/api/v1/namespaces"
+			if test.url != "" {
+				url = test.url
+			}
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+
+			ctx := req.Context()
+			if test.user != nil {
+				ctx = apirequest.WithUser(ctx, test.user)
+			}
+			ctx = audit.WithAuditContext(ctx)
+			req = req.WithContext(ctx)
+
+			ac := audit.AuditContextFrom(req.Context())
+			if ac == nil {
+				t.Fatalf("expected audit context inside the request context")
+			}
+			ac.Event = &auditinternal.Event{
+				Level: auditinternal.LevelMetadata,
+			}
+
+			w := httptest.NewRecorder()
+			w.Code = 0
+			target.ServeHTTP(w, req)
+
+			if test.handlerInvoked != handlerInvoked {
+				t.Errorf("expected the handler to be invoked: %d timed, but got: %d", test.handlerInvoked, handlerInvoked)
+			}
+			if test.statusCodeExpected != w.Result().StatusCode {
+				t.Errorf("expected status code: %d, but got: %d", test.statusCodeExpected, w.Result().StatusCode)
+			}
+
+			key := "apiserver.k8s.io/shutdown"
+			switch {
+			case len(test.annotationShouldContain) == 0:
+				if valueGot, ok := ac.Event.Annotations[key]; ok {
+					t.Errorf("did not expect annotation to be added, but got: %s", valueGot)
+				}
+			default:
+				if valueGot, ok := ac.Event.Annotations[key]; !ok || !strings.Contains(valueGot, test.annotationShouldContain) {
+					t.Logf("got: %s", valueGot)
+					t.Errorf("expected annotation to match, diff: %s", cmp.Diff(test.annotationShouldContain, valueGot))
+				}
+			}
+		})
+	}
+}
+
+func TestWithStartupEarlyAnnotation(t *testing.T) {
+	tests := []struct {
+		name               string
+		readySignalFn      func() lifecycleEvent
+		user               authenticationuser.Info
+		remoteAddr         string
+		handlerInvoked     int
+		statusCodeExpected int
+		annotationExpected string
+	}{
+		{
+			name: "server is ready",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "server not ready, no user in request context",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+			annotationExpected: "early=true self= loopback=false",
+		},
+		{
+			name: "server not ready, self is true, not annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.APIServerUser},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "server not ready, self is false, request is annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+			annotationExpected: "early=true self=false loopback=false",
+		},
+		{
+			name: "server not ready, self is false, looback is true, request is annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:         "127.0.0.1:8080",
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+			annotationExpected: "early=true self=false loopback=true",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var handlerInvoked int
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				handlerInvoked++
+				w.WriteHeader(http.StatusOK)
+			})
+
+			event := test.readySignalFn()
+			target := WithStartupEarlyAnnotation(handler, event)
+
+			req, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+
+			ctx := req.Context()
+			if test.user != nil {
+				ctx = apirequest.WithUser(ctx, test.user)
+			}
+			ctx = audit.WithAuditContext(ctx)
+			req = req.WithContext(ctx)
+
+			ac := audit.AuditContextFrom(req.Context())
+			if ac == nil {
+				t.Fatalf("expected audit context inside the request context")
+			}
+			ac.Event = &auditinternal.Event{
+				Level: auditinternal.LevelMetadata,
+			}
+
+			w := httptest.NewRecorder()
+			w.Code = 0
+			target.ServeHTTP(w, req)
+
+			if test.handlerInvoked != handlerInvoked {
+				t.Errorf("expected the handler to be invoked: %d timed, but got: %d", test.handlerInvoked, handlerInvoked)
+			}
+			if test.statusCodeExpected != w.Result().StatusCode {
+				t.Errorf("expected status code: %d, but got: %d", test.statusCodeExpected, w.Result().StatusCode)
+			}
+
+			key := "apiserver.k8s.io/startup"
+			switch {
+			case len(test.annotationExpected) == 0:
+				if valueGot, ok := ac.Event.Annotations[key]; ok {
+					t.Errorf("did not expect annotation to be added, but got: %s", valueGot)
+				}
+			default:
+				if valueGot, ok := ac.Event.Annotations[key]; !ok || test.annotationExpected != valueGot {
+					t.Errorf("expected annotation: %s, but got: %s", test.annotationExpected, valueGot)
+				}
+			}
+		})
+	}
+}
+
+func TestIsLoopback(t *testing.T) {
+	tests := []struct {
+		address string
+		want    bool
+	}{
+		{
+			address: "www.foo.bar:80",
+			want:    false,
+		},
+		{
+			address: "www.foo.bar",
+			want:    false,
+		},
+		{
+			address: "127.0.0.1:8080",
+			want:    true,
+		},
+		{
+			address: "127.0.0.1",
+			want:    true,
+		},
+		{
+			address: "192.168.0.1",
+			want:    false,
+		},
+		// localhost does not work
+		{
+			address: "localhost:8080",
+			want:    false,
+		},
+		{
+			address: "localhost",
+			want:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.address, func(t *testing.T) {
+			if got := isLoopback(test.address); test.want != got {
+				t.Errorf("expected isLoopback to return: %t, but got: %t", test.want, got)
+			}
+		})
+	}
+}
+
+func TestExemptIfHealthProbe(t *testing.T) {
+	tests := []struct {
+		path   string
+		exempt bool
+	}{
+		{
+			path:   "/apis/v1/foo/bar",
+			exempt: false,
+		},
+		{
+			path:   "/readyz",
+			exempt: true,
+		},
+		{
+			path:   "http://foo.bar///healthz?verbose=1",
+			exempt: true,
+		},
+		{
+			path:   "/livez",
+			exempt: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, test.path, nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if got := exemptIfHealthProbe(req); test.exempt != got {
+				t.Errorf("expected exemptIfHealthProbe to return: %t, but got: %t", test.exempt, got)
+			}
+		})
+	}
+}
+
+type fakeLifecycleSignal struct {
+	ch <-chan struct{}
+	at *time.Time
+}
+
+func (s fakeLifecycleSignal) Name() string              { return "initiated" }
+func (s fakeLifecycleSignal) Signaled() <-chan struct{} { return s.ch }
+func (s fakeLifecycleSignal) SignaledAt() *time.Time    { return s.at }
+
+func newClosedChannel() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals.go
@@ -18,6 +18,10 @@ package server
 
 import (
 	"sync"
+	"sync/atomic"
+	"time"
+
+	utilsclock "k8s.io/utils/clock"
 )
 
 /*
@@ -100,6 +104,10 @@ type lifecycleSignal interface {
 
 	// Name returns the name of the signal, useful for logging.
 	Name() string
+
+	// SignaledAt returns the time the event was signaled. If SignaledAt is
+	// invoked before the event is signaled nil will be returned.
+	SignaledAt() *time.Time
 }
 
 // lifecycleSignals provides an abstraction of the events that
@@ -149,23 +157,25 @@ type lifecycleSignals struct {
 // newLifecycleSignals returns an instance of lifecycleSignals interface to be used
 // to coordinate lifecycle of the apiserver
 func newLifecycleSignals() lifecycleSignals {
+	clock := utilsclock.RealClock{}
 	return lifecycleSignals{
-		ShutdownInitiated:          newNamedChannelWrapper("ShutdownInitiated"),
-		AfterShutdownDelayDuration: newNamedChannelWrapper("AfterShutdownDelayDuration"),
-		PreShutdownHooksStopped:    newNamedChannelWrapper("PreShutdownHooksStopped"),
-		NotAcceptingNewRequest:     newNamedChannelWrapper("NotAcceptingNewRequest"),
-		InFlightRequestsDrained:    newNamedChannelWrapper("InFlightRequestsDrained"),
-		HTTPServerStoppedListening: newNamedChannelWrapper("HTTPServerStoppedListening"),
-		HasBeenReady:               newNamedChannelWrapper("HasBeenReady"),
-		MuxAndDiscoveryComplete:    newNamedChannelWrapper("MuxAndDiscoveryComplete"),
+		ShutdownInitiated:          newNamedChannelWrapper("ShutdownInitiated", clock),
+		AfterShutdownDelayDuration: newNamedChannelWrapper("AfterShutdownDelayDuration", clock),
+		PreShutdownHooksStopped:    newNamedChannelWrapper("PreShutdownHooksStopped", clock),
+		NotAcceptingNewRequest:     newNamedChannelWrapper("NotAcceptingNewRequest", clock),
+		InFlightRequestsDrained:    newNamedChannelWrapper("InFlightRequestsDrained", clock),
+		HTTPServerStoppedListening: newNamedChannelWrapper("HTTPServerStoppedListening", clock),
+		HasBeenReady:               newNamedChannelWrapper("HasBeenReady", clock),
+		MuxAndDiscoveryComplete:    newNamedChannelWrapper("MuxAndDiscoveryComplete", clock),
 	}
 }
 
-func newNamedChannelWrapper(name string) lifecycleSignal {
+func newNamedChannelWrapper(name string, clock utilsclock.PassiveClock) lifecycleSignal {
 	return &namedChannelWrapper{
-		name: name,
-		once: sync.Once{},
-		ch:   make(chan struct{}),
+		name:  name,
+		once:  sync.Once{},
+		ch:    make(chan struct{}),
+		clock: clock,
 	}
 }
 
@@ -173,10 +183,27 @@ type namedChannelWrapper struct {
 	name string
 	once sync.Once
 	ch   chan struct{}
+
+	clock      utilsclock.PassiveClock
+	signaledAt atomic.Value
 }
 
 func (e *namedChannelWrapper) Signal() {
 	e.once.Do(func() {
+		// set the signaledAt value first to support the expected use case:
+		//
+		//   <-s.Signaled()
+		//   ..
+		//   at := s.SignaledAt()
+		//
+		// we guarantee that at will never be nil after the event is signaled,
+		// it also implies that 'SignaledAt' if used independently outside of
+		// the above use case, it may return a valid non-empty time (due to
+		// the delay between setting signaledAt and closing the channel)
+		// even when the event has not signaled yet.
+		now := e.clock.Now()
+		e.signaledAt.Store(&now)
+
 		close(e.ch)
 	})
 }
@@ -187,4 +214,12 @@ func (e *namedChannelWrapper) Signaled() <-chan struct{} {
 
 func (e *namedChannelWrapper) Name() string {
 	return e.name
+}
+
+func (e *namedChannelWrapper) SignaledAt() *time.Time {
+	value := e.signaledAt.Load()
+	if value == nil {
+		return nil
+	}
+	return value.(*time.Time)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestLifecycleSignal(t *testing.T) {
+	signalName := "mysignal"
+	signaledAt := time.Now()
+	clock := clocktesting.NewFakeClock(signaledAt)
+	s := newNamedChannelWrapper(signalName, clock)
+
+	if s.Name() != signalName {
+		t.Errorf("expected signal name to match: %q, but got: %q", signalName, s.Name())
+	}
+	if at := s.SignaledAt(); at != nil {
+		t.Errorf("expected SignaledAt to return nil, but got: %v", *at)
+	}
+	select {
+	case <-s.Signaled():
+		t.Errorf("expected the lifecycle event to not be signaled initially")
+	default:
+	}
+
+	s.Signal()
+
+	if at := s.SignaledAt(); at == nil || !at.Equal(signaledAt) {
+		t.Errorf("expected SignaledAt to return %v, but got: %v", signaledAt, at)
+	}
+	select {
+	case <-s.Signaled():
+	default:
+		t.Errorf("expected the lifecycle event to be signaled")
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/patch_genericapiserver.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -27,7 +26,6 @@ import (
 	"go.uber.org/atomic"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
@@ -82,10 +80,8 @@ func WithLateConnectionFilter(handler http.Handler) http.Handler {
 		if late {
 			if pth := "/" + strings.TrimLeft(r.URL.Path, "/"); pth != "/readyz" && pth != "/healthz" && pth != "/livez" {
 				if isLocal(r) {
-					audit.AddAuditAnnotation(r.Context(), "openshift.io/during-graceful", fmt.Sprintf("loopback=true,%v,readyz=false", r.URL.Host))
 					klog.V(4).Infof("Loopback request to %q (user agent %q) through connection created very late in the graceful termination process (more than 80%% has passed). This client probably does not watch /readyz and might get failures when termination is over.", r.URL.Path, r.UserAgent())
 				} else {
-					audit.AddAuditAnnotation(r.Context(), "openshift.io/during-graceful", fmt.Sprintf("loopback=false,%v,readyz=false", r.URL.Host))
 					klog.Warningf("Request to %q (source IP %s, user agent %q) through a connection created very late in the graceful termination process (more than 80%% has passed), possibly a sign for a broken load balancer setup.", r.URL.Path, r.RemoteAddr, r.UserAgent())
 
 					// create only one event to avoid event spam.
@@ -122,11 +118,9 @@ func WithNonReadyRequestLogging(handler http.Handler, hasBeenReadySignal lifecyc
 		if pth := "/" + strings.TrimLeft(r.URL.Path, "/"); pth != "/readyz" && pth != "/healthz" && pth != "/livez" {
 			if isLocal(r) {
 				if !isKubeApiserverLoopBack(r) {
-					audit.AddAuditAnnotation(r.Context(), "openshift.io/unready", fmt.Sprintf("loopback=true,%v,readyz=false", r.URL.Host))
 					klog.V(2).Infof("Loopback request to %q (user agent %q) before server is ready. This client probably does not watch /readyz and might get inconsistent answers.", r.URL.Path, r.UserAgent())
 				}
 			} else {
-				audit.AddAuditAnnotation(r.Context(), "openshift.io/unready", fmt.Sprintf("loopback=false,%v,readyz=false", r.URL.Host))
 				klog.Warningf("Request to %q (source IP %s, user agent %q) before server is ready, possibly a sign for a broken load balancer setup.", r.URL.Path, r.RemoteAddr, r.UserAgent())
 
 				// create only one event to avoid event spam.


### PR DESCRIPTION


#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
