### PR TITLE
OCPBUGS-15866: remove readiness check for cache exclusion

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -858,14 +858,6 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		case hasExcludeBalancerLabel:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
 
-		case !isNodeReady(newNode) && !isNodeMaster(newNode) && getCloudTaint(newNode.Spec.Taints) == nil:
-			// If not in ready state and not a newly created node, add to excludeLoadBalancerNodes cache.
-			// New nodes (tainted with "node.cloudprovider.kubernetes.io/uninitialized") should not be
-			// excluded from load balancers regardless of their state, so as to reduce the number of
-			// VMSS API calls and not provoke VMScaleSetActiveModelsCountLimitReached.
-			// (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/851)
-			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
-
 		default:
 			// Nodes not falling into the three cases above are valid backends and
 			// should not appear in excludeLoadBalancerNodes cache.
@@ -994,26 +986,6 @@ func (az *Cloud) ShouldNodeExcludedFromLoadBalancer(nodeName string) (bool, erro
 	}
 
 	return az.excludeLoadBalancerNodes.Has(nodeName), nil
-}
-
-func isNodeReady(node *v1.Node) bool {
-	for _, cond := range node.Status.Conditions {
-		if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func isNodeMaster(node *v1.Node) bool {
-	labels := node.GetLabels()
-	for l := range labels {
-		if l == "node-role.kubernetes.io/master" || l == "node-role.kubernetes.io/control-plane" {
-			return true
-		}
-	}
-
-	return false
 }
 
 func getCloudTaint(taints []v1.Taint) *v1.Taint {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -3313,7 +3313,7 @@ func TestUpdateNodeCacheExcludeLoadBalancer(t *testing.T) {
 	az.updateNodeCaches(&prevNode, &newNode)
 	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
 
-	// a non-ready node should be excluded
+	// a non-ready node should be included
 	az.unmanagedNodes = sets.NewString()
 	az.excludeLoadBalancerNodes = sets.NewString()
 	az.nodeNames = sets.NewString()
@@ -3334,9 +3334,9 @@ func TestUpdateNodeCacheExcludeLoadBalancer(t *testing.T) {
 		},
 	}
 	az.updateNodeCaches(nil, &nonReadyNode)
-	assert.Equal(t, 1, len(az.excludeLoadBalancerNodes))
+	assert.Equal(t, 0, len(az.excludeLoadBalancerNodes))
 
-	// node becomes ready, it should be removed from az.excludeLoadBalancerNodes
+	// node becomes ready => no impact on az.excludeLoadBalancerNodes
 	readyNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{


### PR DESCRIPTION
This readiness check is causing issues when adding and removing nodes from the cluster. See kubernetes-sigs/cloud-provider-azure#4230 for details.

Upstream have set a milestone to fix this for 1.28, but we need it in 1.27 and 1.26 so will merge here and create a backport for the in-tree provider for 1.26.

This will go directly to the 4.13 branch to solve the release-1.26 issue.
For 4.14 the Azure CCM will be the default choice and this in-tree code will not be executed, therefore no change required in master for this repo.