### PR TITLE
UPSTREAM: a6c7f63: Set the node-ips annotation correctly with CloudDualStackNodeIPs

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -109,7 +109,11 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 			if node.ObjectMeta.Annotations == nil {
 				node.ObjectMeta.Annotations = make(map[string]string)
 			}
-			node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr] = nodeIP.String()
+			annotation := nodeIP.String()
+			if secondaryNodeIPSpecified {
+				annotation += "," + secondaryNodeIP.String()
+			}
+			node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr] = annotation
 		} else if node.ObjectMeta.Annotations != nil {
 			// Clean up stale annotations if no longer using a cloud provider or
 			// no longer overriding node IP.

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -68,6 +68,7 @@ func TestNodeAddress(t *testing.T) {
 		name                           string
 		hostnameOverride               bool
 		nodeIP                         net.IP
+		secondaryNodeIP                net.IP
 		cloudProviderType              cloudProviderType
 		nodeAddresses                  []v1.NodeAddress
 		expectedAddresses              []v1.NodeAddress
@@ -521,6 +522,74 @@ func TestNodeAddress(t *testing.T) {
 			},
 			shouldError: false,
 		},
+		{
+			// We don't have to test "legacy cloud provider with dual-stack
+			// IPs" etc because we won't have gotten this far with an invalid
+			// config like that.
+			name:              "Dual-stack cloud, with dual-stack nodeIPs",
+			nodeIP:            netutils.ParseIPSloppy("2600:1f14:1d4:d101::ba3d"),
+			secondaryNodeIP:   netutils.ParseIPSloppy("10.1.1.2"),
+			cloudProviderType: cloudProviderExternal,
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "10.1.1.2"},
+				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101::ba3d"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101::ba3d"},
+				{Type: v1.NodeInternalIP, Address: "10.1.1.2"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAnnotations: map[string]string{
+				"alpha.kubernetes.io/provided-node-ip": "2600:1f14:1d4:d101::ba3d,10.1.1.2",
+			},
+			shouldError: false,
+		},
+		{
+			name:              "Upgrade to cloud dual-stack nodeIPs",
+			nodeIP:            netutils.ParseIPSloppy("10.1.1.1"),
+			secondaryNodeIP:   netutils.ParseIPSloppy("2600:1f14:1d4:d101::ba3d"),
+			cloudProviderType: cloudProviderExternal,
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101::ba3d"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101::ba3d"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			existingAnnotations: map[string]string{
+				"alpha.kubernetes.io/provided-node-ip": "10.1.1.1",
+			},
+			expectedAnnotations: map[string]string{
+				"alpha.kubernetes.io/provided-node-ip": "10.1.1.1,2600:1f14:1d4:d101::ba3d",
+			},
+			shouldError: false,
+		},
+		{
+			name:              "Downgrade from cloud dual-stack nodeIPs",
+			nodeIP:            netutils.ParseIPSloppy("10.1.1.1"),
+			cloudProviderType: cloudProviderExternal,
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101::ba3d"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			existingAnnotations: map[string]string{
+				"alpha.kubernetes.io/provided-node-ip": "10.1.1.1,2600:1f14:1d4:d101::ba3d",
+			},
+			expectedAnnotations: map[string]string{
+				"alpha.kubernetes.io/provided-node-ip": "10.1.1.1",
+			},
+			shouldError: false,
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -541,7 +610,6 @@ func TestNodeAddress(t *testing.T) {
 				existingNode.Status.Addresses = append(existingNode.Status.Addresses, existingNodeAddress)
 			}
 
-			nodeIP := testCase.nodeIP
 			nodeIPValidator := func(nodeIP net.IP) error {
 				return nil
 			}
@@ -560,8 +628,13 @@ func TestNodeAddress(t *testing.T) {
 				}
 			}
 
+			nodeIPs := []net.IP{testCase.nodeIP}
+			if testCase.secondaryNodeIP != nil {
+				nodeIPs = append(nodeIPs, testCase.secondaryNodeIP)
+			}
+
 			// construct setter
-			setter := NodeAddress([]net.IP{nodeIP},
+			setter := NodeAddress(nodeIPs,
 				nodeIPValidator,
 				hostname,
 				testCase.hostnameOverride,


### PR DESCRIPTION
Contributes-to: [OPNET-230](https://issues.redhat.com//browse/OPNET-230)
Contributes-to: [OPNET-323](https://issues.redhat.com//browse/OPNET-323)