### PR TITLE
OCPBUGS-39004: UPSTREAM: 127243: Fix invalid label use in validatingadmissionpolicy e2e

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -367,8 +367,8 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 					// If the warnings are empty, touch the policy to retry type checking
 					if len(policy.Status.TypeChecking.ExpressionWarnings) == 0 {
 						applyConfig := applyadmissionregistrationv1.ValidatingAdmissionPolicy(policy.Name).WithLabels(map[string]string{
-							"touched": time.Now().String(),
-							"random":  fmt.Sprintf("%d", rand.Int()),
+							"touched": fmt.Sprintf("a%d", time.Now().UnixMilli()),
+							"random":  fmt.Sprintf("a%d", rand.Int()),
 						})
 						_, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Apply(ctx, applyConfig, metav1.ApplyOptions{FieldManager: "validatingadmissionpolicy-e2e"})
 						return false, err


### PR DESCRIPTION
If this fallback code was hit, it would always fail due to invalid text
in a label.
