### PR TITLE
OCPBUGS-7359: Azure: move to kube-proxy LB probes, don't detach masters when unready

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -858,7 +858,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		case hasExcludeBalancerLabel:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
 
-		case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
+		case !isNodeReady(newNode) && !isNodeMaster(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
 			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
 			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
 			// excluded from load balancers regardless of their state, so as to reduce the number of
@@ -1002,6 +1002,17 @@ func isNodeReady(node *v1.Node) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func isNodeMaster(node *v1.Node) bool {
+	labels := node.GetLabels()
+	for l := range labels {
+		if l == "node-role.kubernetes.io/master" || l == "node-role.kubernetes.io/control-plane" {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -123,6 +123,12 @@ const (
 	serviceUsingDNSKey = "kubernetes-dns-label-service"
 
 	defaultLoadBalancerSourceRanges = "0.0.0.0/0"
+
+	// NOTE: Please keep the following port in sync with ProxyHealthzPort in k/k pkg/cluster/ports/ports.go
+	// ports.ProxyHealthzPort was not used here to avoid dependencies to k8s.io/kubernetes in the
+	// GCE cloud provider which is required as part of the out-of-tree cloud provider efforts.
+	// TODO: use a shared constant once ports in pkg/cluster/ports are in a common external repo.
+	lbNodesHealthCheckPort = 10256
 )
 
 // GetLoadBalancer returns whether the specified load balancer and its components exist, and
@@ -1642,7 +1648,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 		lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
 		klog.V(2).Infof("reconcileLoadBalancerRule lb name (%s) rule name (%s)", lbName, lbRuleName)
 
-		transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(port.Protocol)
+		transportProto, _, _, err := getProtocolsFromKubernetesProtocol(port.Protocol)
 		if err != nil {
 			return expectedProbes, expectedRules, err
 		}
@@ -1670,24 +1676,34 @@ func (az *Cloud) reconcileLoadBalancerRule(
 				},
 			})
 		} else if port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP {
-			// we only add the expected probe if we're doing TCP
-			if probeProtocol == "" {
-				probeProtocol = string(*probeProto)
-			}
 			var actualPath *string
+			probePort := port.NodePort
+
+			if probeProtocol == "" {
+				// If no protocol is specified we want to fall back to HTTP
+				// as we want to leverage kube-proxy's HTTP health endpoint
+				// unless otherwise specified.
+				probeProtocol = string(network.ProbeProtocolHTTP)
+			}
+
 			if !strings.EqualFold(probeProtocol, string(network.ProbeProtocolTCP)) {
+				// In case this is not TCP, instead of using NodePort, we want to probe against
+				// kube-proxy's HTTP health endpoint which, unless otherwise specified,
+				// is available at port lbNodesHealthCheckPort and /healthz path.
+				probePort = lbNodesHealthCheckPort
 				if requestPath != "" {
 					actualPath = to.StringPtr(requestPath)
 				} else {
 					actualPath = to.StringPtr("/healthz")
 				}
 			}
+
 			expectedProbes = append(expectedProbes, network.Probe{
 				Name: &lbRuleName,
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
 					Protocol:          network.ProbeProtocol(probeProtocol),
 					RequestPath:       actualPath,
-					Port:              to.Int32Ptr(port.NodePort),
+					Port:              to.Int32Ptr(probePort),
 					IntervalInSeconds: to.Int32Ptr(5),
 					NumberOfProbes:    to.Int32Ptr(2),
 				},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1675,7 +1675,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "true"}, false, 80),
 			loadBalancerSku: "basic",
 			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthz", lbNodesHealthCheckPort),
 			expectedRules:   getDefaultTestRules(false),
 		},
 		{
@@ -1683,7 +1683,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "True"}, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthz", lbNodesHealthCheckPort),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -1691,7 +1691,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthz", lbNodesHealthCheckPort),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -1701,7 +1701,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			wantLb:          true,
 			probeProtocol:   "http",
 			probePath:       "/healthy",
-			expectedProbes:  getDefaultTestProbes("http", "/healthy"),
+			expectedProbes:  getDefaultTestProbes("http", "/healthy", lbNodesHealthCheckPort),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -1712,7 +1712,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthz", lbNodesHealthCheckPort),
 			expectedRules:   getHATestRules(true),
 		},
 		{
@@ -1723,7 +1723,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80, 8080),
 			loadBalancerSku: "standard",
 			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthz", lbNodesHealthCheckPort),
 			expectedRules:   getHATestRules(true),
 		},
 		{
@@ -1732,7 +1732,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			loadBalancerSku: "standard",
 			wantLb:          true,
 			probeProtocol:   "Tcp",
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedProbes:  getDefaultTestProbes("Tcp", "", 10080),
 			expectedRules:   getDefaultTestRules(true),
 		},
 	}
@@ -1759,13 +1759,13 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 	}
 }
 
-func getDefaultTestProbes(protocol, path string) []network.Probe {
+func getDefaultTestProbes(protocol, path string, port int32) []network.Probe {
 	expectedProbes := []network.Probe{
 		{
 			Name: to.StringPtr("atest1-TCP-80"),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
 				Protocol:          network.ProbeProtocol(protocol),
-				Port:              to.Int32Ptr(10080),
+				Port:              to.Int32Ptr(port),
 				IntervalInSeconds: to.Int32Ptr(5),
 				NumberOfProbes:    to.Int32Ptr(2),
 			},
@@ -1970,6 +1970,19 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			},
 		},
 	}
+	expectedLb1.Probes = &[]network.Probe{
+		{
+			Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port:              to.Int32Ptr(lbNodesHealthCheckPort),
+				RequestPath:       to.StringPtr("/healthz"),
+				Protocol:          network.ProbeProtocol(network.ProtocolHTTP),
+				IntervalInSeconds: to.Int32Ptr(5),
+				NumberOfProbes:    to.Int32Ptr(2),
+			},
+		},
+	}
 
 	service4 := getTestService("service1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "true"}, false, 80)
 	existingSLB := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
@@ -2022,6 +2035,19 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			ID:   to.StringPtr("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+			},
+		},
+	}
+	expectedSLb.Probes = &[]network.Probe{
+		{
+			Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port:              to.Int32Ptr(lbNodesHealthCheckPort),
+				RequestPath:       to.StringPtr("/healthz"),
+				Protocol:          network.ProbeProtocol(network.ProtocolHTTP),
+				IntervalInSeconds: to.Int32Ptr(5),
+				NumberOfProbes:    to.Int32Ptr(2),
 			},
 		},
 	}
@@ -2079,6 +2105,19 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			ID:   to.StringPtr("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+			},
+		},
+	}
+	expectedSLb5.Probes = &[]network.Probe{
+		{
+			Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port:              to.Int32Ptr(lbNodesHealthCheckPort),
+				RequestPath:       to.StringPtr("/healthz"),
+				Protocol:          network.ProbeProtocol(network.ProtocolHTTP),
+				IntervalInSeconds: to.Int32Ptr(5),
+				NumberOfProbes:    to.Int32Ptr(2),
 			},
 		},
 	}
@@ -2155,8 +2194,9 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			Name: to.StringPtr("aservice1-" + string(service8.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service7.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port:              to.Int32Ptr(10080),
-				Protocol:          network.ProbeProtocolTCP,
+				Port:              to.Int32Ptr(lbNodesHealthCheckPort),
+				Protocol:          network.ProbeProtocolHTTP,
+				RequestPath:       to.StringPtr("/healthz"),
 				IntervalInSeconds: to.Int32Ptr(5),
 				NumberOfProbes:    to.Int32Ptr(2),
 			},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1646,7 +1646,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			} else {
 				for _, actualProbe := range *loadBalancer.Probes {
 					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
-						*actualProbe.Port == wantedRule.NodePort {
+						*actualProbe.Port == lbNodesHealthCheckPort {
 						foundProbe = true
 						break
 					}


### PR DESCRIPTION
This PR brings in patches to mitigate upstream issues discussed in https://docs.google.com/document/d/128JjzUZs8kaLvcCFkCmiMg16cwzVE6Gslhefa0naeOw
And tracked by: https://issues.redhat.com/browse/OCPBUGS-7359

It:
- [legacy-cloud-providers: azure: use kube-proxy based health probes by default](https://github.com/openshift/kubernetes/commit/e4fdbdb92cd04da0a98c9807b352bfdf930f123b)
- [legacy-cloud-providers: azure: do not detach masters from lb when unready](https://github.com/openshift/kubernetes/commit/0b381c1ec30710a0214fca4c4cabc4e7d11caf90)

TODO:
- [x] update tests
- [x] do we need to merge this in 4.14 and then backport to 4.13? Or can we directly target 4.13? We don't need it in 4.14 as there we will use out of tree Azure CCM, which will contain a similar fix, which is being proposed [here](https://github.com/openshift/cloud-provider-azure/pull/60).
  - base now changed to release-4.13 directly 