### PR TITLE
Update builder & base images

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.14
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/build/pause/Dockerfile.Rhel
+++ b/build/pause/Dockerfile.Rhel
@@ -1,11 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes/build/pause
 COPY . .
-RUN dnf install -y gcc glibc-static && \
-    mkdir -p bin && \
-    gcc -Os -Wall -Werror -static -o bin/pause ./linux/pause.c
+RUN mkdir -p bin && \
+    gcc -Os -Wall -Werror -o bin/pause ./linux/pause.c
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/kubernetes/build/pause/bin/pause /usr/bin/pod
 LABEL io.k8s.display-name="OpenShift Pod" \
       io.k8s.description="This is a component of OpenShift and contains the binary that holds the pod namespaces." \

--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
 RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination openshift-hack/cmd/k8s-tests' && \
@@ -7,7 +7,7 @@ RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination,k8s-tests} \
     /tmp/build
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all
 COPY --from=builder /tmp/build/* /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \

--- a/openshift-hack/images/os/install.sh
+++ b/openshift-hack/images/os/install.sh
@@ -3,7 +3,7 @@
 set -xeou pipefail
 
 yum install -y ostree rpm-ostree yum-utils selinux-policy-targeted xfsprogs
-curl http://base-4-10-rhel8.ocp.svc > /etc/yum.repos.d/rhel8.repo
+curl http://base-4-15-rhel9.ocp.svc > /etc/yum.repos.d/rhel9.repo
 
 commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 )
 mkdir /tmp/working && cd /tmp/working
@@ -12,7 +12,7 @@ rpm-ostree db list --repo /srv/repo $commit > /tmp/packages
 PACKAGES=(openshift-hyperkube)
 yumdownloader -y --disablerepo=* --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}"
 if ! grep -q cri-o /tmp/packages; then
-  yumdownloader -y --disablerepo=* --enablerepo=rhel-8* --destdir=/tmp/rpms cri-o cri-tools
+  yumdownloader -y --disablerepo=* --enablerepo=rhel-9* --destdir=/tmp/rpms cri-o cri-tools
 fi
 
 ls /tmp/rpms/ && (cd /tmp/rpms/ && ls ${PACKAGES[@]/%/*})

--- a/openshift-hack/images/tests/Dockerfile.rhel
+++ b/openshift-hack/images/tests/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
 RUN make WHAT=openshift-hack/e2e/k8s-e2e.test; \
@@ -8,8 +8,7 @@ RUN make WHAT=openshift-hack/e2e/k8s-e2e.test; \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/ginkgo /tmp/build/; \
     cp /go/src/k8s.io/kubernetes/openshift-hack/test-kubernetes-e2e.sh /tmp/build/
 
-
-FROM registry.ci.openshift.org/ocp/4.14:tools
+FROM registry.ci.openshift.org/ocp/4.15:tools
 COPY --from=builder /tmp/build/k8s-e2e.test /usr/bin/
 COPY --from=builder /tmp/build/ginkgo /usr/bin/
 COPY --from=builder /tmp/build/test-kubernetes-e2e.sh /usr/bin/


### PR DESCRIPTION
/assign @soltysh 

This bumps builder and base images for OCP 4.15. In addition to that, we bump to RHEL 9 images to address the FIPS failures in CI

Join #incident-fips-ci-414-415 for discussions on work.