### PR TITLE
OCPBUGS-22301: UPSTREAM: <carry>: Fix garbage-collection for CRDs.

### DIFF
--- a/cmd/kube-controller-manager/app/patch_gc.go
+++ b/cmd/kube-controller-manager/app/patch_gc.go
@@ -9,15 +9,13 @@ import (
 func applyOpenShiftGCConfig(controllerManager *config.Config) error {
 	// TODO make this configurable or discoverable.  This is going to prevent us from running the stock GC controller
 	// IF YOU ADD ANYTHING TO THIS LIST, MAKE SURE THAT YOU UPDATE THEIR STRATEGIES TO PREVENT GC FINALIZERS
+	//
+	// DO NOT PUT CRDs into the list. apiexstension-apiserver does not implement GarbageCollectionPolicy
+	// so the deletion of these will be blocked because of foregroundDeletion finalizer when foreground deletion strategy is specified.
 	controllerManager.ComponentConfig.GarbageCollectorController.GCIgnoredResources = append(controllerManager.ComponentConfig.GarbageCollectorController.GCIgnoredResources,
 		// explicitly disabled from GC for now - not enough value to track them
-		gcconfig.GroupResource{Group: "authorization.openshift.io", Resource: "rolebindingrestrictions"},
-		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "clusternetworks"},
-		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "hostsubnets"},
-		gcconfig.GroupResource{Group: "network.openshift.io", Resource: "netnamespaces"},
 		gcconfig.GroupResource{Group: "oauth.openshift.io", Resource: "oauthclientauthorizations"},
 		gcconfig.GroupResource{Group: "oauth.openshift.io", Resource: "oauthclients"},
-		gcconfig.GroupResource{Group: "quota.openshift.io", Resource: "clusterresourcequotas"},
 		gcconfig.GroupResource{Group: "user.openshift.io", Resource: "groups"},
 		gcconfig.GroupResource{Group: "user.openshift.io", Resource: "identities"},
 		gcconfig.GroupResource{Group: "user.openshift.io", Resource: "users"},


### PR DESCRIPTION
These types are backed by a CRD and not by openshift-apiserver anymore.

DefaultGarbageCollectionPolicy (Unsupported) does not work with CRDs. The `foregroundDeletion` finalizer was set on these CRD objects which blocks deletion indifinetelly as GC will ignore these resources.


And ClusterResourceQuota strategy needs to be updated: https://github.com/openshift/openshift-apiserver/pull/405