### PR TITLE
WIP: UPSTREAM: <carry>: reverts don't fail integration due to too many goroutines

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -209,7 +209,8 @@ func EtcdMain(tests func() int) {
 	klog.StopFlushDaemon()
 
 	if err := goleakFindRetry(goleakOpts...); err != nil {
-		klog.InfoS("EtcdMain goroutine check", "err", err)
+		klog.ErrorS(err, "EtcdMain goroutine check")
+		result = 1
 	}
 
 	os.Exit(result)


### PR DESCRIPTION
This reverts commit 501f19354bb79f0566039907b179974444f477a2.

