### PR TITLE
UPSTREAM: <carry>: fix e2e test failure

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3350,7 +3350,7 @@ var _ = common.SIGDescribe("Services", func() {
 				Labels: testSvcLabels,
 			},
 			Spec: v1.ServiceSpec{
-				Type: "ClusterIP",
+				Type: v1.ServiceTypeLoadBalancer,
 				Ports: []v1.ServicePort{{
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,


### PR DESCRIPTION
Encountered an [issue](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/1810/pull-ci-openshift-kubernetes-master-e2e-aws-ovn-cgroupsv2/1732015023288487936) while performing the rebase of k8s 1.29 

This change might fix the issue.
