### PR TITLE
OCPBUGS-31384: UPSTREAM: <carry>: allow type mutation for specific secrets

### DIFF
--- a/pkg/apis/core/validation/validation_patch.go
+++ b/pkg/apis/core/validation/validation_patch.go
@@ -39,6 +39,7 @@ var (
 		"openshift-kube-apiserver-operator":          {},
 		"openshift-kube-apiserver":                   {},
 		"openshift-kube-controller-manager-operator": {},
+		"openshift-config-managed":                   {},
 	}
 )
 


### PR DESCRIPTION
Extends https://github.com/openshift/kubernetes/pull/1924 by adding `openshift-config-managed` namespace.

The following secrets are reconciled by the `RotatedSelfSignedCertKeySecret` controller in `kube-apiserver-operator`:
- `kube-controller-manager-client-cert-key` ([link](https://github.com/openshift/cluster-kube-apiserver-operator/blob/b07a384fc7de9589258a3b3b6563e22ba600ea74/pkg/operator/certrotationcontroller/certrotationcontroller.go#L601))
- `kube-scheduler-client-cert-key` ([link](https://github.com/openshift/cluster-kube-apiserver-operator/blob/b07a384fc7de9589258a3b3b6563e22ba600ea74/pkg/operator/certrotationcontroller/certrotationcontroller.go#L661))