### PR TITLE
SDN-5457: Bump kube-proxy image to 4.18 base images

### DIFF
--- a/openshift-hack/images/kube-proxy/Dockerfile.rhel
+++ b/openshift-hack/images/kube-proxy/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
 RUN make WHAT='cmd/kube-proxy' && \
     mkdir -p /tmp/build && \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/kube-proxy /tmp/build
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 RUN INSTALL_PKGS="conntrack-tools iptables nftables" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*


### PR DESCRIPTION
Oops, went to file the openshift/release PR for #2082 and realized the Dockerfile I copied from openshift/sdn still referenced 4.17...

/assign @p0lyn0mial 