### PR TITLE
OCPBUGS-34577: UPSTREAM: <carry>: Clean up Multi-AZ Cluster matching rule

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -13581,7 +13581,7 @@ var Annotations = map[string]string{
 
 	"[sig-storage] Mounted volume expand [Feature:StorageProvider] Should verify mounted devices can be resized": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[sig-storage] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs": " [Disabled:Broken] [Disabled:Unsupported] [Suite:k8s]",
+	"[sig-storage] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs": " [Disabled:Unsupported] [Suite:k8s]",
 
 	"[sig-storage] NFSPersistentVolumes [Disruptive] [Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash": " [Serial] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -144,9 +144,6 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1953478
 			`\[sig-storage\] Dynamic Provisioning Invalid AWS KMS key should report an error and create no PV`,
 
-			// https://issues.redhat.com/browse/OCPBUGS-34577
-			`\[sig-storage\] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs`,
-
 			// https://issues.redhat.com/browse/OCPBUGS-34594
 			`\[sig-node\] \[Feature:PodLifecycleSleepAction\] when create a pod with lifecycle hook using sleep action valid prestop hook using sleep action`,
 		},
@@ -168,7 +165,7 @@ var (
 			`Volumes GlusterFS`,         // OpenShift 4.x does not support Gluster
 			`GlusterDynamicProvisioner`, // OpenShift 4.x does not support Gluster
 			// OCP 4.16 and newer does not support PersistentVolumeLabel admission plugin and thus
-			// the test can's create in-tree PVs.
+			// the test can's create in-tree PVs. See https://issues.redhat.com/browse/OCPBUGS-34577
 			`Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs`,
 			`PersistentVolumes GCEPD`,
 			`\[Driver: azure-disk\] \[Testpattern: Pre-provisioned PV`,


### PR DESCRIPTION
Clean up "Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs" from Disabled:Broken, because the test is already skipped in Disabled:Unsupported section.

This does not really fix the linked bug, it just cleans up related OCP rules. The test still needs to be skipped.


cc @openshift/storage 