### PR TITLE
OCPBUGS-19645: UPSTREAM: <carry>:genericapiserver: set timestamp when creating a new shutdown event

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -1069,12 +1069,15 @@ func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...
 			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
 			Namespace: ref.Namespace,
 		},
-		InvolvedObject: ref,
-		Reason:         reason,
-		Message:        fmt.Sprintf(messageFmt, args...),
-		Type:           eventType,
-		Source:         corev1.EventSource{Component: "apiserver", Host: host},
-		EventTime:      t,
+		InvolvedObject:      ref,
+		Reason:              reason,
+		Message:             fmt.Sprintf(messageFmt, args...),
+		Type:                eventType,
+		Source:              corev1.EventSource{Component: "apiserver", Host: host},
+		EventTime:           t,
+		ReportingController: "apiserver",
+		ReportingInstance:   host,
+		Action:              "shutdown",
 	}
 
 	klog.V(2).Infof("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -1056,7 +1056,7 @@ func getResourceNamesForGroup(apiPrefix string, apiGroupInfo *APIGroupInfo, path
 // Eventf creates an event with the API server as source, either in default namespace against default namespace, or
 // if POD_NAME/NAMESPACE are set against that pod.
 func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...interface{}) {
-	t := metav1.Time{Time: time.Now()}
+	t := metav1.MicroTime{Time: time.Now()}
 	host, _ := os.Hostname() // expicitly ignore error. Empty host is fine
 
 	ref := *s.eventRef
@@ -1074,6 +1074,7 @@ func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...
 		Message:        fmt.Sprintf(messageFmt, args...),
 		Type:           eventType,
 		Source:         corev1.EventSource{Component: "apiserver", Host: host},
+		EventTime:      t,
 	}
 
 	klog.V(2).Infof("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)


### PR DESCRIPTION
GenericAPIServer.Eventf doesn't set timestamps and some other fields, so shutdown events are not properly showing up on Console event timeline.

Setting ReportingController, ReportingInstance and Action seems required too for event to pass validation
