### PR TITLE
UPSTREAM: <carry>: kubelet/cm: use MkdirAll when creating cpuset to ignore file exists error

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -475,7 +475,7 @@ func (m *cgroupManagerImpl) Create(cgroupConfig *CgroupConfig) error {
 		if path == "" {
 			return fmt.Errorf("Failed to find cpuset for newly created cgroup")
 		}
-		if err := os.Mkdir(path, 0o755); err != nil && !os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0o755); err != nil {
 			return fmt.Errorf("failed to create cpuset for newly created cgroup: %w", err)
 		}
 		if err := cgroups.WriteFile(path, "cpuset.sched_load_balance", "0"); err != nil {


### PR DESCRIPTION
Backports https://github.com/openshift/kubernetes/pull/1724 to 4.14