### PR TITLE
OCPBUGS-25331: UPSTREAM: <carry>: extend termination events

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -324,11 +324,6 @@ type Config struct {
 	SendRetryAfterWhileNotReadyOnce bool
 }
 
-// EventSink allows to create events.
-type EventSink interface {
-	Create(event *corev1.Event) (*corev1.Event, error)
-}
-
 type RecommendedConfig struct {
 	Config
 
@@ -828,7 +823,9 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		muxAndDiscoveryCompleteSignals: map[string]<-chan struct{}{},
 
-		eventSink: c.EventSink,
+		OpenShiftGenericAPIServerPatch: OpenShiftGenericAPIServerPatch{
+			eventSink: c.EventSink,
+		},
 	}
 
 	ref, err := eventReference()

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	gpath "path"
 	"strings"
 	"sync"
@@ -287,9 +286,8 @@ type GenericAPIServer struct {
 	// it is not overridden by any other grace period.
 	ShutdownWatchTerminationGracePeriod time.Duration
 
-	// EventSink creates events.
-	eventSink EventSink
-	eventRef  *corev1.ObjectReference
+	// OpenShift patch
+	OpenShiftGenericAPIServerPatch
 }
 
 // DelegationTarget is an interface which allows for composition of API servers with top level handling that works
@@ -1051,34 +1049,4 @@ func getResourceNamesForGroup(apiPrefix string, apiGroupInfo *APIGroupInfo, path
 	}
 
 	return resourceNames, nil
-}
-
-// Eventf creates an event with the API server as source, either in default namespace against default namespace, or
-// if POD_NAME/NAMESPACE are set against that pod.
-func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...interface{}) {
-	t := metav1.Time{Time: time.Now()}
-	host, _ := os.Hostname() // expicitly ignore error. Empty host is fine
-
-	ref := *s.eventRef
-	if len(ref.Namespace) == 0 {
-		ref.Namespace = "default" // TODO: event broadcaster sets event ns to default. We have to match. Odd.
-	}
-
-	e := &corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
-			Namespace: ref.Namespace,
-		},
-		InvolvedObject: ref,
-		Reason:         reason,
-		Message:        fmt.Sprintf(messageFmt, args...),
-		Type:           eventType,
-		Source:         corev1.EventSource{Component: "apiserver", Host: host},
-	}
-
-	klog.V(2).Infof("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
-
-	if _, err := s.eventSink.Create(e); err != nil {
-		klog.Warningf("failed to create event %s/%s: %v", e.Namespace, e.Name, err)
-	}
 }


### PR DESCRIPTION
- set `EventTime` for the shutdown events
 
- we tie the shutdown events that follow with the UID of  the first (shutdown initiated), this provides us with a more deterministic way to compute shutdown duration from these events

- move code snippets from the upstream file to openshift specific patch file, it reduces chance of code conflict

Note for rebase: squash it into the following commit
cfbb6d6711a UPSTREAM: <carry>: create termination events
