### PR TITLE
[WIP] UPSTREAM: <carry>: Drop "Override termination grace period on annotation"

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -999,11 +999,6 @@ func setTerminationGracePeriod(pod *v1.Pod, containerSpec *v1.Container, contain
 				return *containerSpec.LivenessProbe.TerminationGracePeriodSeconds
 			}
 		}
-		if annotationGracePeriod, found := pod.ObjectMeta.Annotations["unsupported.do-not-use.openshift.io/override-liveness-grace-period-seconds"]; found {
-			if val, err := strconv.ParseUint(annotationGracePeriod, 10, 64); err == nil && val > 0 {
-				return int64(val)
-			}
-		}
 		return *pod.Spec.TerminationGracePeriodSeconds
 	}
 	return gracePeriod


### PR DESCRIPTION
Now that https://issues.redhat.com/browse/OCPBUGS-4703 is fixed, we can try to revert the commit that introduced `unsupported.do-not-use.openshift.io/override-liveness-grace-period-secods` annotation. This will be permantely dropped during 1.27 bump, for now I want to check if this works as expected. 

/hold
to prevent accidental merge

This reverts commit af08f301f2e96382ef84c6cc722b94123ed26c91.

