### PR TITLE
[release-4.14] OCPBUGS-14373: Fix flaky HPA e2e tests by not failing on context cancelled (#117669)

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -354,10 +354,7 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric(ctx context.Context) {
 }
 
 func (rc *ResourceConsumer) sendConsumeCPURequest(ctx context.Context, millicores int) {
-	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
-	defer cancel()
-
-	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -375,15 +372,18 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(ctx context.Context, millicore
 		return true, nil
 	})
 
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
+	}
+
 	framework.ExpectNoError(err)
 }
 
 // sendConsumeMemRequest sends POST request for memory consumption
 func (rc *ResourceConsumer) sendConsumeMemRequest(ctx context.Context, megabytes int) {
-	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
-	defer cancel()
-
-	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -401,15 +401,18 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(ctx context.Context, megabytes
 		return true, nil
 	})
 
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
+	}
+
 	framework.ExpectNoError(err)
 }
 
 // sendConsumeCustomMetric sends POST request for custom metric consumption
 func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta int) {
-	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
-	defer cancel()
-
-	err := wait.PollImmediateWithContext(ctx, serviceInitializationInterval, serviceInitializationTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -427,6 +430,13 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta i
 		}
 		return true, nil
 	})
+
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
+	}
+
 	framework.ExpectNoError(err)
 }
 


### PR DESCRIPTION
HPA e2e tests are flaking in CI for 4.14 still, because they broke the tests in 4.14, but it didn't get fixed until 4.15. 

This  backports the fix from 4.15 to 4.14 so the tests in 4.14 will stop flaking. 

Background: 

- The test suite was regarding a context cancellation as an error, so depending on the test timing -- e.g. test already finished, then cancelled context as part of cleanup on the metrics requester -- the test would erroneously still fail
- It's doesn't matter if we eat the timeout in the ResourceConsumer because the actual test case in the test suite will fail if we time out there
- Further details here: https://github.com/kubernetes/kubernetes/pull/117669

Fixes: [OCPBUGS-14373](https://issues.redhat.com/browse/OCPBUGS-14373)