### PR TITLE
OCPBUGS-19056: UPSTREAM: <carry>: optimize IsLongRunningRequest

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/apiserver/apiserverconfig/longrunning.go
+++ b/vendor/github.com/openshift/library-go/pkg/apiserver/apiserverconfig/longrunning.go
@@ -2,25 +2,28 @@ package apiserverconfig
 
 import (
 	"net/http"
-	"regexp"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 )
 
-// request paths that match this regular expression will be treated as long running
-// and not subjected to the default server timeout.
-const originLongRunningEndpointsRE = "(/|^)(buildconfigs/.*/instantiatebinary|imagestreamimports)$"
-
 var (
-	originLongRunningRequestRE = regexp.MustCompile(originLongRunningEndpointsRE)
-	kubeLongRunningFunc        = genericfilters.BasicLongRunningRequestCheck(
+	kubeLongRunningFunc = genericfilters.BasicLongRunningRequestCheck(
 		sets.NewString("watch", "proxy"),
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"),
 	)
 )
 
 func IsLongRunningRequest(r *http.Request, requestInfo *apirequest.RequestInfo) bool {
-	return originLongRunningRequestRE.MatchString(r.URL.Path) || kubeLongRunningFunc(r, requestInfo)
+	if requestInfo.APIPrefix == "apis" && requestInfo.APIGroup == "build.openshift.io" && requestInfo.APIVersion == "v1" && requestInfo.Resource == "buildconfigs" && requestInfo.Subresource == "instantiatebinary" {
+		return true
+	}
+	if requestInfo.APIPrefix == "apis" && requestInfo.APIGroup == "image.openshift.io" && requestInfo.APIVersion == "v1" && requestInfo.Resource == "imagestreamimports" {
+		return true
+	}
+	if kubeLongRunningFunc(r, requestInfo) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Avoid using expensive MatchString when request params are already set in requestInfo

Back in 3.x days this was necessary as buildconfigs and imagestreams was served under `/oapi`, but now they are proper CRs so its better to match them via requestInfo params

```
$ benchstat -delta-test=none old.txt new.txt               
name                                                                 old time/op  new time/op  delta
IsLongRunningRequest/path_/api-8                                     11.5ns ± 5%   9.9ns ± 8%  -14.20%
IsLongRunningRequest/path_/api/buildconfigs/foo/instantiatebinary-8   870ns ± 7%     6ns ± 9%  -99.32%
IsLongRunningRequest/path_/api/imagestreamimports-8                   391ns ± 3%    10ns ± 5%  -97.47%
```
