### PR TITLE
[openshift-apiserver-4.15-kubernetes-1.28.3] UPSTREAM: <carry>: Enable UnauthenticatedHTTP2DOSMitigation by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1210,7 +1210,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
-	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: false, PreRelease: featuregate.Beta},
+	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -294,7 +294,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
-	UnauthenticatedHTTP2DOSMitigation: {Default: false, PreRelease: featuregate.Beta},
+	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
 	WatchBookmark: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 


### PR DESCRIPTION
Enable the UnauthenticatedHTTP2DOSMitigation feature gate by default to mitigate the HTTP/2 CVE across all our components.

This is required to avoid feature gates conflicts when importing both k8s.io/kubernetes and k8s.io/apiserver which is the case for at least openshift-apiserver and oauth-apiserver.

This PR also includes https://github.com/openshift/kubernetes/pull/1646/commits/260ed49c0a31c52ad29ddf10396f158e9cef3e86 to fix feature gate initialization issues in openshift-apiserver https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_openshift-apiserver/396/pull-ci-openshift-openshift-apiserver-master-e2e-aws-ovn/1717524759073263616/artifacts/e2e-aws-ovn/gather-extra/artifacts/pods/openshift-apiserver_apiserver-85c5f89b65-zcqjt_openshift-apiserver.log

Proof: https://github.com/openshift/openshift-apiserver/pull/396