### PR TITLE
OCPBUGS-42315: correct cloud provider detection logic

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -616,16 +616,10 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	}
 
 	if kubeDeps.Cloud == nil {
-		if !cloudprovider.IsExternal(s.CloudProvider) {
-			cloudprovider.DeprecationWarningForProvider(s.CloudProvider)
-			cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-			if err != nil {
-				return err
-			}
-			if cloud != nil {
-				klog.V(2).InfoS("Successfully initialized cloud provider", "cloudProvider", s.CloudProvider, "cloudConfigFile", s.CloudConfigFile)
-			}
-			kubeDeps.Cloud = cloud
+		if !cloudprovider.IsExternal(s.CloudProvider) && len(s.CloudProvider) != 0 {
+			// internal cloud provider loops are disabled
+			cloudprovider.DisableWarningForProvider(s.CloudProvider)
+			return cloudprovider.ErrorForDisabledProvider(s.CloudProvider)
 		}
 	}
 

--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -42,7 +42,7 @@ func (opts *CloudProviderOptions) Validate() []error {
 
 	switch {
 	case opts.CloudProvider == "":
-	case opts.CloudProvider == "external":
+	case cloudprovider.IsExternal(opts.CloudProvider):
 		if !utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) {
 			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+
 				"please set DisableCloudProviders feature to true", opts.CloudProvider))
@@ -50,15 +50,6 @@ func (opts *CloudProviderOptions) Validate() []error {
 		if !utilfeature.DefaultFeatureGate.Enabled(features.DisableKubeletCloudCredentialProviders) {
 			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+
 				"please set DisableKubeletCloudCredentialProviders feature to true", opts.CloudProvider))
-		}
-	case cloudprovider.IsDeprecatedInternal(opts.CloudProvider):
-		if utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) {
-			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+
-				"please set DisableCloudProviders feature to false", opts.CloudProvider))
-		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.DisableKubeletCloudCredentialProviders) {
-			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+
-				"please set DisableKubeletCloudCredentialProviders feature to false", opts.CloudProvider))
 		}
 	default:
 		errs = append(errs, fmt.Errorf("unknown --cloud-provider: %s", opts.CloudProvider))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -389,7 +389,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		return nil, fmt.Errorf("invalid sync frequency %d", kubeCfg.SyncFrequency.Duration)
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) && cloudprovider.IsDeprecatedInternal(cloudProvider) {
+	if !cloudprovider.IsExternal(cloudProvider) && len(cloudProvider) != 0 {
 		cloudprovider.DisableWarningForProvider(cloudProvider)
 		return nil, fmt.Errorf("cloud provider %q was specified, but built-in cloud providers are disabled. Please set --cloud-provider=external and migrate to an external cloud provider", cloudProvider)
 	}

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -33,15 +33,8 @@ type Factory func(config io.Reader) (Interface, error)
 
 // All registered cloud providers.
 var (
-	providersMutex           sync.Mutex
-	providers                = make(map[string]Factory)
-	deprecatedCloudProviders = []struct {
-		name     string
-		external bool
-		detail   string
-	}{
-		{"gce", false, "The GCE provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-gcp"},
-	}
+	providersMutex sync.Mutex
+	providers      = make(map[string]Factory)
 )
 
 const externalCloudProvider = "external"
@@ -87,47 +80,19 @@ func IsExternal(name string) bool {
 	return name == externalCloudProvider
 }
 
-// IsDeprecatedInternal is responsible for preventing cloud.Interface
-// from being initialized in kubelet, kube-controller-manager or kube-api-server
-func IsDeprecatedInternal(name string) bool {
-	for _, provider := range deprecatedCloudProviders {
-		if provider.name == name {
-			return true
-		}
-	}
-
-	return false
-}
-
 // DisableWarningForProvider logs information about disabled cloud provider state
 func DisableWarningForProvider(providerName string) {
-	for _, provider := range deprecatedCloudProviders {
-		if provider.name == providerName {
-			klog.Infof("INFO: Please make sure you are running external cloud controller manager binary for provider %q."+
-				"In-tree cloud providers are currently disabled. Refer to https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/sample"+
-				"for example implementation.", providerName)
-			detail := fmt.Sprintf("Please reach to sig-cloud-provider and use 'external' cloud provider for %q: %s", providerName, provider.detail)
-			klog.Warningf("WARNING: %q built-in cloud provider is now disabled. %s", providerName, detail)
-			break
-		}
+	if !IsExternal(providerName) {
+		klog.Infof("INFO: Please make sure you are running an external cloud controller manager binary for provider %q."+
+			"In-tree cloud providers are disabled. Refer to https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/sample "+
+			"for an example implementation.", providerName)
+		klog.Warningf("WARNING: built-in cloud providers are disabled. Please set \"--cloud-provider=external\" and migrate to an external cloud controller manager for provider %q", providerName)
 	}
 }
 
-// DeprecationWarningForProvider logs information about deprecated cloud provider state
-func DeprecationWarningForProvider(providerName string) {
-	for _, provider := range deprecatedCloudProviders {
-		if provider.name != providerName {
-			continue
-		}
-
-		detail := provider.detail
-		if provider.external {
-			detail = fmt.Sprintf("Please use 'external' cloud provider for %s: %s", providerName, provider.detail)
-		}
-
-		klog.Warningf("WARNING: %s built-in cloud provider is now deprecated. %s", providerName, detail)
-		break
-	}
+// ErrorForDisabledProvider returns an error formatted with the supplied provider name
+func ErrorForDisabledProvider(providerName string) error {
+	return fmt.Errorf("cloud provider %q was specified, but built-in cloud providers are disabled. Please set --cloud-provider=external and migrate to an external cloud provider", providerName)
 }
 
 // InitCloudProvider creates an instance of the named cloud provider.


### PR DESCRIPTION
This is a combination of two commits from the upstream kubernetes/kubernetes#127711

remove IsDeprecatedInternal from cloudprovider.plugins

The internal cloud controller loops are disabled at this point, this function should not be used as it does not return accurate information. In its place we check for the presence of the external cloud provider as that is the only acceptable value.

factor out cloudprovider.DeprecationWarningForProvider

this change removes the deprecation warning function in favor of using the `cloudprovider.DisableWarningForProvider`. it also fixes some of the logic to ensure that non-external providers are properly detected and warned about.