### PR TITLE
OCPBUGS-31467: Return from EnsureHostInPool on all NIC errors

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -823,9 +823,7 @@ func (as *availabilitySet) EnsureHostInPool(service *v1.Service, nodeName types.
 		}
 
 		klog.Errorf("error: az.EnsureHostInPool(%s), az.VMSet.GetPrimaryInterface.Get(%s, %s), err=%v", nodeName, vmName, vmSetName, err)
-		if err != cloudprovider.InstanceNotFound {
-			return "", "", "", nil, err
-		}
+		return "", "", "", nil, err
 	}
 
 	if nic.ProvisioningState != nil && *nic.ProvisioningState == nicFailedState {


### PR DESCRIPTION
When looking up the NIC, if there's an error, this function should return regardless of the error.

The previous code could proceed when an instance wasn't found, and the `nic` would be a nil pointer.


Carry of https://github.com/kubernetes/kubernetes/pull/124541