### PR TITLE
UPSTREAM: <carry>: allow injection of .status.conditions[*].lastTransitionTime

### DIFF
--- a/openshift-kube-apiserver/admission/admissionenablement/admission.go
+++ b/openshift-kube-apiserver/admission/admissionenablement/admission.go
@@ -2,7 +2,6 @@ package admissionenablement
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
-
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration"
 )

--- a/openshift-kube-apiserver/admission/admissionenablement/register.go
+++ b/openshift-kube-apiserver/admission/admissionenablement/register.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/mixedcpus"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/conditiontransitiontimeinjection"
 
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
 	imagepolicyapiv1 "github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1"
@@ -44,6 +45,7 @@ func RegisterOpenshiftKubeAdmissionPlugins(plugins *admission.Plugins) {
 	externalipranger.RegisterExternalIP(plugins)
 	restrictedendpoints.RegisterRestrictedEndpoints(plugins)
 	csiinlinevolumesecurity.Register(plugins)
+	conditiontransitiontimeinjection.Register(plugins)
 }
 
 var (
@@ -77,6 +79,7 @@ var (
 		csiinlinevolumesecurity.PluginName, // "storage.openshift.io/CSIInlineVolumeSecurity"
 		managednode.PluginName,             // "autoscaling.openshift.io/ManagedNode"
 		mixedcpus.PluginName,               // "autoscaling.openshift.io/MixedCPUs"
+		conditiontransitiontimeinjection.PluginName,
 	}
 
 	// openshiftAdmissionPluginsForKubeAfterResourceQuota are the plugins to add after ResourceQuota plugin

--- a/openshift-kube-apiserver/admission/conditiontransitiontimeinjection/mutate_transition_time.go
+++ b/openshift-kube-apiserver/admission/conditiontransitiontimeinjection/mutate_transition_time.go
@@ -1,0 +1,201 @@
+package conditiontransitiontimeinjection
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"strconv"
+	"strings"
+
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	PluginName                                 = "openshift.io/ConditionTransitionTimeInjector"
+	ConditionTransitionTimeInjectionAnnotation = "openshift.io/ConditionTransitionTimeInjection"
+
+	InjectDefault            = ""
+	InjectOnStatusChange     = "OnStatusChange"
+	InjectOnReasonChange     = "OnReasonChange"
+	InjectOnMessageChange    = "OnMessageChange"
+	InjectOnGenerationChange = "OnGenerationChange"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return &mutateConditionTransitionTime{
+			Handler: admission.NewHandler(admission.Create, admission.Update),
+		}, nil
+	})
+}
+
+// ValidateCustomResource is an implementation of admission.Interface.
+// It looks at all new pods and overrides each container's image pull policy to Always.
+type mutateConditionTransitionTime struct {
+	*admission.Handler
+}
+
+var _ admission.MutationInterface = &mutateConditionTransitionTime{}
+
+// Validate is an admission function that will validate a CRD in config.openshift.io.  uncastAttributes are attributes
+// that are of type unstructured.
+func (*mutateConditionTransitionTime) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if a.GetSubresource() != "status" {
+		return nil
+	}
+	newObj := a.GetObject()
+	if newObj == nil {
+		return nil
+	}
+	newMetadata, err := meta.Accessor(newObj)
+	if err != nil {
+		return nil
+	}
+	injectionReasons := getInjectionReasons(newMetadata)
+	if len(injectionReasons) == 0 {
+		return nil
+	}
+
+	oldObj := a.GetOldObject()
+	newConditions := getConditions(newObj)
+	oldConditions := getConditions(oldObj)
+	now := now()
+
+	for i, newCondition := range newConditions {
+		oldCondition := meta.FindStatusCondition(oldConditions, newCondition.Type)
+		if oldCondition == nil {
+			if err := setLastTransitionTime(newObj, i, now); err != nil {
+				return fmt.Errorf("unable to inject last transition time for %q: %w", newCondition.Type, err)
+			}
+			continue
+		}
+
+		injectTransitionTime := false
+		injectTransitionTime = injectTransitionTime || (injectionReasons.Has(InjectOnStatusChange) && newCondition.Status != oldCondition.Status)
+		injectTransitionTime = injectTransitionTime || (injectionReasons.Has(InjectOnGenerationChange) && newCondition.ObservedGeneration != oldCondition.ObservedGeneration)
+		injectTransitionTime = injectTransitionTime || (injectionReasons.Has(InjectOnMessageChange) && newCondition.Message != oldCondition.Message)
+		injectTransitionTime = injectTransitionTime || (injectionReasons.Has(InjectOnReasonChange) && newCondition.Reason != oldCondition.Reason)
+
+		if !injectTransitionTime {
+			// we have an existing old transition time.  Be sure we preserve this.
+			if err := setLastTransitionTime(newObj, i, oldCondition.LastTransitionTime); err != nil {
+				return fmt.Errorf("unable to re-use last transition time for %q: %w", newCondition.Type, err)
+			}
+			continue
+		}
+
+		if err := setLastTransitionTime(newObj, i, now); err != nil {
+			return fmt.Errorf("unable to inject last transition time for %q: %w", newCondition.Type, err)
+		}
+	}
+
+	return nil
+}
+
+// for unit testing
+var now func() metav1.Time = metav1.Now
+
+func getInjectionReasons(metadata metav1.Object) sets.Set[string] {
+	injectionPolicy, ok := metadata.GetAnnotations()[ConditionTransitionTimeInjectionAnnotation]
+	if !ok {
+		return nil
+	}
+
+	// if set to empty, use the default
+	if len(strings.TrimSpace(injectionPolicy)) == 0 {
+		return sets.New(InjectOnStatusChange)
+	}
+
+	ret := sets.Set[string]{}
+	for _, curr := range strings.Split(injectionPolicy, ",") {
+		ret.Insert(strings.TrimSpace(curr))
+	}
+	return ret
+}
+
+// coerce as much as we can to metav1.Condition.
+func getConditions(obj runtime.Object) []metav1.Condition {
+	if obj == nil {
+		return nil
+	}
+
+	unstructuredObj, ok := obj.(runtime.Unstructured)
+	// If we aren't unstructured, then we must not be a CR.  While this should be handled eventually, for now just do nothing.
+	// Our immediate concern is for CRs.
+	if !ok {
+		return nil
+	}
+
+	unstructuredMap := unstructuredObj.UnstructuredContent()
+	conditionsSlice, found, err := unstructured.NestedSlice(unstructuredMap, "status", "conditions")
+	if !found {
+		return nil
+	}
+	if err != nil {
+		return nil
+	}
+
+	ret := []metav1.Condition{}
+	for _, currConditionUncast := range conditionsSlice {
+		currCondition, ok := currConditionUncast.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		typedCondition := metav1.Condition{}
+		typedCondition.Type, _, _ = unstructured.NestedString(currCondition, "type")
+		tempString, _, _ := unstructured.NestedString(currCondition, "status")
+		typedCondition.Status = metav1.ConditionStatus(tempString)
+		typedCondition.Reason, _, _ = unstructured.NestedString(currCondition, "reason")
+		typedCondition.Message, _, _ = unstructured.NestedString(currCondition, "message")
+		typedCondition.ObservedGeneration, _, _ = unstructured.NestedInt64(currCondition, "observedGeneration")
+		tempString, _, _ = unstructured.NestedString(currCondition, "lastTransitionTime")
+		if len(tempString) > 0 {
+			if err := typedCondition.LastTransitionTime.UnmarshalJSON([]byte(strconv.Quote(tempString))); err != nil {
+				panic(fmt.Sprintf("got %q: %v", tempString, err))
+			}
+		}
+		ret = append(ret, typedCondition)
+	}
+
+	return ret
+}
+
+// coerce as much as we can to metav1.Condition.
+func setLastTransitionTime(obj runtime.Object, index int, desiredTime metav1.Time) error {
+	if obj == nil {
+		return nil
+	}
+
+	unstructuredObj, ok := obj.(runtime.Unstructured)
+	// If we aren't unstructured, then we must not be a CR.  While this should be handled eventually, for now just do nothing.
+	// Our immediate concern is for CRs.
+	if !ok {
+		return nil
+	}
+
+	unstructuredMap := unstructuredObj.UnstructuredContent()
+	conditionsSlice, found, err := unstructured.NestedSlice(unstructuredMap, "status", "conditions")
+	if !found {
+		return fmt.Errorf("no conditions found")
+	}
+	if err != nil {
+		return fmt.Errorf("unable to get conditions: %w", err)
+	}
+	conditionMap, ok := conditionsSlice[index].(map[string]interface{})
+	tBytes, _ := desiredTime.MarshalJSON()
+	conditionMap["lastTransitionTime"], _ = strconv.Unquote(string(tBytes))
+	conditionsSlice[index] = conditionMap
+	if err := unstructured.SetNestedSlice(unstructuredMap, conditionsSlice, "status", "conditions"); err != nil {
+		return fmt.Errorf("unable to set conditions: %w", err)
+	}
+	unstructuredObj.SetUnstructuredContent(unstructuredMap)
+
+	return nil
+}

--- a/openshift-kube-apiserver/admission/conditiontransitiontimeinjection/mutate_transition_time_test.go
+++ b/openshift-kube-apiserver/admission/conditiontransitiontimeinjection/mutate_transition_time_test.go
@@ -1,0 +1,295 @@
+package conditiontransitiontimeinjection
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"reflect"
+	"sigs.k8s.io/yaml"
+	"testing"
+	"time"
+)
+
+func Test_mutateConditionTransitionTime_Admit(t *testing.T) {
+	nowTime, err := time.Parse(time.RFC3339, "2024-07-02T15:04:05Z")
+	if err != nil {
+		panic(err)
+	}
+
+	oldNow := now
+	now = func() metav1.Time {
+		return metav1.Time{
+			Time: nowTime,
+		}
+	}
+	defer func() {
+		now = oldNow
+	}()
+
+	type fields struct {
+		Handler *admission.Handler
+	}
+	type args struct {
+		ctx context.Context
+		a   admission.Attributes
+		o   admission.ObjectInterfaces
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		desiredObj runtime.Object
+		wantErr    bool
+	}{
+		{
+			name: "simple",
+			args: args{
+				ctx: nil,
+				a: admission.NewAttributesRecord(
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z
+`),
+					nil,
+					schema.GroupVersionKind{},
+					"namespace",
+					"name",
+					schema.GroupVersionResource{},
+					"status",
+					admission.Update,
+					nil,
+					false,
+					nil,
+				),
+				o: nil,
+			},
+			desiredObj: mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+    lastTransitionTime: 2024-07-02T15:04:05Z
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-02T15:04:05Z # we overwrite this value because we have no old value
+`),
+		},
+		{
+			name: "update the right one",
+			args: args{
+				ctx: nil,
+				a: admission.NewAttributesRecord(
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+  - type: Baz
+    status: "False"
+`),
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "False"
+    lastTransitionTime: 2024-07-01T15:09:01Z
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z
+`),
+					schema.GroupVersionKind{},
+					"namespace",
+					"name",
+					schema.GroupVersionResource{},
+					"status",
+					admission.Update,
+					nil,
+					false,
+					nil,
+				),
+				o: nil,
+			},
+			desiredObj: mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+    lastTransitionTime: 2024-07-02T15:04:05Z # this condition's status changed, so inject it.
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z # we should take this value from the existing
+  - type: Baz
+    status: "False"
+    lastTransitionTime: 2024-07-02T15:04:05Z # this condition is new, so inject it
+`),
+		},
+		{
+			name: "no injection unless requested",
+			args: args{
+				ctx: nil,
+				a: admission.NewAttributesRecord(
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z
+`),
+					nil,
+					schema.GroupVersionKind{},
+					"namespace",
+					"name",
+					schema.GroupVersionResource{},
+					"status",
+					admission.Update,
+					nil,
+					false,
+					nil,
+				),
+				o: nil,
+			},
+			desiredObj: mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z
+`),
+		},
+		{
+			name: "update no injection unless requested",
+			args: args{
+				ctx: nil,
+				a: admission.NewAttributesRecord(
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+  - type: Baz
+    status: "False"
+`),
+					mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
+status:
+  conditions:
+  - type: Foo
+    status: "False"
+    lastTransitionTime: 2024-07-01T15:09:01Z
+  - type: Bar
+    status: "True"
+    lastTransitionTime: 2024-07-06T15:09:01Z
+`),
+					schema.GroupVersionKind{},
+					"namespace",
+					"name",
+					schema.GroupVersionResource{},
+					"status",
+					admission.Update,
+					nil,
+					false,
+					nil,
+				),
+				o: nil,
+			},
+			desiredObj: mustYamlToUnstructured(`
+kind: ClusterOperator
+apiVersion: config.openshift.io/v1
+metadata:
+  annotations:
+status:
+  conditions:
+  - type: Foo
+    status: "True"
+  - type: Bar
+    status: "True"
+  - type: Baz
+    status: "False"
+`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mu := &mutateConditionTransitionTime{
+				Handler: tt.fields.Handler,
+			}
+			if err := mu.Admit(tt.args.ctx, tt.args.a, tt.args.o); (err != nil) != tt.wantErr {
+				t.Errorf("Admit() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			actualObj := tt.args.a.GetObject()
+			if !reflect.DeepEqual(actualObj, tt.desiredObj) {
+				t.Error(cmp.Diff(actualObj, tt.desiredObj))
+			}
+		})
+	}
+}
+
+func mustYamlToUnstructured(in string) runtime.Object {
+	jsonString, err := yaml.YAMLToJSON([]byte(in))
+	if err != nil {
+		panic(err)
+	}
+	ret, _, err := unstructured.UnstructuredJSONScheme.Decode(jsonString, nil, &unstructured.Unstructured{})
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}


### PR DESCRIPTION
Adds a way to have particular resources request that lastTransitionTime get injected for them using 
```yaml
metadata:
  annotations:
    openshift.io/ConditionTransitionTimeInjection: OnStatusChange
```

Doing this means that the admission plugin will find any `.status.conditions` on a CR (only works for CRs today) and will set the lastTransitionTime if the status value changes, but not if anything else changes.

This will allow apply statements in the form: 
```yaml
status:
  conditions:
  - type: Foo
    status: "True"
  - type: Bar
    status: "True"
  - type: Baz
    status: "False"
```
to be accepted by the kube-apiserver and have the "now" transition time applied whenever the condition's `status` changes and left alone otherwise.

We may be able to keep the existing logic that does the computation client-side. I'm not yet sure which is easier overall.

Thoughts @JoelSpeed ?