### PR TITLE
OCPEDGE-1314: feat: add arbiter node role

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/apis/well_known_openshift_labels.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/well_known_openshift_labels.go
@@ -24,6 +24,7 @@ const (
 	NodeLabelControlPlane = "node-role.kubernetes.io/control-plane"
 	NodeLabelMaster       = "node-role.kubernetes.io/master"
 	NodeLabelWorker       = "node-role.kubernetes.io/worker"
+	NodeLabelArbiter      = "node-role.kubernetes.io/arbiter"
 	NodeLabelEtcd         = "node-role.kubernetes.io/etcd"
 )
 
@@ -32,6 +33,7 @@ var openshiftNodeLabels = sets.NewString(
 	NodeLabelMaster,
 	NodeLabelWorker,
 	NodeLabelEtcd,
+	NodeLabelArbiter,
 )
 
 func OpenShiftNodeLabels() []string {


### PR DESCRIPTION
#### What this PR does / why we need it:

Per EP: https://github.com/openshift/enhancements/pull/1674

This PR adds the new node role of `arbiter` to the well known labels for openshift so that the kubelet is allowed to register a role of type `arbiter`

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/openshift/enhancements/blob/master/enhancements/arbiter-clusters.md#kubernetes-change

