### PR TITLE
OCPBUGS-4970: ExternalIP admission: admit IP if allowedCIDRs not specified and not …

### DIFF
--- a/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission_test.go
+++ b/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission_test.go
@@ -136,6 +136,14 @@ func TestAdmission(t *testing.T) {
 			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
+			admit:       true,
+			rejects:     []*net.IPNet{ipv4},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "IP not in reject range on create and admits is empty",
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
+		},
+		{
 			admit:       false,
 			admits:      []*net.IPNet{ipv4},
 			externalIPs: []string{"1.2.3.4"},


### PR DESCRIPTION
…in rejectedCIDRs

Previous to this change, if rejectedCIDRS contains IP(s), and if allowedCIDRs does not contain any IPs, all ExternalIPs are rejected unless its also specified in allowedCIDRs.

This is contrary to openshift documentation.
