### PR TITLE
UPSTREAM: 115484: Don't explicitly set image version in tests

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -83,7 +83,6 @@ var _ = SIGDescribe("Security Context", func() {
 			gidDefinedInImage := int64(50000)
 			supplementalGroup := int64(60000)
 			agnhost := imageutils.GetConfig(imageutils.Agnhost)
-			(&agnhost).SetVersion("2.43")
 			pod := scTestPod(false, false)
 			pod.Spec.Containers[0].Image = agnhost.GetE2EImage()
 			pod.Spec.Containers[0].Command = []string{"id", "-G"}


### PR DESCRIPTION
Image versions are already explicitly set in our manifests configuration, so tests should not be setting these values to ensure we're using the same versions across the board.

/assign @rphillips @sanchezl 

/hold
to wait for upstream to merge as well 