### PR TITLE
API-1809: Provide SCC access via RBAC

### DIFF
--- a/openshift-hack/e2e/namespace.go
+++ b/openshift-hack/e2e/namespace.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kclientset "k8s.io/client-go/kubernetes"
@@ -19,7 +18,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	projectv1 "github.com/openshift/api/project/v1"
-	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 )
 
 // CreateTestingNS ensures that kubernetes e2e tests have their service accounts in the privileged and anyuid SCCs
@@ -54,28 +52,24 @@ func CreateTestingNS(ctx context.Context, baseName string, c kclientset.Interfac
 		return ns, err
 	}
 
-	securityClient, err := securityv1client.NewForConfig(clientConfig)
+	rbacClient, err := rbacv1client.NewForConfig(clientConfig)
 	if err != nil {
 		return ns, err
 	}
 	framework.Logf("About to run a Kube e2e test, ensuring namespace/%s is privileged", ns.Name)
 	// add the "privileged" scc to ensure pods that explicitly
 	// request extra capabilities are not rejected
-	addE2EServiceAccountsToSCC(ctx, securityClient, []corev1.Namespace{*ns}, "privileged")
+	addRoleToE2EServiceAccounts(ctx, rbacClient, []corev1.Namespace{*ns}, "system:openshift:scc:privileged")
 	// add the "anyuid" scc to ensure pods that don't specify a
 	// uid don't get forced into a range (mimics upstream
 	// behavior)
-	addE2EServiceAccountsToSCC(ctx, securityClient, []corev1.Namespace{*ns}, "anyuid")
+	addRoleToE2EServiceAccounts(ctx, rbacClient, []corev1.Namespace{*ns}, "system:openshift:scc:anyuid")
 	// add the "hostmount-anyuid" scc to ensure pods using hostPath
 	// can execute tests
-	addE2EServiceAccountsToSCC(ctx, securityClient, []corev1.Namespace{*ns}, "hostmount-anyuid")
+	addRoleToE2EServiceAccounts(ctx, rbacClient, []corev1.Namespace{*ns}, "system:openshift:scc:hostmount-anyuid")
 
 	// The intra-pod test requires that the service account have
 	// permission to retrieve service endpoints.
-	rbacClient, err := rbacv1client.NewForConfig(clientConfig)
-	if err != nil {
-		return ns, err
-	}
 	addRoleToE2EServiceAccounts(ctx, rbacClient, []corev1.Namespace{*ns}, "view")
 
 	// in practice too many kube tests ignore scheduling constraints
@@ -85,32 +79,6 @@ func CreateTestingNS(ctx context.Context, baseName string, c kclientset.Interfac
 }
 
 var longRetry = wait.Backoff{Steps: 100}
-
-// TODO: ideally this should be rewritten to use dynamic client, not to rely on openshift types
-func addE2EServiceAccountsToSCC(ctx context.Context, securityClient securityv1client.Interface, namespaces []corev1.Namespace, sccName string) {
-	// Because updates can race, we need to set the backoff retries to be > than the number of possible
-	// parallel jobs starting at once. Set very high to allow future high parallelism.
-	err := retry.RetryOnConflict(longRetry, func() error {
-		scc, err := securityClient.SecurityV1().SecurityContextConstraints().Get(ctx, sccName, metav1.GetOptions{})
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		for _, ns := range namespaces {
-			scc.Groups = append(scc.Groups, fmt.Sprintf("system:serviceaccounts:%s", ns.Name))
-		}
-		if _, err := securityClient.SecurityV1().SecurityContextConstraints().Update(ctx, scc, metav1.UpdateOptions{}); err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		fatalErr(err)
-	}
-}
 
 func fatalErr(msg interface{}) {
 	// the path that leads to this being called isn't always clear...


### PR DESCRIPTION
Instead of providing SCC access when running tests by modifying the SCC, just use RBAC and the existing system cluster roles