### PR TITLE
OCPBUGS-34544: UPSTREAM: <carry>: Disable PersistentVolumeLabel by default

### DIFF
--- a/openshift-kube-apiserver/admission/admissionenablement/register.go
+++ b/openshift-kube-apiserver/admission/admissionenablement/register.go
@@ -88,7 +88,6 @@ var (
 	additionalDefaultOnPlugins = sets.NewString(
 		"NodeRestriction",
 		"OwnerReferencesPermissionEnforcement",
-		"PersistentVolumeLabel",
 		"PodNodeSelector",
 		"PodTolerationRestriction",
 		"Priority",


### PR DESCRIPTION
Remove PersistentVolumeLabel admission plugin from the default list of enabled admissions.

The plugin is deprecated upstream and most of its functionality was removed in 1.29 and 1.30.

This is continuation of https://github.com/openshift/cluster-kube-apiserver-operator/pull/1693, the admission is enabled on too many places.
