### PR TITLE
OCPBUGS-17145: Increase service idle max timeout to 100 minutes

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -885,7 +885,7 @@ func getDomainNameLabel(pip *network.PublicIPAddress) string {
 func getIdleTimeout(s *v1.Service) (*int32, error) {
 	const (
 		min = 4
-		max = 30
+		max = 100
 	)
 
 	val, ok := s.Annotations[ServiceAnnotationLoadBalancerIdleTimeout]

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -282,7 +282,7 @@ func TestGetIdleTimeout(t *testing.T) {
 		{desc: "annotation negative value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "-6"}, err: true},
 		{desc: "annotation zero value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "0"}, err: true},
 		{desc: "annotation too low value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "3"}, err: true},
-		{desc: "annotation too high value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "31"}, err: true},
+		{desc: "annotation too high value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "101"}, err: true},
 		{desc: "annotation good value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "24"}, i: to.Int32Ptr(24)},
 	} {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

In-tree version of https://github.com/openshift/cloud-provider-azure/pull/81

The value was changed by Azure to support a maximum of 100 minutes instead of 30 minutes. This PR bumps the allowed maximum in the code to prevent errors when trying to configure a valid maximum value.