### PR TITLE
UPSTREAM: <carry>: OCPBUGS-34102: force static build of linux binaries

### DIFF
--- a/openshift-hack/images/installer-kube-apiserver-artifacts/Dockerfile.rhel
+++ b/openshift-hack/images/installer-kube-apiserver-artifacts/Dockerfile.rhel
@@ -22,6 +22,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 ARG TAGS=""
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 ENV KUBE_BUILD_PLATFORMS=linux/amd64
 ENV KUBE_STATIC_OVERRIDES=kube-apiserver
 RUN make WHAT='cmd/kube-apiserver'
@@ -30,6 +31,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 ARG TAGS=""
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 ENV KUBE_BUILD_PLATFORMS=linux/arm64
 ENV KUBE_STATIC_OVERRIDES=kube-apiserver
 RUN make WHAT='cmd/kube-apiserver'
@@ -38,6 +40,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS 
 ARG TAGS=""
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 ENV KUBE_STATIC_OVERRIDES=kube-apiserver
 RUN make WHAT='cmd/kube-apiserver'
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Setting `KUBE_STATIC_OVERRIDES` is necessary for the kubernetes build system to attempt a static build but we also need to set `GO_COMPLIANCE_EXCLUDE` so the `CGO_ENABLED` value is not overridden by the fips-or-die toolchain used to build the release payload.

This fixes an issue when running the openshift-installer in centos7/rhel8 systems which fails with:
```
E0521 18:04:24.925722    2077 server.go:317] "unable to start the controlplane" err="unable to run command \"cluster-api/kube-apiserver\" to check for flag \"insecure-port\": exit status 1" logger="controller-runtime.test-env" tries=4
ERROR failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to run cluster api system: failed to run local control plane: unable to start control plane itself: failed to start the controlplane. ret\
ried 5 times: unable to run command "cluster-api/kube-apiserver" to check for flag "insecure-port": exit status 1
```
because it's trying to run a dynamically-linked kube-apiserver binary.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
