### PR TITLE
[release-4.12] OCPBUGS-15527: Prevent partially filled HPA behaviors from crashing kube-controller-manager 

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	autoscalingapiv2 "k8s.io/kubernetes/pkg/apis/autoscaling/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	metricsclient "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
 )
@@ -574,6 +575,11 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 	// make a copy so that we never mutate the shared informer cache (conversion can mutate the object)
 	hpa := hpaShared.DeepCopy()
 	hpaStatusOriginal := hpa.Status.DeepCopy()
+
+	// Make sure we don't have any nil behaviors before we touch them. They can come in with old v1 objects,
+	// and it's easier here than having to nil check/default later for every calculation
+	// See: https://issues.redhat.com/browse/OCPBUGS-12210
+	a.ensureScalingBehaviorsNotPartiallyPopulated(hpa)
 
 	reference := fmt.Sprintf("%s/%s/%s", hpa.Spec.ScaleTargetRef.Kind, hpa.Namespace, hpa.Spec.ScaleTargetRef.Name)
 
@@ -1210,4 +1216,14 @@ func min(a, b int32) int32 {
 		return a
 	}
 	return b
+}
+
+// ensureScalingBehaviorsNotPartiallyPopulated uses the defualters to ensure that scaling behaviors cannot
+// be partially populated, because if they are, the calculation code will potentially dereference the
+// nil pointers and panic.
+func (a *HorizontalController) ensureScalingBehaviorsNotPartiallyPopulated(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	if hpa.Spec.Behavior != nil {
+		hpa.Spec.Behavior.ScaleUp = autoscalingapiv2.GenerateHPAScaleUpRules(hpa.Spec.Behavior.ScaleUp)
+		hpa.Spec.Behavior.ScaleDown = autoscalingapiv2.GenerateHPAScaleDownRules(hpa.Spec.Behavior.ScaleDown)
+	}
 }

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -226,8 +226,11 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 				LastScaleTime:   tc.lastScaleTime,
 			},
 		}
+		// jkyros: we were cheating our way through our tests by defaulting these here, we would
+		// have caught the "partially filled HPA behaviors" crashes a lot sooner otherwise
+
 		// Initialize default values
-		autoscalingapiv2.SetDefaults_HorizontalPodAutoscalerBehavior(&hpa)
+		// autoscalingapiv2.SetDefaults_HorizontalPodAutoscalerBehavior(&hpa)
 
 		obj := &autoscalingv2.HorizontalPodAutoscalerList{
 			Items: []autoscalingv2.HorizontalPodAutoscaler{hpa},
@@ -4179,4 +4182,45 @@ func TestNoScaleDownOneMetricEmpty(t *testing.T) {
 	})
 	tc.testEMClient = testEMClient
 	tc.runTest(t)
+}
+
+// TestPartialBehaviors makes sure that the controller is filling in any
+// partial behaviors that are nil so we don't panic
+// See: https://issues.redhat.com/browse/OCPBUGS-12210
+func TestPartialBehaviors(t *testing.T) {
+
+	t.Run("ensure no panic if scaleDown rules are missing", func(t *testing.T) {
+		tc := testCase{
+			minReplicas:             2,
+			maxReplicas:             6,
+			specReplicas:            3,
+			statusReplicas:          3,
+			expectedDesiredReplicas: 5,
+			CPUTarget:               30,
+			verifyCPUCurrent:        true,
+			reportedLevels:          []uint64{300, 500, 700},
+			reportedCPURequests:     []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
+			useMetricsAPI:           true,
+			scaleUpRules:            autoscalingapiv2.GenerateHPAScaleUpRules(nil),
+		}
+		tc.runTest(t)
+	})
+
+	t.Run("ensure no panic if scaleUp rules are missing", func(t *testing.T) {
+		tc := testCase{
+			minReplicas:             2,
+			maxReplicas:             6,
+			specReplicas:            5,
+			statusReplicas:          5,
+			expectedDesiredReplicas: 3,
+			CPUTarget:               50,
+			verifyCPUCurrent:        true,
+			reportedLevels:          []uint64{100, 300, 500, 250, 250},
+			reportedCPURequests:     []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
+			useMetricsAPI:           true,
+			recommendations:         []timestampedRecommendation{},
+			scaleDownRules:          autoscalingapiv2.GenerateHPAScaleDownRules(nil),
+		}
+		tc.runTest(t)
+	})
 }


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/kubernetes/pull/1876. It looks like we probably also need to take it back through 4.11 even though we originally weren't intending to.  

(Manual backport because my diff was unlucky enough to collide with the `TestMultipleHPAs` test from 4.12)