### PR TITLE
OCPBUGS-11652: UPSTREAM: <carry>: Extend NodeLogQuery feature

### DIFF
--- a/pkg/kubelet/kubelet_server_journal_linux.go
+++ b/pkg/kubelet/kubelet_server_journal_linux.go
@@ -40,7 +40,7 @@ func getLoggingCmd(n *nodeLogQuery, services []string) (string, []string, error)
 	}
 
 	if len(n.Until) > 0 {
-		args = append(args, fmt.Sprintf("--since=%s", n.Since))
+		args = append(args, fmt.Sprintf("--until=%s", n.Until))
 	} else if n.UntilTime != nil {
 		args = append(args, fmt.Sprintf("--until=%s", n.SinceTime.Format(dateLayout)))
 	}


### PR DESCRIPTION
Fix handling of the "until" parameter when generating the journalctl command. This was incorrectly being passed with the "since" value.
