### PR TITLE
OCPBUGS-30954: Set up CEL IP/CIDR library from 4.14 onwards

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -124,7 +124,7 @@ var baseOpts = []VersionedOptions{
 		},
 	},
 	{
-		IntroducedVersion: version.MajorMinor(1, 28),
+		IntroducedVersion: version.MajorMinor(1, 27),
 		EnvOptions: []cel.EnvOption{
 			library.IP(),
 			library.CIDR(),


### PR DESCRIPTION
To be carried until K8s 1.31 rebase.

Due to upgrade ordering, to be able to leverage CEL IP/CIDR validations in OCP, we need to have the 4.15 branch accept these new validations. There are CRDs that are updated by CVO prior to KAS being updated, eg the infrastructure object.

By moving the version to 1.27/4.14, it will allow these 4.16 CRDs to be installed on the 4.15 KAS prior to ugprade.

We need to then backport this to 4.15 and set a minimum upgrade edge to 4.16 based on whenever this lands.

Once in 4.15, to prevent breaking downgrades, even though we aren't going to use any of these validations in payload, we will need to set up the CEL validation in 4.14 as well
