### PR TITLE
CORS-3191: Add Dockerfile to buld kube-apiserver for openshift-install architectures

### DIFF
--- a/openshift-hack/images/installer-kube-apiserver-artifacts/Dockerfile.rhel
+++ b/openshift-hack/images/installer-kube-apiserver-artifacts/Dockerfile.rhel
@@ -1,0 +1,44 @@
+# This Dockerfile builds an image containing Mac and Linux/AMD64 versions of
+# the kube-apiserver layered on top of the cluster-native Linux installer image.
+# The resulting image is used to build the openshift-install binary.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macbuilder
+ARG TAGS=""
+WORKDIR /go/src/k8s.io/kubernetes
+COPY . .
+ENV KUBE_BUILD_PLATFORMS=darwin/amd64
+ENV KUBE_STATIC_OVERRIDES=kube-apiserver
+RUN make WHAT='cmd/kube-apiserver'
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macarmbuilder
+ARG TAGS=""
+WORKDIR /go/src/k8s.io/kubernetes
+COPY . .
+ENV KUBE_BUILD_PLATFORMS=darwin/arm64
+ENV KUBE_STATIC_OVERRIDES=kube-apiserver
+RUN make WHAT='cmd/kube-apiserver'
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxbuilder
+ARG TAGS=""
+WORKDIR /go/src/k8s.io/kubernetes
+COPY . .
+ENV KUBE_BUILD_PLATFORMS=linux/amd64
+ENV KUBE_STATIC_OVERRIDES=kube-apiserver
+RUN make WHAT='cmd/kube-apiserver'
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxarmbuilder
+ARG TAGS=""
+WORKDIR /go/src/k8s.io/kubernetes
+COPY . .
+ENV KUBE_BUILD_PLATFORMS=linux/arm64
+ENV KUBE_STATIC_OVERRIDES=kube-apiserver
+RUN make WHAT='cmd/kube-apiserver'
+
+FROM registry.ci.openshift.org/ocp/4.16:base
+COPY --from=macbuilder /go/src/k8s.io/kubernetes/_output/local/bin/darwin/amd64/kube-apiserver /usr/share/openshift/darwin/amd64/kube-apiserver
+COPY --from=macarmbuilder /go/src/k8s.io/kubernetes/_output/local/bin/darwin/arm64/kube-apiserver /usr/share/openshift/darwin/arm64/kube-apiserver
+COPY --from=linuxbuilder /go/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/kube-apiserver /usr/share/openshift/linux/amd64/kube-apiserver
+COPY --from=linuxarmbuilder /go/src/k8s.io/kubernetes/_output/local/bin/linux/arm64/kube-apiserver /usr/share/openshift/linux/arm64/kube-apiserver
+
+# This image is not an operator, it is only used as part of the build pipeline.
+LABEL io.openshift.release.operator=false

--- a/openshift-hack/images/installer-kube-apiserver-artifacts/OWNERS
+++ b/openshift-hack/images/installer-kube-apiserver-artifacts/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - JoelSpeed
+  - vincepri
+  - patrickdillon
+  - r4f4
+approvers:
+  - JoelSpeed
+  - vincepri
+  - patrickdillon
+  - r4f4


### PR DESCRIPTION
The installer team are currently migrating towards using Cluster API and envtest to run a temporary control plane as part of the installation procedure.
As part of this requirement, we need to include, within the installer kube-apiserver binaries, suitable for the 4 architectures supported by the installer program (plus the specific arch for s390x/ppcle64 where appropriate, these are handled separately though).

To ensure that the installer can always support `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`, we need to have an intermediary image, built into the CI and ART pipelines, that the installer can source from.

This PR adds a dockerfile that will cross compile the 4 required architectures for kube-apiserver and then publish them into an image, I'm intending to call `installer-kube-apiserver-artifacts`.

We will do the same for etcd as well to satisfy that dependency.