### PR TITLE
OCPBUGS-7268: Extractor more fixes 4.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/opencontainers/runc v1.1.4
 	github.com/opencontainers/selinux v1.10.0
 	github.com/openshift/api v0.0.0-20230208193339-068b2ae5534f
-	github.com/openshift/apiserver-library-go v0.0.0-20230120221150-cefee9e0162b
+	github.com/openshift/apiserver-library-go v0.0.0-20230411124846-9fe2aa032a6f
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
 	github.com/openshift/library-go v0.0.0-20230222090221-582055a1d5c4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK9
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift/api v0.0.0-20230208193339-068b2ae5534f h1:+GaTEfR8gYzh64fdlRKLYZLwt5p4wQd2mdnvkhFDa8k=
 github.com/openshift/api v0.0.0-20230208193339-068b2ae5534f/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
-github.com/openshift/apiserver-library-go v0.0.0-20230120221150-cefee9e0162b h1:1AeKPWFTSSSqSl0VYmwnaOuxw2kExQgJ6pjuC4XV33A=
-github.com/openshift/apiserver-library-go v0.0.0-20230120221150-cefee9e0162b/go.mod h1:FmOGJTf5L1X9LiqnsNDwKJyt5ycUNxnNqpxs0rgylTc=
+github.com/openshift/apiserver-library-go v0.0.0-20230411124846-9fe2aa032a6f h1:rcaCMJa6vCtX/4orBfonBz2Z2zjdlJzDOzxwhlcq10U=
+github.com/openshift/apiserver-library-go v0.0.0-20230411124846-9fe2aa032a6f/go.mod h1:pI5W5+O/b0A7qOAXuLLCQqQjoCcQoEPsoBNoFfScvUQ=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
 github.com/openshift/library-go v0.0.0-20230222090221-582055a1d5c4 h1:B9e1Sga7Q6iSI1YgzLgfABo+LDET7HZngJ+tKlrwVSk=

--- a/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
+++ b/plugin/pkg/admission/security/podsecurity/patch_podspecextractor.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/apis/core"
 	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	saadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	podsecurityadmission "k8s.io/pod-security-admission/admission"
 )
 
@@ -68,6 +69,9 @@ func (s *SCCMutatingPodSpecExtractor) ExtractPodSpec(obj runtime.Object) (*metav
 	}
 	if len(pod.Name) == 0 {
 		pod.Name = "pod-for-container-named-" + objectMeta.GetName()
+	}
+	if len(pod.Spec.ServiceAccountName) == 0 {
+		pod.Spec.ServiceAccountName = saadmission.DefaultServiceAccountName
 	}
 	internalPod := &core.Pod{}
 	if err := v1.Convert_v1_Pod_To_core_Pod(pod, internalPod, nil); err != nil {

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching/patched_sc_accessors.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching/patched_sc_accessors.go
@@ -1,0 +1,471 @@
+/*
+ * This file is a copy of k8s.io/kubernetes/pkg/securitycontext/accessors.go that
+ * contains the patch from https://github.com/kubernetes/kubernetes/pull/115968
+ * that only appears in kube 1.27.
+ * FIXME: Remove this file when OpenShift users kube 1.27 as its base.
+ */
+
+package sccmatching
+
+import (
+	"reflect"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/securitycontext"
+)
+
+type SecccompProfileAccessor interface {
+	SeccompProfile() *api.SeccompProfile
+}
+
+type SeccompProfileMutator interface {
+	SetSeccompProfile(*api.SeccompProfile)
+}
+
+type PatchedPodSecurityContextAccessor interface {
+	securitycontext.PodSecurityContextAccessor
+	SecccompProfileAccessor
+}
+
+type PatchedPodSecurityContextMutator interface {
+	securitycontext.PodSecurityContextMutator
+	SecccompProfileAccessor
+	SeccompProfileMutator
+}
+
+// NewPodSecurityContextAccessor returns an accessor for the given pod security context.
+// May be initialized with a nil PodSecurityContext.
+func NewPodSecurityContextAccessor(podSC *api.PodSecurityContext) PatchedPodSecurityContextAccessor {
+	return &podSecurityContextWrapper{podSC: podSC}
+}
+
+// NewPodSecurityContextMutator returns a mutator for the given pod security context.
+// May be initialized with a nil PodSecurityContext.
+func NewPodSecurityContextMutator(podSC *api.PodSecurityContext) PatchedPodSecurityContextMutator {
+	return &podSecurityContextWrapper{podSC: podSC}
+}
+
+type podSecurityContextWrapper struct {
+	podSC *api.PodSecurityContext
+}
+
+func (w *podSecurityContextWrapper) PodSecurityContext() *api.PodSecurityContext {
+	return w.podSC
+}
+
+func (w *podSecurityContextWrapper) ensurePodSC() {
+	if w.podSC == nil {
+		w.podSC = &api.PodSecurityContext{}
+	}
+}
+
+func (w *podSecurityContextWrapper) HostNetwork() bool {
+	if w.podSC == nil {
+		return false
+	}
+	return w.podSC.HostNetwork
+}
+func (w *podSecurityContextWrapper) SetHostNetwork(v bool) {
+	if w.podSC == nil && v == false {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.HostNetwork = v
+}
+func (w *podSecurityContextWrapper) HostPID() bool {
+	if w.podSC == nil {
+		return false
+	}
+	return w.podSC.HostPID
+}
+func (w *podSecurityContextWrapper) SetHostPID(v bool) {
+	if w.podSC == nil && v == false {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.HostPID = v
+}
+func (w *podSecurityContextWrapper) HostIPC() bool {
+	if w.podSC == nil {
+		return false
+	}
+	return w.podSC.HostIPC
+}
+func (w *podSecurityContextWrapper) SetHostIPC(v bool) {
+	if w.podSC == nil && v == false {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.HostIPC = v
+}
+func (w *podSecurityContextWrapper) SELinuxOptions() *api.SELinuxOptions {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.SELinuxOptions
+}
+func (w *podSecurityContextWrapper) SetSELinuxOptions(v *api.SELinuxOptions) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.SELinuxOptions = v
+}
+func (w *podSecurityContextWrapper) RunAsUser() *int64 {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.RunAsUser
+}
+func (w *podSecurityContextWrapper) SetRunAsUser(v *int64) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.RunAsUser = v
+}
+func (w *podSecurityContextWrapper) RunAsGroup() *int64 {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.RunAsGroup
+}
+func (w *podSecurityContextWrapper) SetRunAsGroup(v *int64) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.RunAsGroup = v
+}
+
+func (w *podSecurityContextWrapper) RunAsNonRoot() *bool {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.RunAsNonRoot
+}
+func (w *podSecurityContextWrapper) SetRunAsNonRoot(v *bool) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.RunAsNonRoot = v
+}
+func (w *podSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.SeccompProfile
+}
+func (w *podSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if w.podSC == nil && p == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.SeccompProfile = p
+}
+func (w *podSecurityContextWrapper) SupplementalGroups() []int64 {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.SupplementalGroups
+}
+func (w *podSecurityContextWrapper) SetSupplementalGroups(v []int64) {
+	if w.podSC == nil && len(v) == 0 {
+		return
+	}
+	w.ensurePodSC()
+	if len(v) == 0 && len(w.podSC.SupplementalGroups) == 0 {
+		return
+	}
+	w.podSC.SupplementalGroups = v
+}
+func (w *podSecurityContextWrapper) FSGroup() *int64 {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.FSGroup
+}
+func (w *podSecurityContextWrapper) SetFSGroup(v *int64) {
+	if w.podSC == nil && v == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.FSGroup = v
+}
+
+type PatchedContainerSecurityContextAccessor interface {
+	securitycontext.ContainerSecurityContextAccessor
+	SecccompProfileAccessor
+}
+
+type PatchedContainerSecurityContextMutator interface {
+	securitycontext.ContainerSecurityContextMutator
+	SecccompProfileAccessor
+	SeccompProfileMutator
+}
+
+// NewContainerSecurityContextAccessor returns an accessor for the provided container security context
+// May be initialized with a nil SecurityContext
+func NewContainerSecurityContextAccessor(containerSC *api.SecurityContext) PatchedContainerSecurityContextAccessor {
+	return &containerSecurityContextWrapper{containerSC: containerSC}
+}
+
+// NewContainerSecurityContextMutator returns a mutator for the provided container security context
+// May be initialized with a nil SecurityContext
+func NewContainerSecurityContextMutator(containerSC *api.SecurityContext) PatchedContainerSecurityContextMutator {
+	return &containerSecurityContextWrapper{containerSC: containerSC}
+}
+
+type containerSecurityContextWrapper struct {
+	containerSC *api.SecurityContext
+}
+
+func (w *containerSecurityContextWrapper) ContainerSecurityContext() *api.SecurityContext {
+	return w.containerSC
+}
+
+func (w *containerSecurityContextWrapper) ensureContainerSC() {
+	if w.containerSC == nil {
+		w.containerSC = &api.SecurityContext{}
+	}
+}
+
+func (w *containerSecurityContextWrapper) Capabilities() *api.Capabilities {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.Capabilities
+}
+func (w *containerSecurityContextWrapper) SetCapabilities(v *api.Capabilities) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.Capabilities = v
+}
+func (w *containerSecurityContextWrapper) Privileged() *bool {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.Privileged
+}
+func (w *containerSecurityContextWrapper) SetPrivileged(v *bool) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.Privileged = v
+}
+func (w *containerSecurityContextWrapper) ProcMount() api.ProcMountType {
+	if w.containerSC == nil {
+		return api.DefaultProcMount
+	}
+	if w.containerSC.ProcMount == nil {
+		return api.DefaultProcMount
+	}
+	return *w.containerSC.ProcMount
+}
+func (w *containerSecurityContextWrapper) SELinuxOptions() *api.SELinuxOptions {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.SELinuxOptions
+}
+func (w *containerSecurityContextWrapper) SetSELinuxOptions(v *api.SELinuxOptions) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.SELinuxOptions = v
+}
+func (w *containerSecurityContextWrapper) RunAsUser() *int64 {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.RunAsUser
+}
+func (w *containerSecurityContextWrapper) SetRunAsUser(v *int64) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.RunAsUser = v
+}
+func (w *containerSecurityContextWrapper) RunAsGroup() *int64 {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.RunAsGroup
+}
+func (w *containerSecurityContextWrapper) SetRunAsGroup(v *int64) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.RunAsGroup = v
+}
+
+func (w *containerSecurityContextWrapper) RunAsNonRoot() *bool {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.RunAsNonRoot
+}
+func (w *containerSecurityContextWrapper) SetRunAsNonRoot(v *bool) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.RunAsNonRoot = v
+}
+func (w *containerSecurityContextWrapper) ReadOnlyRootFilesystem() *bool {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.ReadOnlyRootFilesystem
+}
+func (w *containerSecurityContextWrapper) SetReadOnlyRootFilesystem(v *bool) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.ReadOnlyRootFilesystem = v
+}
+func (w *containerSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.SeccompProfile
+}
+func (w *containerSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if w.containerSC == nil && p == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.SeccompProfile = p
+}
+
+func (w *containerSecurityContextWrapper) AllowPrivilegeEscalation() *bool {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.AllowPrivilegeEscalation
+}
+func (w *containerSecurityContextWrapper) SetAllowPrivilegeEscalation(v *bool) {
+	if w.containerSC == nil && v == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.AllowPrivilegeEscalation = v
+}
+
+// NewEffectiveContainerSecurityContextAccessor returns an accessor for reading effective values
+// for the provided pod security context and container security context
+func NewEffectiveContainerSecurityContextAccessor(podSC PatchedPodSecurityContextAccessor, containerSC PatchedContainerSecurityContextMutator) PatchedContainerSecurityContextAccessor {
+	return &effectiveContainerSecurityContextWrapper{podSC: podSC, containerSC: containerSC}
+}
+
+// NewEffectiveContainerSecurityContextMutator returns a mutator for reading and writing effective values
+// for the provided pod security context and container security context
+func NewEffectiveContainerSecurityContextMutator(podSC PatchedPodSecurityContextAccessor, containerSC PatchedContainerSecurityContextMutator) PatchedContainerSecurityContextMutator {
+	return &effectiveContainerSecurityContextWrapper{podSC: podSC, containerSC: containerSC}
+}
+
+type effectiveContainerSecurityContextWrapper struct {
+	podSC       PatchedPodSecurityContextAccessor
+	containerSC PatchedContainerSecurityContextMutator
+}
+
+func (w *effectiveContainerSecurityContextWrapper) ContainerSecurityContext() *api.SecurityContext {
+	return w.containerSC.ContainerSecurityContext()
+}
+
+func (w *effectiveContainerSecurityContextWrapper) Capabilities() *api.Capabilities {
+	return w.containerSC.Capabilities()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetCapabilities(v *api.Capabilities) {
+	if !reflect.DeepEqual(w.Capabilities(), v) {
+		w.containerSC.SetCapabilities(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) Privileged() *bool {
+	return w.containerSC.Privileged()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetPrivileged(v *bool) {
+	if !reflect.DeepEqual(w.Privileged(), v) {
+		w.containerSC.SetPrivileged(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) ProcMount() api.ProcMountType {
+	return w.containerSC.ProcMount()
+}
+func (w *effectiveContainerSecurityContextWrapper) SELinuxOptions() *api.SELinuxOptions {
+	if v := w.containerSC.SELinuxOptions(); v != nil {
+		return v
+	}
+	return w.podSC.SELinuxOptions()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetSELinuxOptions(v *api.SELinuxOptions) {
+	if !reflect.DeepEqual(w.SELinuxOptions(), v) {
+		w.containerSC.SetSELinuxOptions(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) RunAsUser() *int64 {
+	if v := w.containerSC.RunAsUser(); v != nil {
+		return v
+	}
+	return w.podSC.RunAsUser()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetRunAsUser(v *int64) {
+	if !reflect.DeepEqual(w.RunAsUser(), v) {
+		w.containerSC.SetRunAsUser(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) RunAsGroup() *int64 {
+	if v := w.containerSC.RunAsGroup(); v != nil {
+		return v
+	}
+	return w.podSC.RunAsGroup()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetRunAsGroup(v *int64) {
+	if !reflect.DeepEqual(w.RunAsGroup(), v) {
+		w.containerSC.SetRunAsGroup(v)
+	}
+}
+
+func (w *effectiveContainerSecurityContextWrapper) RunAsNonRoot() *bool {
+	if v := w.containerSC.RunAsNonRoot(); v != nil {
+		return v
+	}
+	return w.podSC.RunAsNonRoot()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetRunAsNonRoot(v *bool) {
+	if !reflect.DeepEqual(w.RunAsNonRoot(), v) {
+		w.containerSC.SetRunAsNonRoot(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) ReadOnlyRootFilesystem() *bool {
+	return w.containerSC.ReadOnlyRootFilesystem()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetReadOnlyRootFilesystem(v *bool) {
+	if !reflect.DeepEqual(w.ReadOnlyRootFilesystem(), v) {
+		w.containerSC.SetReadOnlyRootFilesystem(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	return w.containerSC.SeccompProfile()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if !reflect.DeepEqual(w.SeccompProfile(), p) {
+		w.containerSC.SetSeccompProfile(p)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) AllowPrivilegeEscalation() *bool {
+	return w.containerSC.AllowPrivilegeEscalation()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetAllowPrivilegeEscalation(v *bool) {
+	if !reflect.DeepEqual(w.AllowPrivilegeEscalation(), v) {
+		w.containerSC.SetAllowPrivilegeEscalation(v)
+	}
+}

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -2,6 +2,7 @@ package sccmatching
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -99,7 +100,7 @@ func NewSimpleProvider(scc *securityv1.SecurityContextConstraints) (SecurityCont
 // on the PodSecurityContext it will not be changed.  Validate should be used after the context
 // is created to ensure it complies with the required restrictions.
 func (s *simpleProvider) CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurityContext, map[string]string, error) {
-	sc := securitycontext.NewPodSecurityContextMutator(pod.Spec.SecurityContext)
+	sc := NewPodSecurityContextMutator(pod.Spec.SecurityContext)
 
 	annotationsCopy := maps.CopySS(pod.Annotations)
 
@@ -138,6 +139,7 @@ func (s *simpleProvider) CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurit
 			annotationsCopy = map[string]string{}
 		}
 		annotationsCopy[api.SeccompPodAnnotationKey] = seccompProfile
+		sc.SetSeccompProfile(seccompFieldForAnnotation(seccompProfile))
 	}
 
 	return sc.PodSecurityContext(), annotationsCopy, nil
@@ -147,9 +149,9 @@ func (s *simpleProvider) CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurit
 // container's security context then it will not be changed.  Validation should be used after
 // the context is created to ensure it complies with the required restrictions.
 func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error) {
-	sc := securitycontext.NewEffectiveContainerSecurityContextMutator(
-		securitycontext.NewPodSecurityContextAccessor(pod.Spec.SecurityContext),
-		securitycontext.NewContainerSecurityContextMutator(container.SecurityContext),
+	sc := NewEffectiveContainerSecurityContextMutator(
+		NewPodSecurityContextAccessor(pod.Spec.SecurityContext),
+		NewContainerSecurityContextMutator(container.SecurityContext),
 	)
 	if sc.RunAsUser() == nil {
 		uid, err := s.runAsUserStrategy.Generate(pod, container)
@@ -212,6 +214,11 @@ func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container 
 				break
 			}
 		}
+	}
+
+	containerSeccomp, ok := pod.Annotations[api.SeccompContainerAnnotationKeyPrefix+container.Name]
+	if ok {
+		sc.SetSeccompProfile(seccompFieldForAnnotation(containerSeccomp))
 	}
 
 	// if the SCC sets DefaultAllowPrivilegeEscalation and the container security context
@@ -496,4 +503,35 @@ func allowsVolumeType(allowedVolumes sets.String, fsType securityv1.FSType, volu
 	return allowedVolumes.Has(string(securityv1.FSTypeSecret)) &&
 		fsType == securityv1.FSProjected &&
 		sccutil.IsOnlyServiceAccountTokenSources(volumeSource.Projected)
+}
+
+// seccompFieldForAnnotation takes a pod annotation and returns the converted
+// seccomp profile field.
+// SeccompAnnotations removal is planned for Kube 1.27, remove this logic afterwards
+func seccompFieldForAnnotation(annotation string) *api.SeccompProfile {
+	// If only seccomp annotations are specified, copy the values into the
+	// corresponding fields. This ensures that existing applications continue
+	// to enforce seccomp, and prevents the kubelet from needing to resolve
+	// annotations & fields.
+	if annotation == corev1.SeccompProfileNameUnconfined {
+		return &api.SeccompProfile{Type: api.SeccompProfileTypeUnconfined}
+	}
+
+	if annotation == api.SeccompProfileRuntimeDefault || annotation == api.DeprecatedSeccompProfileDockerDefault {
+		return &api.SeccompProfile{Type: api.SeccompProfileTypeRuntimeDefault}
+	}
+
+	if strings.HasPrefix(annotation, corev1.SeccompLocalhostProfileNamePrefix) {
+		localhostProfile := strings.TrimPrefix(annotation, corev1.SeccompLocalhostProfileNamePrefix)
+		if localhostProfile != "" {
+			return &api.SeccompProfile{
+				Type:             api.SeccompProfileTypeLocalhost,
+				LocalhostProfile: &localhostProfile,
+			}
+		}
+	}
+
+	// we can only reach this code path if the localhostProfile name has a zero
+	// length or if the annotation has an unrecognized value
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -692,7 +692,7 @@ github.com/openshift/api/security
 github.com/openshift/api/security/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20230120221150-cefee9e0162b
+# github.com/openshift/apiserver-library-go v0.0.0-20230411124846-9fe2aa032a6f
 ## explicit; go 1.19
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1


### PR DESCRIPTION
This is a backport of #1482.

The carry commit is cherry-picked and the drop commit is replaced with a bump of https://github.com/openshift/apiserver-library-go/pull/102, instead of https://github.com/openshift/apiserver-library-go/pull/100.