### PR TITLE
OCPBUGS-24404: UPSTREAM <carry>: use snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - "**/vendor/**"
+    - "**/*_test.go"
+    - "**/testdata/**"
+    - "**/cluster/**"


### PR DESCRIPTION
We will need to revert https://github.com/openshift/kubernetes/pull/1870 since the filename is not correct. The revert and recreation of the PR will aid in backporting.