### PR TITLE
UPSTREAM: <carry>: add shutdown annotation to response header

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
@@ -119,10 +119,11 @@ func withShutdownLateAnnotation(handler http.Handler, shutdownInitiated lifecycl
 			self = fmt.Sprintf("%s%t", self, requestor.GetName() == user.APIServerUser)
 		}
 
-		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/shutdown",
-			fmt.Sprintf("%s %s loopback=%t", late, self, isLoopback(req.RemoteAddr)))
+		message := fmt.Sprintf("%s %s loopback=%t", late, self, isLoopback(req.RemoteAddr))
+		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/shutdown", message)
 
 		handler.ServeHTTP(w, req)
+		w.Header().Set("X-OpenShift-Shutdown", message)
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
@@ -230,6 +230,9 @@ func TestWithShutdownLateAnnotation(t *testing.T) {
 					t.Logf("got: %s", valueGot)
 					t.Errorf("expected annotation to match, diff: %s", cmp.Diff(test.annotationShouldContain, valueGot))
 				}
+				if header := w.Header().Get("X-OpenShift-Shutdown"); !strings.Contains(header, test.annotationShouldContain) {
+					t.Errorf("expected response header to match, diff: %s", cmp.Diff(test.annotationShouldContain, header))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The disruption test can inspect the response header immediately after receiving a response from the server, no need to gather and analyze audit logs after the test job completes. Also, requests that arrive after shutdown-delay duration are not audited

The disruption test that will utilize this is here: https://github.com/openshift/origin/pull/27838 
This is intended for CI only. 

If it is useful we will combine this with the following carry:
https://github.com/openshift/kubernetes/commit/20caad91a3f995e7ac7396854ba3c448da700088: UPSTREAM: 115328: annotate early and late requests

Also, we can emit the response header only for those requests coming from the disruption test (we can identify these via their user-agent)