### PR TITLE
UPSTREAM: 115863: Remove global framework variable

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1289,7 +1289,7 @@ func (v *vSphereDriver) PrepareTest(f *framework.Framework) *storageframework.Pe
 	ginkgo.DeferCleanup(func() {
 		// Driver Cleanup function
 		// Logout each vSphere client connection to prevent session leakage
-		nodes := vspheretest.GetReadySchedulableNodeInfos()
+		nodes := vspheretest.GetReadySchedulableNodeInfos(f.ClientSet)
 		for _, node := range nodes {
 			if node.VSphere.Client != nil {
 				node.VSphere.Client.Logout(context.TODO())
@@ -1306,7 +1306,7 @@ func (v *vSphereDriver) PrepareTest(f *framework.Framework) *storageframework.Pe
 func (v *vSphereDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {
 	f := config.Framework
 	vspheretest.Bootstrap(f)
-	nodeInfo := vspheretest.GetReadySchedulableRandomNodeInfo()
+	nodeInfo := vspheretest.GetReadySchedulableRandomNodeInfo(f.ClientSet)
 	volumePath, err := nodeInfo.VSphere.CreateVolume(&vspheretest.VolumeOptions{}, nodeInfo.DataCenterRef)
 	framework.ExpectNoError(err)
 	return &vSphereVolume{

--- a/test/e2e/storage/vsphere/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap.go
@@ -26,21 +26,21 @@ import (
 
 var once sync.Once
 var waiting = make(chan bool)
-var f *framework.Framework
 
 // Bootstrap takes care of initializing necessary test context for vSphere tests
 func Bootstrap(fw *framework.Framework) {
 	done := make(chan bool)
-	f = fw
 	go func() {
-		once.Do(bootstrapOnce)
+		once.Do(func() {
+			bootstrapOnce(fw)
+		})
 		<-waiting
 		done <- true
 	}()
 	<-done
 }
 
-func bootstrapOnce() {
+func bootstrapOnce(f *framework.Framework) {
 	// 1. Read vSphere conf and get VSphere instances
 	vsphereInstances, err := GetVSphereInstances()
 	if err != nil {

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -70,7 +70,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere [Feature:vsphere]", func() 
 		clientPod = nil
 		pvc = nil
 		pv = nil
-		nodeInfo = GetReadySchedulableRandomNodeInfo()
+		nodeInfo = GetReadySchedulableRandomNodeInfo(c)
 
 		volLabel = labels.Set{e2epv.VolumeSelectorKey: ns}
 		selector = metav1.SetAsLabelSelector(volLabel)

--- a/test/e2e/storage/vsphere/pv_reclaimpolicy.go
+++ b/test/e2e/storage/vsphere/pv_reclaimpolicy.go
@@ -57,7 +57,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:ReclaimPo
 		ginkgo.BeforeEach(func() {
 			e2eskipper.SkipUnlessProviderIs("vsphere")
 			Bootstrap(f)
-			nodeInfo = GetReadySchedulableRandomNodeInfo()
+			nodeInfo = GetReadySchedulableRandomNodeInfo(c)
 			pv = nil
 			pvc = nil
 			volumePath = ""
@@ -84,7 +84,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:ReclaimPo
 			volumePath, pv, pvc, err = testSetupVSpherePersistentVolumeReclaim(c, nodeInfo, ns, v1.PersistentVolumeReclaimDelete)
 			framework.ExpectNoError(err)
 
-			deletePVCAfterBind(c, ns, pvc, pv)
+			deletePVCAfterBind(c, ns, pvc, pv, f.Timeouts)
 			pvc = nil
 
 			ginkgo.By("verify pv is deleted")
@@ -244,11 +244,11 @@ func testCleanupVSpherePersistentVolumeReclaim(c clientset.Interface, nodeInfo *
 }
 
 // func to wait until PV and PVC bind and once bind completes, delete the PVC
-func deletePVCAfterBind(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
+func deletePVCAfterBind(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, timeouts *framework.TimeoutContext) {
 	var err error
 
 	ginkgo.By("wait for the pv and pvc to bind")
-	framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, f.Timeouts, ns, pv, pvc))
+	framework.ExpectNoError(e2epv.WaitOnPVandPVC(c, timeouts, ns, pv, pvc))
 
 	ginkgo.By("delete pvc")
 	framework.ExpectNoError(e2epv.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)

--- a/test/e2e/storage/vsphere/pvc_label_selector.go
+++ b/test/e2e/storage/vsphere/pvc_label_selector.go
@@ -68,7 +68,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:LabelSele
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		Bootstrap(f)
-		nodeInfo = GetReadySchedulableRandomNodeInfo()
+		nodeInfo = GetReadySchedulableRandomNodeInfo(c)
 		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 		ssdlabels = make(map[string]string)
 		ssdlabels["volume-type"] = "ssd"

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -752,8 +752,8 @@ func getUUIDFromProviderID(providerID string) string {
 }
 
 // GetReadySchedulableNodeInfos returns NodeInfo objects for all nodes with Ready and schedulable state
-func GetReadySchedulableNodeInfos() []*NodeInfo {
-	nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+func GetReadySchedulableNodeInfos(c clientset.Interface) []*NodeInfo {
+	nodeList, err := e2enode.GetReadySchedulableNodes(c)
 	framework.ExpectNoError(err)
 	var nodesInfo []*NodeInfo
 	for _, node := range nodeList.Items {
@@ -768,8 +768,8 @@ func GetReadySchedulableNodeInfos() []*NodeInfo {
 // GetReadySchedulableRandomNodeInfo returns NodeInfo object for one of the Ready and Schedulable Node.
 // if multiple nodes are present with Ready and Schedulable state then one of the Node is selected randomly
 // and it's associated NodeInfo object is returned.
-func GetReadySchedulableRandomNodeInfo() *NodeInfo {
-	nodesInfo := GetReadySchedulableNodeInfos()
+func GetReadySchedulableRandomNodeInfo(c clientset.Interface) *NodeInfo {
+	nodesInfo := GetReadySchedulableNodeInfos(c)
 	gomega.Expect(nodesInfo).NotTo(gomega.BeEmpty())
 	return nodesInfo[rand.Int()%len(nodesInfo)]
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
@@ -57,7 +57,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		nodeInfo = GetReadySchedulableRandomNodeInfo()
+		nodeInfo = GetReadySchedulableRandomNodeInfo(client)
 		scParameters = make(map[string]string)
 		clusterDatastore = GetAndExpectStringEnvVar(VCPClusterDatastore)
 	})

--- a/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
@@ -74,7 +74,7 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		nodeName = GetReadySchedulableRandomNodeInfo().Name
+		nodeName = GetReadySchedulableRandomNodeInfo(client).Name
 		nodeLabelValue = "vsphere_e2e_" + string(uuid.NewUUID())
 		nodeKeyValueLabel = map[string]string{NodeLabelKey: nodeLabelValue}
 		e2enode.AddOrUpdateLabelOnNode(client, nodeName, NodeLabelKey, nodeLabelValue)

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -80,7 +80,7 @@ var _ = utils.SIGDescribe("Volume FStype [Feature:vsphere]", func() {
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		gomega.Expect(GetReadySchedulableNodeInfos()).NotTo(gomega.BeEmpty())
+		gomega.Expect(GetReadySchedulableNodeInfos(client)).NotTo(gomega.BeEmpty())
 	})
 
 	ginkgo.It("verify fstype - ext3 formatted volume", func() {

--- a/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
@@ -70,7 +70,7 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		gomega.Expect(GetReadySchedulableNodeInfos()).NotTo(gomega.BeEmpty())
+		gomega.Expect(GetReadySchedulableNodeInfos(client)).NotTo(gomega.BeEmpty())
 		if scale := os.Getenv("VOLUME_OPS_SCALE"); scale != "" {
 			volumeOpsScale, err = strconv.Atoi(scale)
 			framework.ExpectNoError(err)


### PR DESCRIPTION
`f framework.Framework` does not need to be global, it's used only on a few
places.

This fixes vSphereDriver.PrepareTest() in in_tree.go that schedules
ginkgo.DeferCleanup() that uses the global `f` variable, but its value is not
valid at the time of ginkgo cleanup.
