### PR TITLE
OCPBUGS-41678: mount-utils: treat syscall.ENODEV as corrupted mount

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_unix.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_unix.go
@@ -58,7 +58,13 @@ func IsCorruptedMnt(err error) bool {
 		underlyingError = err
 	}
 
-	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES || underlyingError == syscall.EHOSTDOWN || underlyingError == syscall.EWOULDBLOCK
+	return errors.Is(underlyingError, syscall.ENOTCONN) ||
+		errors.Is(underlyingError, syscall.ESTALE) ||
+		errors.Is(underlyingError, syscall.EIO) ||
+		errors.Is(underlyingError, syscall.EACCES) ||
+		errors.Is(underlyingError, syscall.EHOSTDOWN) ||
+		errors.Is(underlyingError, syscall.EWOULDBLOCK) ||
+		errors.Is(underlyingError, syscall.ENODEV)
 }
 
 // MountInfo represents a single line in /proc/<pid>/mountinfo.


### PR DESCRIPTION
https://issues.redhat.com//browse/OCPBUGS-41678

In 4.14+ we were able to simply bump the upstream mount-utils version, but on 4.13 we need this patch in openshift/kubernetes first before pointing azure-file-csi-driver to the version of mount-utils in the o/k release-4.13 branch.

/cc @openshift/storage @bertinatto
