### PR TITLE
OCPBUGS-11143: Azure: move to kube-proxy LB probes, don't detach masters when unready

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -858,7 +858,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		case hasExcludeBalancerLabel:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
 
-		case !isNodeReady(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
+		case !isNodeReady(newNode) && !isNodeMaster(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
 			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
 			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
 			// excluded from load balancers regardless of their state, so as to reduce the number of
@@ -1002,6 +1002,17 @@ func isNodeReady(node *v1.Node) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func isNodeMaster(node *v1.Node) bool {
+	labels := node.GetLabels()
+	for l := range labels {
+		if l == "node-role.kubernetes.io/master" || l == "node-role.kubernetes.io/control-plane" {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1646,7 +1646,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			} else {
 				for _, actualProbe := range *loadBalancer.Probes {
 					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
-						*actualProbe.Port == wantedRule.NodePort {
+						*actualProbe.Port == lbNodesHealthCheckPort {
 						foundProbe = true
 						break
 					}


### PR DESCRIPTION
This is a port of https://github.com/openshift/kubernetes/pull/1547