### PR TITLE
[openshift-apiserver-4.13-kubernetes-1.26.10] UPSTREAM: <carry>: Enable UnauthenticatedHTTP2DOSMitigation by default 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1184,7 +1184,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.Beta},
 
-	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: false, PreRelease: featuregate.Beta},
+	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -266,7 +266,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
-	UnauthenticatedHTTP2DOSMitigation: {Default: false, PreRelease: featuregate.Beta},
+	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
 	WatchBookmark: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }


### PR DESCRIPTION
Enable the UnauthenticatedHTTP2DOSMitigation feature gate by default to mitigate the HTTP/2 CVE across all our components.

This is required to avoid feature gates conflicts when importing both k8s.io/kubernetes and k8s.io/apiserver which is the case for at least openshift-apiserver and oauth-apiserver.

Proof: https://github.com/openshift/openshift-apiserver/pull/398