### PR TITLE
OCPBUGS-30963: Set up CEL IP/CIDR library from 4.14 onwards

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -83,7 +83,7 @@ var baseOpts = []VersionedOptions{
 	},
 	// TODO: switch to ext.Strings version 2 once format() is fixed to work with HomogeneousAggregateLiterals.
 	{
-		IntroducedVersion: version.MajorMinor(1, 28),
+		IntroducedVersion: version.MajorMinor(1, 27),
 		EnvOptions: []cel.EnvOption{
 			library.IP(),
 			library.CIDR(),


### PR DESCRIPTION
Backport of https://github.com/openshift/kubernetes/pull/1911, see PR description their for context

/jira cherry-pick OCPBUGS-30954