### PR TITLE
OCPBUGS-38121: OCPBUGS-39305: UPSTREAM: <carry>: log only deprecated api requests

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount/apiaccess_count_controller.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/apiaccess_count_controller.go
@@ -49,7 +49,7 @@ type controller struct {
 
 // IsDeprecated return true if the resource is deprecated.
 func (c *controller) IsDeprecated(resource, version, group string) bool {
-	_, ok := deprecatedApiRemovedRelease[schema.GroupVersionResource{
+	_, ok := DeprecatedAPIRemovedRelease[schema.GroupVersionResource{
 		Group:    group,
 		Version:  version,
 		Resource: resource,

--- a/openshift-kube-apiserver/filters/apirequestcount/apiaccess_count_controller_test.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/apiaccess_count_controller_test.go
@@ -25,10 +25,10 @@ func TestRemovedRelease(t *testing.T) {
 	rr := removedRelease(
 		schema.GroupVersionResource{
 			Group:    "flowcontrol.apiserver.k8s.io",
-			Version:  "v1alpha1",
+			Version:  "v1beta3",
 			Resource: "flowschemas",
 		})
-	assert.Equal(t, "1.21", rr)
+	assert.Equal(t, "1.32", rr)
 }
 
 func TestLoggingResetRace(t *testing.T) {

--- a/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
@@ -1,70 +1,20 @@
 package apirequestcount
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"fmt"
 
-var deprecatedApiRemovedRelease = map[schema.GroupVersionResource]string{
-	// Kubernetes APIs
-	{Group: "apps", Version: "v1beta1", Resource: "controllerrevisions"}:                                     "1.16",
-	{Group: "apps", Version: "v1beta1", Resource: "deploymentrollbacks"}:                                     "1.16",
-	{Group: "apps", Version: "v1beta1", Resource: "deployments"}:                                             "1.16",
-	{Group: "apps", Version: "v1beta1", Resource: "scales"}:                                                  "1.16",
-	{Group: "apps", Version: "v1beta1", Resource: "statefulsets"}:                                            "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "controllerrevisions"}:                                     "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "daemonsets"}:                                              "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "deployments"}:                                             "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "replicasets"}:                                             "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "scales"}:                                                  "1.16",
-	{Group: "apps", Version: "v1beta2", Resource: "statefulsets"}:                                            "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "daemonsets"}:                                        "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "deploymentrollbacks"}:                               "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "deployments"}:                                       "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "networkpolicies"}:                                   "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "podsecuritypolicies"}:                               "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}:                                       "1.16",
-	{Group: "extensions", Version: "v1beta1", Resource: "scales"}:                                            "1.16",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1", Resource: "flowschemas"}:                    "1.21",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1", Resource: "prioritylevelconfigurations"}:    "1.21",
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:   "1.22",
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}: "1.22",
-	{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}:               "1.22",
-	{Group: "apiregistration.k8s.io", Version: "v1beta1", Resource: "apiservices"}:                           "1.22",
-	{Group: "authentication.k8s.io", Version: "v1beta1", Resource: "tokenreviews"}:                           "1.22",
-	{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "localsubjectaccessreviews"}:               "1.22",
-	{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "selfsubjectaccessreviews"}:                "1.22",
-	{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "selfsubjectrulesreviews"}:                 "1.22",
-	{Group: "authorization.k8s.io", Version: "v1beta1", Resource: "subjectaccessreviews"}:                    "1.22",
-	{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"}:               "1.22",
-	{Group: "coordination.k8s.io", Version: "v1beta1", Resource: "leases"}:                                   "1.22",
-	{Group: "extensions", Version: "v1beta1", Resource: "ingresses"}:                                         "1.22",
-	{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresses"}:                                  "1.22",
-	{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingressclasses"}:                             "1.22",
-	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterrolebindings"}:                "1.22",
-	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterroles"}:                       "1.22",
-	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "rolebindings"}:                       "1.22",
-	{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "roles"}:                              "1.22",
-	{Group: "scheduling.k8s.io", Version: "v1beta1", Resource: "priorityclasses"}:                            "1.22",
-	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csidrivers"}:                                    "1.22",
-	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csinodes"}:                                      "1.22",
-	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "storageclasses"}:                                "1.22",
-	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "volumeattachments"}:                             "1.22",
-	{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}:                                               "1.25",
-	{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"}:                              "1.25",
-	{Group: "events.k8s.io", Version: "v1beta1", Resource: "events"}:                                         "1.25",
-	{Group: "autoscaling", Version: "v2beta1", Resource: "horizontalpodautoscalers"}:                         "1.25",
-	{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"}:                                  "1.25",
-	{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"}:                                   "1.25",
-	{Group: "node.k8s.io", Version: "v1beta1", Resource: "runtimeclasses"}:                                   "1.25",
-	{Group: "autoscaling", Version: "v2beta2", Resource: "horizontalpodautoscalers"}:                         "1.26",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1", Resource: "flowschemas"}:                     "1.26",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1", Resource: "prioritylevelconfigurations"}:     "1.26",
-	{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csistoragecapacities"}:                          "1.27",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "flowschemas"}:                     "1.29",
-	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "prioritylevelconfigurations"}:     "1.29",
-	// OpenShift APIs
-	{Group: "operator.openshift.io", Version: "v1beta1", Resource: "kubedeschedulers"}: "1.22",
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var DeprecatedAPIRemovedRelease = map[schema.GroupVersionResource]uint{
+	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}:                 32,
+	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}: 32,
 }
 
 // removedRelease of a specified resource.version.group.
 func removedRelease(resource schema.GroupVersionResource) string {
-	return deprecatedApiRemovedRelease[resource]
+	if minor, ok := DeprecatedAPIRemovedRelease[resource]; ok {
+		return fmt.Sprintf("1.%d", minor)
+	}
+	return ""
 }

--- a/openshift-kube-apiserver/filters/apirequestcount_filter.go
+++ b/openshift-kube-apiserver/filters/apirequestcount_filter.go
@@ -4,16 +4,27 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	versioninfo "k8s.io/component-base/version"
 	"k8s.io/kubernetes/openshift-kube-apiserver/filters/apirequestcount"
 )
 
 // WithAPIRequestCountLogging adds a handler that logs counts of api requests.
 func WithAPIRequestCountLogging(handler http.Handler, requestLogger apirequestcount.APIRequestLogger) http.Handler {
+	currentMinor := version.MustParseSemantic(versioninfo.Get().GitVersion).Minor()
 	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer handler.ServeHTTP(w, req)
 		info, ok := request.RequestInfoFrom(req.Context())
 		if !ok || !info.IsResourceRequest {
+			return
+		}
+		gvr := schema.GroupVersionResource{
+			Group:    info.APIGroup,
+			Version:  info.APIVersion,
+			Resource: info.Resource,
+		}
+		if minor, ok := apirequestcount.DeprecatedAPIRemovedRelease[gvr]; !ok || minor <= currentMinor {
 			return
 		}
 		timestamp, ok := request.ReceivedTimestampFrom(req.Context())
@@ -25,11 +36,7 @@ func WithAPIRequestCountLogging(handler http.Handler, requestLogger apirequestco
 			return
 		}
 		requestLogger.LogRequest(
-			schema.GroupVersionResource{
-				Group:    info.APIGroup,
-				Version:  info.APIVersion,
-				Resource: info.Resource,
-			},
+			gvr,
 			timestamp,
 			user.GetName(),
 			req.UserAgent(),


### PR DESCRIPTION
Unrevert https://github.com/openshift/kubernetes/pull/2067.

This PR needs https://github.com/openshift/cluster-authentication-operator/pull/712 to go in before merging as well as a green pass on `/payload-job periodic-ci-openshift-release-master-ci-4.18-upgrade-from-stable-4.17-e2e-aws-ovn-upgrade`