### PR TITLE
OCPBUGS-20096: bump pause image to RHEL9

### DIFF
--- a/build/pause/Dockerfile.Rhel
+++ b/build/pause/Dockerfile.Rhel
@@ -1,13 +1,13 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes/build/pause
 COPY . .
 RUN dnf install -y gcc glibc-static && \
-    mkdir -p bin && \
-    gcc -Os -Wall -Werror -static -o bin/pause ./linux/pause.c
+  mkdir -p bin && \
+  gcc -Os -Wall -Werror -static -o bin/pause ./linux/pause.c
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/kubernetes/build/pause/bin/pause /usr/bin/pod
 LABEL io.k8s.display-name="OpenShift Pod" \
-      io.k8s.description="This is a component of OpenShift and contains the binary that holds the pod namespaces." \
-      io.openshift.tags="openshift"
+  io.k8s.description="This is a component of OpenShift and contains the binary that holds the pod namespaces." \
+  io.openshift.tags="openshift"
 ENTRYPOINT [ "/usr/bin/pod" ]


### PR DESCRIPTION
Keeps static, but bumps to RHEL9.

Update: We have a good [build](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_kubernetes/1734/pull-ci-openshift-kubernetes-master-images/1709620919581806592/artifacts/build-logs/pod-amd64.log).