### PR TITLE
OCPEDGE-1181: UPSTREAM: <carry>: update test annotations for sno

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -575,7 +575,7 @@ var Annotations = map[string]string{
 
 	"[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] stateful upgrade should maintain a functioning cluster": " [Disabled:Unimplemented] [Suite:k8s]",
 
-	"[sig-architecture] Conformance Tests should have at least two untainted nodes [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[sig-architecture] Conformance Tests should have at least two untainted nodes [Conformance]": " [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[sig-auth] Certificates API [Privileged:ClusterAdmin] should support CSR API operations [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -334,6 +334,7 @@ var (
 			`\[sig-cli\] Kubectl client Kubectl taint \[Serial\] should remove all the taints with the same key off a node`,
 			`\[sig-network\] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on different nodes`,
 			`\[sig-network\] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same nodes`,
+			`\[sig-architecture\] Conformance Tests should have at least two untainted nodes`,
 		},
 
 		// Tests which can't be run/don't make sense to run against a cluster with all optional capabilities disabled


### PR DESCRIPTION
recent addition (https://github.com/openshift/kubernetes/pull/2017) of upstream architecture package to openshift tests include.go is breaking conformance tests for sno 

should squash with tooling

