### PR TITLE
`e2e`: jig.ExternalIPs configurable

### DIFF
--- a/openshift-hack/cmd/k8s-tests/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests/k8s-tests.go
@@ -44,6 +44,7 @@ func main() {
 	flag.CommandLine = flag.NewFlagSet("empty", flag.ExitOnError)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+	framework.RegisterNetworkFlags(flag.CommandLine)
 
 	if err := func() error {
 		return root.Execute()

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -194,6 +194,9 @@ type TestContextType struct {
 
 	// Enable volume drivers which are disabled by default. See test/e2e/storage/in_tree_volumes.go for details.
 	EnabledVolumeDrivers []string
+
+	// Network e2e specific test context
+	NetworkTestContextType
 }
 
 // NodeKillerConfig describes configuration of NodeKiller -- a utility to
@@ -242,6 +245,12 @@ type NodeTestContextType struct {
 	RestartKubelet bool
 	// ExtraEnvs is a map of environment names to values.
 	ExtraEnvs map[string]string
+}
+
+// NodeTestContextType is part of TestContextType, it is shared by all network e2e test.
+type NetworkTestContextType struct {
+	// If true, do not check service reachability using a node's external IPs
+	ServiceToNodePortDisableExternalIPs bool
 }
 
 // CloudConfig holds the cloud configuration for e2e test suites.
@@ -429,6 +438,12 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&nodeKiller.Interval, "node-killer-interval", 1*time.Minute, "Time between node failures.")
 	flags.Float64Var(&nodeKiller.JitterFactor, "node-killer-jitter-factor", 60, "Factor used to jitter node failures.")
 	flags.DurationVar(&nodeKiller.SimulatedDowntime, "node-killer-simulated-downtime", 10*time.Minute, "A delay between node death and recreation")
+}
+
+// RegisterNetworkFlags registers flags specific to the network e2e test suite.
+func RegisterNetworkFlags(flags *flag.FlagSet) {
+	netTextContext := &TestContext.NetworkTestContextType
+	flags.BoolVar(&netTextContext.ServiceToNodePortDisableExternalIPs, "net-srv2nodeport-disable-ext-ips", false, "If true, do not check service reachability using a node's external IPs")
 }
 
 // GenerateSecureToken returns a string of length tokenLen, consisting

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1366,7 +1366,7 @@ var _ = common.SIGDescribe("Services", func() {
 		serviceName := "nodeport-update-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-		jig.ExternalIPs = true
+		jig.ExternalIPs = !framework.TestContext.ServiceToNodePortDisableExternalIPs
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns)
 		tcpService, err := jig.CreateTCPService(nil)


### PR DESCRIPTION
With regard to [DPTP-3402](https://issues.redhat.com/browse/DPTP-3402) this PR aims to make [jig.ExternalIPs](https://github.com/kubernetes/kubernetes/blob/d73b3a696a4357a126f04eacedf51ea76ac22290/test/e2e/network/service.go#L1347) a configurable setting for the e2e network test: `should be able to update service type to NodePort listening on same port number but different protocols`.

If we agree on this PR being the right path to follow, we have to accomplish also the following changes then:
- the `openshift-tests` binary needs to be modified in order to expose such a new flag (check [InitStandardFlags](https://github.com/openshift/origin/blob/433fe954969fb0b7703ea7835d0b321972c511cb/test/extended/util/test.go#L47-L53))
-  `openshift/installer` [e2e-aws-ovn-public-subnets](https://github.com/openshift/release/blob/dd20324e7c3c97efa47088e6ccdcb0add6a0aaaa/ci-operator/config/openshift/installer/openshift-installer-master.yaml#L693-L699) test needs to override the `TEST_ARGS` parameter as follow:
```diff
  as: e2e-aws-ovn-public-subnets
  optional: true
  run_if_changed: /aws/subnet.go
  steps:
+    env:
+      TEST_ARGS: --net-srv2nodeport-disable-ext-ips
    cluster_profile: aws
    workflow: openshift-e2e-aws-publicsubnets
  timeout: 6h0m0s
```

/kind feature
/cc @jupierce @deads2k 