### PR TITLE
CNF-8326: advertise shared cpus for mixed cpus feature

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -104,6 +104,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/server"
 	servermetrics "k8s.io/kubernetes/pkg/kubelet/server/metrics"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
+	"k8s.io/kubernetes/pkg/kubelet/sharedcpus"
 	"k8s.io/kubernetes/pkg/kubelet/stats"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
@@ -617,6 +618,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	if managed.IsEnabled() {
 		klog.InfoS("Pinned Workload Management Enabled")
+	}
+	if sharedcpus.IsEnabled() {
+		klog.InfoS("Mixed CPUs Workload Enabled")
 	}
 
 	if kubeDeps.KubeClient != nil {

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/managed"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
+	"k8s.io/kubernetes/pkg/kubelet/sharedcpus"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	taintutil "k8s.io/kubernetes/pkg/util/taints"
 	volutil "k8s.io/kubernetes/pkg/volume/util"
@@ -119,6 +120,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 	if managed.IsEnabled() {
 		requiresUpdate = kl.addManagementNodeCapacity(node, existingNode) || requiresUpdate
 	}
+	requiresUpdate = kl.reconcileSharedCPUsNodeCapacity(node, existingNode) || requiresUpdate
 	if requiresUpdate {
 		if _, _, err := nodeutil.PatchNodeStatus(kl.kubeClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
 			klog.ErrorS(err, "Unable to reconcile node with API server,error updating node", "node", klog.KObj(node))
@@ -145,6 +147,25 @@ func (kl *Kubelet) addManagementNodeCapacity(initialNode, existingNode *v1.Node)
 		return false
 	}
 	existingNode.Status.Capacity[managedResourceName] = *newCPURequest
+	return true
+}
+
+func (kl *Kubelet) reconcileSharedCPUsNodeCapacity(initialNode, existingNode *v1.Node) bool {
+	updateDefaultResources(initialNode, existingNode)
+	sharedCPUsResourceName := sharedcpus.GetResourceName()
+	// delete resources in case they exist and feature has been disabled
+	if !sharedcpus.IsEnabled() {
+		if _, ok := existingNode.Status.Capacity[sharedCPUsResourceName]; ok {
+			delete(existingNode.Status.Capacity, sharedCPUsResourceName)
+			return true
+		}
+		return false
+	}
+	q := resource.NewQuantity(sharedcpus.GetConfig().ContainersLimit, resource.DecimalSI)
+	if existingCapacity, ok := existingNode.Status.Capacity[sharedCPUsResourceName]; ok && existingCapacity.Equal(*q) {
+		return false
+	}
+	existingNode.Status.Capacity[sharedCPUsResourceName] = *q
 	return true
 }
 
@@ -450,6 +471,7 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 	if managed.IsEnabled() {
 		kl.addManagementNodeCapacity(node, node)
 	}
+	kl.reconcileSharedCPUsNodeCapacity(node, node)
 
 	kl.setNodeStatus(ctx, node)
 

--- a/pkg/kubelet/sharedcpus/sharedcpus.go
+++ b/pkg/kubelet/sharedcpus/sharedcpus.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedcpus
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	configFileName         = "/etc/kubernetes/openshift-workload-mixed-cpus"
+	sharedCpusResourceName = "workload.openshift.io/enable-shared-cpus"
+)
+
+var (
+	config            Config
+	sharedCpusEnabled bool
+)
+
+type Config struct {
+	sharedCpus `json:"shared_cpus"`
+}
+
+type sharedCpus struct {
+	// ContainersLimit specify the number of containers that are allowed to access the shared CPU pool`
+	ContainersLimit int64 `json:"containers_limit"`
+}
+
+func init() {
+	parseConfig()
+}
+
+func IsEnabled() bool {
+	return sharedCpusEnabled
+}
+
+func GetResourceName() corev1.ResourceName {
+	return sharedCpusResourceName
+}
+
+func GetConfig() Config {
+	return config
+}
+
+func parseConfig() {
+	b, err := os.ReadFile(configFileName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		klog.ErrorS(err, "Failed to read configuration file for shared cpus", "fileName", configFileName)
+		return
+	}
+	cfg, err := parseConfigData(b)
+	if err != nil {
+		return
+	}
+	config = *cfg
+	sharedCpusEnabled = true
+}
+
+func parseConfigData(data []byte) (*Config, error) {
+	cfg := &Config{}
+	err := json.Unmarshal(data, cfg)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse configuration file for shared cpus", "fileContent", string(data))
+	}
+	return cfg, err
+}

--- a/pkg/kubelet/sharedcpus/sharedcpus_test.go
+++ b/pkg/kubelet/sharedcpus/sharedcpus_test.go
@@ -1,0 +1,39 @@
+package sharedcpus
+
+import "testing"
+
+func TestParseConfigData(t *testing.T) {
+	testCases := []struct {
+		data                []byte
+		expectedToBeParsed  bool
+		containerLimitValue int64
+	}{
+		{
+			data: []byte(`{
+					"shared_cpus": {
+     					"containers_limit": 15
+					}
+				}`),
+			expectedToBeParsed:  true,
+			containerLimitValue: 15,
+		},
+		{
+			data: []byte(`{
+					"shared_cpus": {
+     					"abc": "25"
+  					}
+				}`),
+			expectedToBeParsed:  false,
+			containerLimitValue: 0,
+		},
+	}
+	for _, tc := range testCases {
+		cfg, err := parseConfigData(tc.data)
+		if err != nil && tc.expectedToBeParsed {
+			t.Errorf("shared cpus data expected to be parsed")
+		}
+		if cfg.ContainersLimit != tc.containerLimitValue {
+			t.Errorf("shared cpus ContainersLimit is different than expected: want: %d; got %d", tc.containerLimitValue, cfg.ContainersLimit)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Talor Itzhak <titzhak@redhat.com>



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Kubelet should advertise the shared cpus as extedned resources. 
This has the benefit of limiting the amount of containers that can request an access to the shared cpus.

For more information see - https://github.com/openshift/enhancements/pull/1396

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

* The Mixed-CPUs feature allows guaranteed workloads to have an access for both isolated and shared cpus.
* As long as the configuration file is not present, this PR should not affect the existing flow.
* This PR alone doesn't enable the feature functionality, there will be following PRs for that. 
* Rlated to #1799 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]:  https://github.com/openshift/enhancements/commit/76ea48a88bca15ef6157aacf90b8544a763e6075
```
