### PR TITLE
SDN-5457: Add Dockerfile for standalone kube-proxy image

### DIFF
--- a/openshift-hack/images/kube-proxy/Dockerfile.rhel
+++ b/openshift-hack/images/kube-proxy/Dockerfile.rhel
@@ -1,0 +1,15 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+WORKDIR /go/src/k8s.io/kubernetes
+COPY . .
+RUN make WHAT='cmd/kube-proxy' && \
+    mkdir -p /tmp/build && \
+    cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/kube-proxy /tmp/build
+
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+RUN INSTALL_PKGS="conntrack-tools iptables nftables" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum clean all && rm -rf /var/cache/*
+COPY --from=builder /tmp/build/* /usr/bin/
+LABEL io.k8s.display-name="Kubernetes kube-proxy" \
+      io.k8s.description="Provides kube-proxy for external CNI plugins" \
+      io.openshift.tags="openshift,kube-proxy"

--- a/openshift-hack/images/kube-proxy/OWNERS
+++ b/openshift-hack/images/kube-proxy/OWNERS
@@ -1,0 +1,19 @@
+reviewers:
+  - abhat
+  - danwinship
+  - dougbtv
+  - JacobTanenbaum
+  - jcaamano
+  - kyrtapz
+  - trozet
+  - tssurya
+approvers:
+  - abhat
+  - danwinship
+  - dougbtv
+  - fepan
+  - JacobTanenbaum
+  - jcaamano
+  - knobunc
+  - kyrtapz
+  - trozet

--- a/openshift-hack/images/kube-proxy/test-kube-proxy.sh
+++ b/openshift-hack/images/kube-proxy/test-kube-proxy.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# This script tests the kube-proxy image without actually using it as
+# part of the infrastructure of a cluster. It is intended to be copied
+# to the kubernetes-tests image for use in CI and should have no
+# dependencies beyond oc and basic shell stuff.
+
+# There is no good way to "properly" test the kube-proxy image in
+# OpenShift CI, because it is only used as a dependency of third-party
+# software (e.g. Calico); no fully-RH-supported configuration uses it.
+#
+# However, since we don't apply any kube-proxy-specific patches to our
+# tree, we can assume that it *mostly* works, since we are building
+# from sources that passed upstream testing. This script is just to
+# confirm that our build is not somehow completely broken (e.g.
+# immediate segfault due to a bad build environment).
+
+if [[ -z "${KUBE_PROXY_IMAGE}" ]]; then
+    echo "KUBE_PROXY_IMAGE not set" 1>&2
+    exit 1
+fi
+
+TMPDIR=$(mktemp --tmpdir -d kube-proxy.XXXXXX)
+function cleanup() {
+    oc delete namespace kube-proxy-test || true
+    oc delete clusterrole kube-proxy-test || true
+    oc delete clusterrolebinding kube-proxy-test || true
+    rm -rf "${TMPDIR}"
+}
+trap "cleanup" EXIT
+
+function indent() {
+    sed -e 's/^/  /' "$@"
+    echo ""
+}
+
+# Decide what kube-proxy mode to use.
+# (jsonpath expression copied from types_cluster_version.go)
+OCP_VERSION=$(oc get clusterversion version -o jsonpath='{.status.history[?(@.state=="Completed")].version}')
+case "${OCP_VERSION}" in
+    4.17.*|4.18.*)
+        # 4.17 and 4.18 always use RHEL 9 (and nftables mode was still alpha in 4.17), so
+        # use iptables mode
+        PROXY_MODE="iptables"
+        ;;
+    *)
+        # 4.19 and later may use RHEL 10, so use nftables mode
+        PROXY_MODE="nftables"
+        ;;
+esac
+
+echo "Setting up Namespace and RBAC"
+oc create -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-proxy-test
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-proxy-test
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - endpoints
+  - services
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-proxy-test
+  namespace: kube-proxy-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-proxy-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-proxy-test
+subjects:
+- kind: ServiceAccount
+  name: kube-proxy-test
+  namespace: kube-proxy-test
+EOF
+echo ""
+
+# We run kube-proxy in a pod-network pod, so that it can create rules
+# in that pod's network namespace without interfering with
+# ovn-kubernetes in the host network namespace.
+#
+# We need to manually set all of the conntrack values to 0 so it won't
+# try to set the sysctls (which would fail). This is the most fragile
+# part of this script in terms of future compatibility. Likewise, we
+# need to set .iptables.localhostNodePorts=false so it won't try to
+# set the sysctl associated with that. (The nftables mode never tries
+# to set that sysctl.)
+oc create -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: kube-proxy-test
+data:
+  kube-proxy-config.yaml: |-
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    kind: KubeProxyConfiguration
+    conntrack:
+      maxPerCore: 0
+      min: 0
+      tcpCloseWaitTimeout: 0s
+      tcpEstablishedTimeout: 0s
+      udpStreamTimeout: 0s
+      udpTimeout: 0s
+    iptables:
+      localhostNodePorts: false
+    mode: ${PROXY_MODE}
+EOF
+echo "config is:"
+oc get configmap -n kube-proxy-test config -o yaml | indent
+
+# The --hostname-override is needed to fake out the node detection,
+# since we aren't running in a host-network pod. (The fact that we're
+# cheating here means we'll end up generating incorrect NodePort rules
+# but that doesn't matter.)
+oc create -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-proxy-test
+spec:
+  containers:
+  - name: kube-proxy
+    image: ${KUBE_PROXY_IMAGE}
+    command:
+    - /bin/sh
+    - -c
+    - exec kube-proxy --hostname-override "\${NODENAME}" --config /config/kube-proxy-config.yaml -v 4
+    env:
+    - name: NODENAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /config
+      name: config
+      readOnly: true
+  serviceAccountName: kube-proxy-test
+  volumes:
+  - name: config
+    configMap:
+      name: config
+EOF
+echo "pod is:"
+oc get pod -n kube-proxy-test kube-proxy -o yaml | indent
+oc wait --for=condition=Ready -n kube-proxy-test pod/kube-proxy
+
+echo "Waiting for kube-proxy to program initial ${PROXY_MODE} rules..."
+function kube_proxy_synced() {
+    oc exec -n kube-proxy-test kube-proxy -- curl -s http://127.0.0.1:10249/metrics > "${TMPDIR}/metrics.txt"
+    grep -q '^kubeproxy_sync_proxy_rules_duration_seconds_count [^0]' "${TMPDIR}/metrics.txt"
+}
+synced=false
+for count in $(seq 1 10); do
+    date
+    if kube_proxy_synced; then
+        synced=true
+        break
+    fi
+    sleep 5
+done
+date
+if [[ "${synced}" != true ]]; then
+    echo "kube-proxy failed to sync to ${PROXY_MODE}:"
+    oc logs -n kube-proxy-test kube-proxy |& indent
+
+    echo "last-seen metrics:"
+    indent "${TMPDIR}/metrics.txt"
+
+    exit 1
+fi
+
+# Dump the ruleset; since RHEL9 uses iptables-nft, kube-proxy's rules
+# will show up in the nft ruleset regardless of whether kube-proxy is
+# using iptables or nftables.
+echo "Dumping rules"
+oc exec -n kube-proxy-test kube-proxy -- nft list ruleset >& "${TMPDIR}/nft.out"
+
+# We don't want to hardcode any assumptions about what kube-proxy's
+# rules look like, but it necessarily must be the case that every
+# clusterIP appears somewhere in the output. (We could look for
+# endpoint IPs too, but that's more racy if there's any chance the
+# cluster could be changing.)
+exitcode=0
+for service in kubernetes.default dns-default.openshift-dns router-default.openshift-ingress; do
+    name="${service%.*}"
+    namespace="${service#*.}"
+    clusterIP="$(oc get service -n ${namespace} ${name} -o jsonpath='{.spec.clusterIP}')"
+    echo "Looking for ${service} cluster IP (${clusterIP}) in ruleset"
+    for ip in ${clusterIP}; do
+        if ! grep --quiet --fixed-strings " ${ip} " "${TMPDIR}/nft.out"; then
+            echo "Did not find IP ${ip} (from service ${name} in namespace ${namespace}) in ruleset" 1>&2
+            exitcode=1
+        fi
+    done
+done
+echo ""
+
+if [[ "${exitcode}" == 1 ]]; then
+    echo "Ruleset was:"
+    indent "${TMPDIR}/nft.out"
+
+    echo "kube-proxy logs:"
+    oc logs -n kube-proxy-test kube-proxy |& indent
+fi
+
+exit "${exitcode}"

--- a/openshift-hack/images/tests/Dockerfile.rhel
+++ b/openshift-hack/images/tests/Dockerfile.rhel
@@ -6,12 +6,14 @@ RUN make WHAT=openshift-hack/e2e/k8s-e2e.test; \
     mkdir -p /tmp/build; \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/k8s-e2e.test /tmp/build/; \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/ginkgo /tmp/build/; \
-    cp /go/src/k8s.io/kubernetes/openshift-hack/test-kubernetes-e2e.sh /tmp/build/
+    cp /go/src/k8s.io/kubernetes/openshift-hack/test-kubernetes-e2e.sh /tmp/build/; \
+    cp /go/src/k8s.io/kubernetes/openshift-hack/images/kube-proxy/test-kube-proxy.sh /tmp/build/
 
 FROM registry.ci.openshift.org/ocp/4.18:tools
 COPY --from=builder /tmp/build/k8s-e2e.test /usr/bin/
 COPY --from=builder /tmp/build/ginkgo /usr/bin/
 COPY --from=builder /tmp/build/test-kubernetes-e2e.sh /usr/bin/
+COPY --from=builder /tmp/build/test-kube-proxy.sh /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2080,6 +2080,173 @@ func TestClusterIPGeneral(t *testing.T) {
 	})
 }
 
+func TestOpenShiftDNSHackTCP(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.10"
+	svcPort := 53
+	podPort := 5353
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("openshift-dns", "dns-default"),
+		Port:           "dns-tcp",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				// This endpoint is ignored because it's remote
+				Addresses: []string{"10.180.0.2"},
+				NodeName:  ptr.To("node2"),
+			}, {
+				Addresses: []string{"10.180.0.1"},
+				NodeName:  ptr.To(testHostname),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To[int32](int32(podPort)),
+				Protocol: &svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	runPacketFlowTests(t, getLine(), ipt, testNodeIPs, []packetFlowTest{
+		{
+			name:     "TCP DNS only goes to local endpoint",
+			sourceIP: "10.0.0.2",
+			destIP:   "172.30.0.10",
+			destPort: 53,
+			output:   "10.180.0.1:5353",
+		},
+	})
+}
+
+func TestOpenShiftDNSHackUDP(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.10"
+	svcPort := 53
+	podPort := 5353
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("openshift-dns", "dns-default"),
+		Port:           "dns",
+		Protocol:       v1.ProtocolUDP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				// This endpoint is ignored because it's remote
+				Addresses: []string{"10.180.0.2"},
+				NodeName:  ptr.To("node2"),
+			}, {
+				Addresses: []string{"10.180.0.1"},
+				NodeName:  ptr.To(testHostname),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To[int32](int32(podPort)),
+				Protocol: &svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	runPacketFlowTests(t, getLine(), ipt, testNodeIPs, []packetFlowTest{
+		{
+			name:     "UDP DNS only goes to local endpoint",
+			sourceIP: "10.0.0.2",
+			protocol: v1.ProtocolUDP,
+			destIP:   "172.30.0.10",
+			destPort: 53,
+			output:   "10.180.0.1:5353",
+		},
+	})
+}
+
+func TestOpenShiftDNSHackFallback(t *testing.T) {
+	ipt := iptablestest.NewFake()
+	fp := NewFakeProxier(ipt)
+	svcIP := "172.30.0.10"
+	svcPort := 53
+	podPort := 5353
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("openshift-dns", "dns-default"),
+		Port:           "dns",
+		Protocol:       v1.ProtocolUDP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			// Both endpoints are used because neither is local
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"10.180.1.2"},
+				NodeName:  ptr.To("node2"),
+			}, {
+				Addresses: []string{"10.180.2.3"},
+				NodeName:  ptr.To("node3"),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To[int32](int32(podPort)),
+				Protocol: &svcPortName.Protocol,
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	runPacketFlowTests(t, getLine(), ipt, testNodeIPs, []packetFlowTest{
+		{
+			name:     "DNS goes to all endpoints when none are local",
+			sourceIP: "10.0.0.2",
+			protocol: v1.ProtocolUDP,
+			destIP:   "172.30.0.10",
+			destPort: 53,
+			output:   "10.180.1.2:5353, 10.180.2.3:5353",
+		},
+	})
+}
+
 func TestLoadBalancer(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)


### PR DESCRIPTION
OpenShift ships a `kube-proxy` image in the release payload for use by third-party CNI plugins (eg, Calico). In the past, this was built out of `openshift/sdn`, but since openshift-sdn is no longer part of OpenShift as of 4.17, this no longer makes a lot of sense.

In the future we do not expect to ever have any carry patches against kube-proxy, so @deads2k agreed it makes sense to just build our kube-proxy images out of `openshift/kubernetes` along with the other upstream stuff.

This adds a Dockerfile for that; the top half of the Dockerfile is a simplified version of the hyperkube Dockerfile, and the bottom half comes from [the existing kube-proxy Dockerfile in openshift-sdn](https://github.com/openshift/sdn/blob/release-4.17/images/kube-proxy/Dockerfile.rhel). (The OWNERS file is from cluster-network-operator, since sdn's OWNERS file had gotten out-of-date.)

AFAIK, there's no way to test this PR until after we also update `openshift/release`, right? Though, related, `openshift-hack/lib/constants.sh` has `OS_ALL_IMAGES` and `os::build::images()` with "all images in this repo", but I couldn't find anything that actually _uses_ them? (So I didn't add the kube-proxy image to those. Should I?)

Also, the hyperkube Dockerfile adds a `io.openshift.build.versions="kubernetes=1.30.3"` label to the image, and according to `REBASE.openshift.md`, the label is "among other things, used by ART to inject appropriate version of kubernetes during build process"... I wasn't sure if I should have a label on the kube-proxy image too (for the "other things"?). For now I didn't add it.

----

The last bit is CI... So, up until 4.16, we did not explicitly CI (or QE) this image, but the kube-proxy image was built from the same source tree as the openshift-sdn image, so we kinda sorta almost did? In 4.17 currently we do not have CI for the kube-proxy image and also aren't testing openshift-sdn...

Doing "proper" e2e testing of the kube-proxy image within OCP is not really possible, because the image is only used in non-RH-supported configurations; we would have to write a CI workflow to install an OCP cluster with Calico or flannel or something (and maintain it forever).

However, we know that the kube-proxy image must at least _almost_ work, since it's based on working upstream code, and we aren't applying any kube-proxy-specific patches, and `ci/prow/unit` would have failed if the kube-proxy unit tests failed. So if we just test that the `kube-proxy` binary in the image is able to start up without crashing, and eventually reports itself healthy, and has written out some vaguely-plausible-looking iptables/nftables rules when it does, then that seems good enough to be confident that it works. The `test-kube-proxy.sh` script in this PR does just that; I [tested it against the sdn kube-proxy build](https://github.com/openshift/release/pull/57995) to make sure it works. After this PR merges, I will file a PR against openshift/release to add another step to the `openshift-kubernetes-e2e-test` workflow used by `k8s-e2e-gcp-ovn` to run this test as well. (And to build and promote the `kube-proxy` image out of kubernetes rather than sdn.)