### PR TITLE
DNM: break kubelet to verify CI

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -22,17 +22,15 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register"          // for JSON log format registration
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // for client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
-	"k8s.io/kubernetes/cmd/kubelet/app"
 )
 
 func main() {
-	command := app.NewKubeletCommand()
-	code := cli.Run(command)
-	os.Exit(code)
+	fmt.Printf("in your kubelet, breaking things\n")
+	os.Exit(1)
 }


### PR DESCRIPTION
This will sanity-check in a much more straight-forward way that the kubelet built from PRs is what's actually getting tested in CI.

See also
https://github.com/openshift/kubernetes/pull/1805#issuecomment-1812819515 and following.