### PR TITLE
WIP: delay detach for debugging

### DIFF
--- a/pkg/volume/awsebs/attacher.go
+++ b/pkg/volume/awsebs/attacher.go
@@ -277,6 +277,10 @@ func (plugin *awsElasticBlockStorePlugin) NewDeviceUnmounter() (volume.DeviceUnm
 }
 
 func (detacher *awsElasticBlockStoreDetacher) Detach(volumeName string, nodeName types.NodeName) error {
+	if _, err := os.Stat("/tmp/detach-error"); err == nil {
+		time.Sleep(100 * time.Second)
+		return fmt.Errorf("simulated error detaching volume %q", volumeName)
+	}
 	volumeID := aws.KubernetesVolumeID(path.Base(volumeName))
 
 	if _, err := detacher.awsVolumes.DetachDisk(volumeID, nodeName); err != nil {


### PR DESCRIPTION
For testing only.

AWS EBS in-tree volume plugin `Detach()` call hangs for 100 seconds and returns error when  `/tmp/detach-error` is present in kube-controller-manager container.

Create / delete the file to simulate slow  AWS API calls.