### PR TITLE
[4.14] OCPBUGS-32580: allow override of NewVolumeManagerReconstruction

### DIFF
--- a/pkg/features/patch_kube_features.go
+++ b/pkg/features/patch_kube_features.go
@@ -1,0 +1,27 @@
+package features
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
+)
+
+// This override should only be used with a support exception. It provides a way
+// to set the NewVolumeManagerReconstruction feature gate in a way that still
+// allows the cluster to be upgradable. This is only needed on 4.14, since the
+// feature gate defaults to true on 4.15 and later. Owners: @jsafrane @dobsonj
+func OpenShiftNewVolumeManagerReconstructionOverride() {
+	overrideVariable := "OCP_4_14_SUPPORT_EXCEPTION_ENABLE_NEW_VOLUME_MANAGER_RECONSTRUCTION"
+	_, enabled := os.LookupEnv(overrideVariable)
+	if enabled {
+		klog.Infof("Environment variable %s is set, setting feature gate %s to true", overrideVariable, string(NewVolumeManagerReconstruction))
+		fg := map[string]bool{string(NewVolumeManagerReconstruction): true}
+		runtime.Must(utilfeature.DefaultMutableFeatureGate.SetFromMap(fg))
+	}
+}
+
+func init() {
+	OpenShiftNewVolumeManagerReconstructionOverride()
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-32580

This provides a way to set the NewVolumeManagerReconstruction feature gate in a way that still allows the cluster to be upgradable. This is only needed on 4.14, since the feature gate defaults to true on 4.15 and later.

To test, you can log into a 4.14 node, install the following test rpm, and set the environment variable in `/etc/kubernetes/kubelet-env`:

```
$ oc debug node/ip-10-0-92-74.us-east-2.compute.internal
Starting pod/ip-10-0-92-74us-east-2computeinternal-debug-nkwpd ...
To use host binaries, run `chroot /host`
Pod IP: 10.0.92.74
If you don't see a command prompt, try pressing enter.
sh-4.4# chroot /host

sh-5.1# rpm-ostree override replace https://files.dobsonj.com/openshift-hyperkube-1.27.13-1.0.401bb48.x86_64.rpm

sh-5.1# vi /etc/kubernetes/kubelet-env
sh-5.1# cat /etc/kubernetes/kubelet-env
OCP_4_14_SUPPORT_EXCEPTION_ENABLE_NEW_VOLUME_MANAGER_RECONSTRUCTION=true
sh-5.1# systemctl reboot
```

If it was successful, kubelet should have a log message showing that the environment variable took effect, and the NewVolumeManagerReconstruction feature gate should be true.

```
sh-5.1# journalctl -u kubelet | grep -m1 OCP_4_14_SUPPORT_EXCEPTION_ENABLE_NEW_VOLUME_MANAGER_RECONSTRUCTION
Apr 24 20:24:18 ip-10-0-92-74 kubenswrapper[2052]: I0424 20:24:18.141491    2052 patch_kube_features.go:19] Environment variable OCP_4_14_SUPPORT_EXCEPTION_ENABLE_NEW_VOLUME_MANAGER_RECONSTRUCTION is set, setting feature gate NewVolumeManagerReconstruction to true

sh-5.1# journalctl -u kubelet | grep -m1 'feature gates: .*NewVolumeManagerReconstruction'
Apr 24 20:24:18 ip-10-0-92-74 kubenswrapper[2052]: I0424 20:24:18.198774    2052 feature_gate.go:250] feature gates: &{map[AdmissionWebhookMatchConditions:false CloudDualStackNodeIPs:true DynamicResourceAllocation:false EventedPLEG:false MaxUnavailableStatefulSet:false NewVolumeManagerReconstruction:true NodeSwap:false RetroactiveDefaultStorageClass:false ValidatingAdmissionPolicy:false]}
```

/cc @openshift/storage @jsafrane @rphillips 