### PR TITLE
OCPBUGS-18608: UPSTREAM: <carry>: Force using host go always and use host libriaries

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -348,7 +348,9 @@ kube::golang::is_statically_linked_library() {
   if [[ -n "${KUBE_CGO_OVERRIDES_LIST:+x}" ]]; then
     for e in "${KUBE_CGO_OVERRIDES_LIST[@]}"; do [[ "${1}" == *"/${e}" ]] && return 1; done;
   fi
-  for e in "${KUBE_STATIC_LIBRARIES[@]}"; do [[ "${1}" == *"/${e}" ]] && return 0; done;
+  if [[ -n "${KUBE_STATIC_LIBRARIES:+x}" ]]; then
+    for e in "${KUBE_STATIC_LIBRARIES[@]}"; do [[ "${1}" == *"/${e}" ]] && return 0; done;
+  fi
   if [[ -n "${KUBE_STATIC_OVERRIDES_LIST:+x}" ]]; then
     for e in "${KUBE_STATIC_OVERRIDES_LIST[@]}"; do [[ "${1}" == *"/${e}" ]] && return 0; done;
   fi


### PR DESCRIPTION
4dccebd introduced a build [failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_windows-machine-config-operator/1756/pull-ci-openshift-windows-machine-config-operator-release-4.11-images/1697673254124130304) of the Windows kubelet: 
```
[1/2] STEP 29/53: RUN make kubelet
KUBE_GIT_VERSION=v1.24.16+7aa7ea9 KUBE_BUILD_PLATFORMS=windows/amd64 make -C kubelet WHAT=cmd/kubelet
make[1]: Entering directory `/build/windows-machine-config-operator/kubelet'
make[2]: Entering directory `/build/windows-machine-config-operator/kubelet'
Makefile.generated_files:61: .make/go-pkgdeps.mk: No such file or directory
+++ [0905 19:33:37] Building go targets for linux/amd64
/build/windows-machine-config-operator/kubelet/hack/lib/golang.sh: line 351: KUBE_STATIC_LIBRARIES[@]: unbound variable
!!! [0905 19:33:37] Call tree:
!!! [0905 19:33:37]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [0905 19:33:37] Call tree:
!!! [0905 19:33:37]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
make[2]: *** [.make/go-pkgdeps.mk] Error 1
make[2]: Leaving directory `/build/windows-machine-config-operator/kubelet'
make[1]: *** [generated_files] Error 2
make[1]: Leaving directory `/build/windows-machine-config-operator/kubelet'
make: *** [kubelet] Error 2
Error: building at STEP "RUN make kubelet": while running runtime: exit status 2
```

This PR fixes the build failure by checking the array before traversing it.