### PR TITLE
openshift-hack: Fix sporadic 141 errors in build-rpms

### DIFF
--- a/openshift-hack/build-rpms.sh
+++ b/openshift-hack/build-rpms.sh
@@ -31,7 +31,8 @@ fi
 os::build::rpm::get_nvra_vars
 
 OS_RPM_SPECFILE="$( find "${OS_ROOT}" -name '*.spec' )"
-OS_RPM_NAME="$( rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}" | head -1 )"
+OS_RPM_SPECQUERY="$( rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}" )"
+OS_RPM_NAME="$( head -1  <<< "${OS_RPM_SPECQUERY}" )"
 
 os::log::info "Building release RPMs for ${OS_RPM_SPECFILE} ..."
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
`head` sometimes exits before `rpmspec` finishes piping it all its data. Workaround that by separating the `rpmspec` and `head` calls.

#### Which issue(s) this PR fixes:
Fixes #

#### Additional documentation 
Ref: https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors