### PR TITLE
OCPBUGS-5943: UPSTREAM: <carry>: endpointslice: Reduce event spam

### DIFF
--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -53,6 +53,9 @@ type reconciler struct {
 	topologyCache *topologycache.TopologyCache
 	// eventRecorder allows reconciler to record and publish events.
 	eventRecorder record.EventRecorder
+	// topologyHintsRecorder allows reconciler to record and publish events
+	// related to TopologyAwareHints with deduplication of events.
+	topologyHintsRecorder record.EventRecorder
 }
 
 // endpointMeta includes the attributes we group slices on, this type helps with
@@ -284,7 +287,7 @@ func (r *reconciler) reconcileByAddressType(service *corev1.Service, pods []*cor
 		errs = append(errs, err)
 	}
 	for _, event := range events {
-		r.eventRecorder.Event(service, event.EventType, event.Reason, event.Message)
+		r.topologyHintsRecorder.Event(service, event.EventType, event.Reason, event.Message)
 	}
 	return utilerrors.NewAggregate(errs)
 

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -1918,12 +1918,13 @@ func newReconciler(client *fake.Clientset, nodes []*corev1.Node, maxEndpointsPer
 	}
 
 	return &reconciler{
-		client:               client,
-		nodeLister:           corelisters.NewNodeLister(indexer),
-		maxEndpointsPerSlice: maxEndpointsPerSlice,
-		endpointSliceTracker: endpointsliceutil.NewEndpointSliceTracker(),
-		metricsCache:         metrics.NewCache(maxEndpointsPerSlice),
-		eventRecorder:        eventRecorder,
+		client:                client,
+		nodeLister:            corelisters.NewNodeLister(indexer),
+		maxEndpointsPerSlice:  maxEndpointsPerSlice,
+		endpointSliceTracker:  endpointsliceutil.NewEndpointSliceTracker(),
+		metricsCache:          metrics.NewCache(maxEndpointsPerSlice),
+		eventRecorder:         eventRecorder,
+		topologyHintsRecorder: eventRecorder,
 	}
 }
 


### PR DESCRIPTION
Add rate-limiting to the endpointslice controller's event broadcaster for events related to the TopologyAwareHints feature to reduce event spam.

Kubernetes 1.26 [added logic](https://github.com/kubernetes/kubernetes/commit/4faede03fa4a124ef9b91736eec313a31951f3b5) to publish events for services that are annotated to enable [the TopologyAwareHints feature](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/) if the feature cannot be enabled on the cluster.  The controller emits an event every time it reconciles such a service on such a cluster, resulting in many repeated events.  This commit adds rate-limiting to reduce the amount of duplicate events for TopologyAwareHints.

* `pkg/controller/endpointslice/endpointslice_controller.go` (`topologyHintsEventQPS`, `topologyHintsEventBurstSize`): New consts.
(`topologyHintsEventKeyFunc`): New function.  This is an `EventAggregatorKeyFunc` that is like the default one, `EventAggregatorByReasonFunc`, except that it doesn't group together two events that differ only in the message.
(`NewController`): Use `topologyHintsEventQPS`, `topologyHintsEventBurstSize`, and `topologyHintsEventKeyFunc` to configure an event recorder with stricter rate-limiting and deduplication than the default event recorder, and configure the reconciler to use this event recorder for events related to the TopologyAwareHints feature.
(`Controller`): Add `topologyHintsRecorder` field.
* `pkg/controller/endpointslice/reconciler.go` (`reconciler`): Add `topologyHintsRecorder` field.
(`reconcileByAddressType`): Use `topologyHintsRecorder`.
* `pkg/controller/endpointslice/reconciler_test.go` (`newReconciler`): Set `topologyHintsRecorder` on the reconciler.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/king bug
/kind regression
/kind failing-test

#### What this PR does / why we need it:

Kubernetes 1.26 introduced a change that causes the "events should not repeat pathologically" test to fail.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-5943.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Duplicate events from the endpointslice controller are suppressed to mitigate spam related to the Topology-Aware Hints feature.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
