### PR TITLE
UPSTREAM: <carry>: Revert "Wait for default service account in node authorizer test"

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -52,8 +52,6 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		nodeIPs := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)
 		framework.ExpectNotEqual(len(nodeIPs), 0)
 
-		framework.ExpectNoError(framework.WaitForDefaultServiceAccountInNamespace(f.ClientSet, ns))
-
 		// make sure ServiceAccount admission controller is enabled, so secret generation on SA creation works
 		saName := "default"
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(context.TODO(), saName, metav1.GetOptions{})

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -56,9 +56,6 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		nodeName = nodeList.Items[0].Name
 		asUser = nodeNamePrefix + nodeName
 		saName := "default"
-
-		framework.ExpectNoError(framework.WaitForDefaultServiceAccountInNamespace(f.ClientSet, ns))
-
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(context.TODO(), saName, metav1.GetOptions{})
 		framework.ExpectNotEqual(len(sa.Secrets), 0)
 		framework.ExpectNoError(err, "failed to retrieve service account (%s:%s)", ns, saName)


### PR DESCRIPTION
This reverts commit d3dd288e8c1b38c7cba9aa9081c08df4381e351a (https://github.com/openshift/kubernetes/pull/1398).

I'm seeing this fail pretty consistently in CI https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-kubernetes-release-4.10-k8s-e2e-gcp, whereas the origin version of this tests is rather working just fine, and it's w/o this carry. 