### PR TITLE
OCPNODE-2940: add minimumkubeletversion package

### DIFF
--- a/cmd/kube-apiserver/app/config.go
+++ b/cmd/kube-apiserver/app/config.go
@@ -23,12 +23,8 @@ import (
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
 
-	"k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
-	"k8s.io/kubernetes/openshift-kube-apiserver/authorization/minimumkubeletversion"
-	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 	"k8s.io/kubernetes/pkg/controlplane"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
@@ -88,17 +84,6 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	if ocfg := enablement.OpenshiftConfig(); ocfg != nil {
-		// Add MinimumKubeletVerison authorizer, to block a node from being able to access most resources if it's not new enough.
-		// We must do so here instead of in pkg/apiserver because it relies on a node informer, which is not present in generic control planes.
-		genericConfig.Authorization.Authorizer = union.New(genericConfig.Authorization.Authorizer, minimumkubeletversion.NewMinimumKubeletVersion(
-			ocfg.MinimumKubeletVersion,
-			nodeidentifier.NewDefaultNodeIdentifier(),
-			versionedInformers.Core().V1().Nodes().Informer(),
-			versionedInformers.Core().V1().Nodes().Lister(),
-		))
 	}
 
 	kubeAPIs, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)

--- a/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version.go
+++ b/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version.go
@@ -1,0 +1,90 @@
+package minimumkubeletversion
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	nodelib "github.com/openshift/library-go/pkg/apiserver/node"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	v1listers "k8s.io/client-go/listers/core/v1"
+	cache "k8s.io/client-go/tools/cache"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
+)
+
+type minimumKubeletVersionAuth struct {
+	nodeIdentifier          nodeidentifier.NodeIdentifier
+	nodeLister              v1listers.NodeLister
+	minVersion              *semver.Version
+	hasNodeInformerSyncedFn func() bool // factored for unit tests
+}
+
+// Creates a new minimumKubeletVersionAuth object, which is an authorizer that checks
+// whether nodes are new enough to be authorized.
+func NewMinimumKubeletVersion(minVersionStr string,
+	nodeIdentifier nodeidentifier.NodeIdentifier,
+	nodeInformer cache.SharedIndexInformer,
+	nodeLister v1listers.NodeLister,
+) *minimumKubeletVersionAuth {
+	var minVersionPtr *semver.Version
+	if len(minVersionStr) != 0 {
+		v := semver.MustParse(minVersionStr)
+		minVersionPtr = &v
+	}
+
+	return &minimumKubeletVersionAuth{
+		nodeIdentifier:          nodeIdentifier,
+		nodeLister:              nodeLister,
+		hasNodeInformerSyncedFn: nodeInformer.HasSynced,
+		minVersion:              minVersionPtr,
+	}
+}
+
+func (m *minimumKubeletVersionAuth) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
+	if m.minVersion == nil {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
+	nodeName, isNode := m.nodeIdentifier.NodeIdentity(attrs.GetUser())
+	if !isNode {
+		// ignore requests from non-nodes
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
+	if len(nodeName) == 0 {
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("unknown node for user %q", attrs.GetUser().GetName()), nil
+	}
+
+	// Short-circut if "subjectaccessreviews", or a "get" or "update" on the node object.
+	// Regardless of kubelet version, it should be allowed to do these things.
+	if attrs.IsResourceRequest() {
+		requestResource := schema.GroupResource{Group: attrs.GetAPIGroup(), Resource: attrs.GetResource()}
+		switch requestResource {
+		case api.Resource("nodes"):
+			if v := attrs.GetVerb(); v == "get" || v == "update" {
+				return authorizer.DecisionNoOpinion, "", nil
+			}
+		// TODO(haircommander): do we need other flavors of access reviews here?
+		case authorizationv1.Resource("subjectaccessreviews"):
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+	}
+
+	if !m.hasNodeInformerSyncedFn() {
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("node informer not synced, cannot check if node %s is new enough", nodeName), nil
+	}
+
+	node, err := m.nodeLister.Get(nodeName)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("failed to get node %s: %v", nodeName, err), nil
+	}
+
+	if err := nodelib.IsNodeTooOld(node, m.minVersion); err != nil {
+		return authorizer.DecisionDeny, err.Error(), nil
+	}
+
+	return authorizer.DecisionNoOpinion, "", nil
+}

--- a/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version.go
+++ b/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version.go
@@ -2,15 +2,19 @@ package minimumkubeletversion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	openshiftfeatures "github.com/openshift/api/features"
 	nodelib "github.com/openshift/library-go/pkg/apiserver/node"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/util/feature"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	cache "k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/featuregate"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 )
@@ -24,38 +28,26 @@ type minimumKubeletVersionAuth struct {
 
 // Creates a new minimumKubeletVersionAuth object, which is an authorizer that checks
 // whether nodes are new enough to be authorized.
-func NewMinimumKubeletVersion(minVersionStr string,
+func NewMinimumKubeletVersion(minVersion *semver.Version,
 	nodeIdentifier nodeidentifier.NodeIdentifier,
 	nodeInformer cache.SharedIndexInformer,
 	nodeLister v1listers.NodeLister,
 ) *minimumKubeletVersionAuth {
-	var minVersionPtr *semver.Version
-	if len(minVersionStr) != 0 {
-		v := semver.MustParse(minVersionStr)
-		minVersionPtr = &v
+	if !feature.DefaultFeatureGate.Enabled(featuregate.Feature(openshiftfeatures.FeatureGateMinimumKubeletVersion)) {
+		minVersion = nil
 	}
 
 	return &minimumKubeletVersionAuth{
 		nodeIdentifier:          nodeIdentifier,
 		nodeLister:              nodeLister,
 		hasNodeInformerSyncedFn: nodeInformer.HasSynced,
-		minVersion:              minVersionPtr,
+		minVersion:              minVersion,
 	}
 }
 
 func (m *minimumKubeletVersionAuth) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if m.minVersion == nil {
 		return authorizer.DecisionNoOpinion, "", nil
-	}
-
-	nodeName, isNode := m.nodeIdentifier.NodeIdentity(attrs.GetUser())
-	if !isNode {
-		// ignore requests from non-nodes
-		return authorizer.DecisionNoOpinion, "", nil
-	}
-
-	if len(nodeName) == 0 {
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("unknown node for user %q", attrs.GetUser().GetName()), nil
 	}
 
 	// Short-circut if "subjectaccessreviews", or a "get" or "update" on the node object.
@@ -67,23 +59,31 @@ func (m *minimumKubeletVersionAuth) Authorize(ctx context.Context, attrs authori
 			if v := attrs.GetVerb(); v == "get" || v == "update" {
 				return authorizer.DecisionNoOpinion, "", nil
 			}
-		// TODO(haircommander): do we need other flavors of access reviews here?
 		case authorizationv1.Resource("subjectaccessreviews"):
 			return authorizer.DecisionNoOpinion, "", nil
 		}
 	}
 
+	nodeName, isNode := m.nodeIdentifier.NodeIdentity(attrs.GetUser())
+	if !isNode {
+		// ignore requests from non-nodes
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	if !m.hasNodeInformerSyncedFn() {
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("node informer not synced, cannot check if node %s is new enough", nodeName), nil
+		return authorizer.DecisionDeny, "", fmt.Errorf("node informer not synced, cannot check if node %s is new enough", nodeName)
 	}
 
 	node, err := m.nodeLister.Get(nodeName)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("failed to get node %s: %v", nodeName, err), nil
+		return authorizer.DecisionDeny, "", err
 	}
 
 	if err := nodelib.IsNodeTooOld(node, m.minVersion); err != nil {
-		return authorizer.DecisionDeny, err.Error(), nil
+		if errors.Is(err, nodelib.ErrKubeletOutdated) {
+			return authorizer.DecisionDeny, err.Error(), nil
+		}
+		return authorizer.DecisionDeny, "", err
 	}
 
 	return authorizer.DecisionNoOpinion, "", nil

--- a/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version_test.go
+++ b/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version_test.go
@@ -1,0 +1,193 @@
+package minimumkubeletversion
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+func TestAuthorize(t *testing.T) {
+	nodeUser := &user.DefaultInfo{Name: "system:node:node0", Groups: []string{"system:nodes"}}
+
+	testCases := []struct {
+		name            string
+		minVersion      string
+		attributes      kauthorizer.AttributesRecord
+		expectedAllowed kauthorizer.Decision
+		expectedErr     string
+		expectedMsg     string
+		node            *v1.Node
+	}{
+		{
+			name:            "no version",
+			minVersion:      "",
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			expectedErr:     "",
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "name"}},
+		},
+		{
+			name:       "user not a node",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            &user.DefaultInfo{Name: "name"},
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		},
+		{
+			name:       "skips if subjectaccessreviews",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+				Resource:        "subjectaccessreviews",
+				APIGroup:        authorizationv1.GroupName,
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		},
+		{
+			name:       "skips if get node",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+				Resource:        "nodes",
+				Verb:            "get",
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		},
+		{
+			name:       "skips if update nodes",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+				Resource:        "nodes",
+				Verb:            "update",
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		},
+		{
+			name:       "fail if update node not found",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			expectedMsg:     `failed to get node node0: node "node0" not found`,
+			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		},
+		{
+			name:       "skip if bogus kubelet version",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+			},
+			expectedAllowed: kauthorizer.DecisionDeny,
+			expectedMsg:     `failed to parse node version bogus: No Major.Minor.Patch elements found`,
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{
+						KubeletVersion: "bogus",
+					},
+				}},
+		},
+		{
+			name:       "deny if too low version",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+			},
+			expectedAllowed: kauthorizer.DecisionDeny,
+			expectedMsg:     `kubelet version is outdated: kubelet version is 1.29.8, which is lower than minimumKubeletVersion of 1.30.0`,
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{
+						KubeletVersion: "v1.29.8-20+15d27f9ba1c119",
+					},
+				}},
+		},
+		{
+			name:       "accept if high enough version",
+			minVersion: "1.30.0",
+			attributes: kauthorizer.AttributesRecord{
+				ResourceRequest: true,
+				Namespace:       "ns",
+				User:            nodeUser,
+			},
+			expectedAllowed: kauthorizer.DecisionNoOpinion,
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{
+						KubeletVersion: "1.30.0",
+					},
+				}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, controller.NoResyncPeriodFunc())
+			fakeNodeInformer := fakeInformerFactory.Core().V1().Nodes()
+			fakeNodeInformer.Informer().GetStore().Add(tc.node)
+			var minVersion *semver.Version
+			if tc.minVersion != "" {
+				v := semver.MustParse(tc.minVersion)
+				minVersion = &v
+			}
+
+			authorizer := &minimumKubeletVersionAuth{
+				nodeIdentifier: nodeidentifier.NewDefaultNodeIdentifier(),
+				nodeLister:     fakeNodeInformer.Lister(),
+				minVersion:     minVersion,
+				hasNodeInformerSyncedFn: func() bool {
+					return true
+				},
+			}
+
+			actualAllowed, actualMsg, actualErr := authorizer.Authorize(context.TODO(), tc.attributes)
+			switch {
+			case len(tc.expectedErr) == 0 && actualErr == nil:
+			case len(tc.expectedErr) == 0 && actualErr != nil:
+				t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+			case len(tc.expectedErr) != 0 && actualErr == nil:
+				t.Errorf("%s: missing error: %v", tc.name, tc.expectedErr)
+			case len(tc.expectedErr) != 0 && actualErr != nil:
+				if !strings.Contains(actualErr.Error(), tc.expectedErr) {
+					t.Errorf("expected %v, got %v", tc.expectedErr, actualErr)
+				}
+			}
+			if tc.expectedMsg != actualMsg {
+				t.Errorf("expected %v, got %v", tc.expectedMsg, actualMsg)
+			}
+			if tc.expectedAllowed != actualAllowed {
+				t.Errorf("expected %v, got %v", tc.expectedAllowed, actualAllowed)
+			}
+		})
+	}
+}

--- a/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version_test.go
+++ b/openshift-kube-apiserver/authorization/minimumkubeletversion/minimum_kubelet_version_test.go
@@ -94,8 +94,8 @@ func TestAuthorize(t *testing.T) {
 				Namespace:       "ns",
 				User:            nodeUser,
 			},
-			expectedAllowed: kauthorizer.DecisionNoOpinion,
-			expectedMsg:     `failed to get node node0: node "node0" not found`,
+			expectedAllowed: kauthorizer.DecisionDeny,
+			expectedErr:     `node "node0" not found`,
 			node:            &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
 		},
 		{
@@ -107,7 +107,7 @@ func TestAuthorize(t *testing.T) {
 				User:            nodeUser,
 			},
 			expectedAllowed: kauthorizer.DecisionDeny,
-			expectedMsg:     `failed to parse node version bogus: No Major.Minor.Patch elements found`,
+			expectedErr:     `failed to parse node version bogus: No Major.Minor.Patch elements found`,
 			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"},
 				Status: v1.NodeStatus{
 					NodeInfo: v1.NodeSystemInfo{

--- a/openshift-kube-apiserver/enablement/intialization.go
+++ b/openshift-kube-apiserver/enablement/intialization.go
@@ -87,6 +87,11 @@ func ForceGlobalInitializationForOpenShift() {
 	// we need to have the authorization chain place something before system:masters
 	// SkipSystemMastersAuthorizer disable implicitly added system/master authz, and turn it into another authz mode "SystemMasters", to be added via authorization-mode
 	authorizer.SkipSystemMastersAuthorizer()
+
+	// Set the minimum kubelet version
+	// If the OpenshiftConfig wasn't configured by this point, it's a programming error,
+	// and this should panic.
+	authorizer.SetMinimumKubeletVersion(OpenshiftConfig().MinimumKubeletVersion)
 }
 
 var SCCAdmissionPlugin = sccadmission.NewConstraint()

--- a/pkg/features/openshift_features.go
+++ b/pkg/features/openshift_features.go
@@ -5,10 +5,15 @@ import (
 )
 
 var RouteExternalCertificate featuregate.Feature = "RouteExternalCertificate"
+var MinimumKubeletVersion featuregate.Feature = "MinimumKubeletVersion"
 
 // registerOpenshiftFeatures injects openshift-specific feature gates
 func registerOpenshiftFeatures() {
 	defaultKubernetesFeatureGates[RouteExternalCertificate] = featuregate.FeatureSpec{
+		Default:    false,
+		PreRelease: featuregate.Alpha,
+	}
+	defaultKubernetesFeatureGates[MinimumKubeletVersion] = featuregate.FeatureSpec{
 		Default:    false,
 		PreRelease: featuregate.Alpha,
 	}

--- a/pkg/kubeapiserver/authorizer/modes/patch.go
+++ b/pkg/kubeapiserver/authorizer/modes/patch.go
@@ -2,7 +2,8 @@ package modes
 
 var ModeScope = "Scope"
 var ModeSystemMasters = "SystemMasters"
+var ModeMinimumKubeletVersion = "MinimumKubeletVersion"
 
 func init() {
-	AuthorizationModeChoices = append(AuthorizationModeChoices, ModeScope, ModeSystemMasters)
+	AuthorizationModeChoices = append(AuthorizationModeChoices, ModeScope, ModeSystemMasters, ModeMinimumKubeletVersion)
 }

--- a/pkg/kubeapiserver/authorizer/patch.go
+++ b/pkg/kubeapiserver/authorizer/patch.go
@@ -1,8 +1,54 @@
 package authorizer
 
+import (
+	"sync"
+
+	"github.com/blang/semver/v4"
+)
+
 var skipSystemMastersAuthorizer = false
 
 // SkipSystemMastersAuthorizer disable implicitly added system/master authz, and turn it into another authz mode "SystemMasters", to be added via authorization-mode
 func SkipSystemMastersAuthorizer() {
 	skipSystemMastersAuthorizer = true
+}
+
+var (
+	minimumKubeletVersion *semver.Version
+	versionLock           sync.Mutex
+	versionSet            bool
+)
+
+// GetMinimumKubeletVersion retrieves the set global minimum kubelet version in a safe way.
+// It ensures it is only retrieved once, and is set before it's retrieved.
+// The global value should only be gotten through this function.
+// It is valid for the version to be unset. It will be treated the same as explicitly setting version to "".
+// This function (and the corresponding functions/variables) are added to avoid a import cycle between the
+// ./openshift-kube-apiserver/enablement and ./pkg/kubeapiserver/authorizer packages
+func GetMinimumKubeletVersion() *semver.Version {
+	versionLock.Lock()
+	defer versionLock.Unlock()
+	if !versionSet {
+		panic("coding error: MinimumKubeletVersion not set yet")
+	}
+	return minimumKubeletVersion
+}
+
+// SetMinimumKubeletVersion sets the global minimum kubelet version in a safe way.
+// It ensures it is only set once, and the passed version is valid.
+// If will panic on any error.
+// The global value should only be set through this function.
+// Passing an empty string for version is valid, and means there is no minimum version.
+func SetMinimumKubeletVersion(version string) {
+	versionLock.Lock()
+	defer versionLock.Unlock()
+	if versionSet {
+		panic("coding error: MinimumKubeletVersion already set")
+	}
+	versionSet = true
+	if len(version) == 0 {
+		return
+	}
+	v := semver.MustParse(version)
+	minimumKubeletVersion = &v
 }

--- a/vendor/github.com/openshift/library-go/pkg/apiserver/node/minimum_kubelet_version.go
+++ b/vendor/github.com/openshift/library-go/pkg/apiserver/node/minimum_kubelet_version.go
@@ -1,0 +1,80 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// An error to be returned when kubelet version is lower than specified minimum kubelet version.
+// Used to differentiate between a parsing failure, and a failure because the kubelet is out of date.
+var ErrKubeletOutdated = fmt.Errorf("kubelet version is outdated")
+
+// ValidateMinimumKubeletVersion takes a list of nodes and a currently set min version.
+// It parses the min version and iterates through the nodes, comparing the version of the kubelets
+// to the min version.
+// It will error if any nodes are older than the min version.
+func ValidateMinimumKubeletVersion(nodes []*corev1.Node, minimumKubeletVersion string) error {
+	// unset, no error
+	if minimumKubeletVersion == "" {
+		return nil
+	}
+
+	version, err := semver.Parse(minimumKubeletVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse submitted version %s %v", minimumKubeletVersion, err.Error())
+	}
+
+	for _, node := range nodes {
+		if err := IsNodeTooOld(node, &version); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsNodeTooOld answers that very question. It takes a node object and a minVersion,
+// parses each into a semver version, and then determines whether the version of the kubelet on the
+// node is older than min version.
+// When the node is too old, it returns the error ErrKubeletOutdated. If a different error occurs, an error is returned.
+// If the node is new enough and no error happens, nil is returned.
+func IsNodeTooOld(node *corev1.Node, minVersion *semver.Version) error {
+	return IsKubeletVersionTooOld(node.Status.NodeInfo.KubeletVersion, minVersion)
+}
+
+// IsKubeletVerisionTooOld answers that very question. It takes a kubelet version and a minVersion,
+// parses each into a semver version, and then determines whether the version of the kubelet on the
+// node is older than min version.
+// It will fail if the minVersion is nil, if the kubeletVersion is invalid, or if the minVersion is greater than
+// the kubeletVersion
+// When the kubelet is too old, it returns the error ErrKubeletOutdated. If a different error occurs, an error is returned.
+// If the node is new enough and no error happens, nil is returned.
+func IsKubeletVersionTooOld(kubeletVersion string, minVersion *semver.Version) error {
+	if minVersion == nil {
+		return fmt.Errorf("given minimum version is nil")
+	}
+	version, err := ParseKubeletVersion(kubeletVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse node version %s: %v", kubeletVersion, err)
+	}
+	if minVersion.GT(*version) {
+		return fmt.Errorf("%w: kubelet version is %v, which is lower than minimumKubeletVersion of %v", ErrKubeletOutdated, *version, *minVersion)
+	}
+	return nil
+}
+
+// ParseKubeletVersion parses it into a semver.Version object, stripping
+// any information in the version that isn't "major.minor.patch".
+func ParseKubeletVersion(kubeletVersion string) (*semver.Version, error) {
+	version, err := semver.Parse(strings.TrimPrefix(kubeletVersion, "v"))
+	if err != nil {
+		return nil, err
+	}
+
+	version.Pre = nil
+	version.Build = nil
+	return &version, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -703,6 +703,7 @@ github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtes
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig
 github.com/openshift/library-go/pkg/apiserver/admission/admissiontimeout
 github.com/openshift/library-go/pkg/apiserver/apiserverconfig
+github.com/openshift/library-go/pkg/apiserver/node
 github.com/openshift/library-go/pkg/authorization/authorizationutil
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/authorization/scopemetadata


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds an additional admission feature that verifies all kubelets are above a certain version. WIP, TODOs inline
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
