### PR TITLE
UPSTREAM: <carry>: add audit annotations to track etcd state

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -158,7 +158,7 @@ func writeLatencyToAnnotation(ctx context.Context, ev *auditinternal.Event) {
 	// of the given request exceeds 500ms, this is in keeping with the
 	// traces in rest/handlers for create, delete, update,
 	// get, list, and deletecollection.
-	const threshold = 500 * time.Millisecond
+	const threshold = 0 * time.Millisecond
 	latency := ev.StageTimestamp.Time.Sub(ev.RequestReceivedTimestamp.Time)
 	if latency <= threshold {
 		return


### PR DESCRIPTION
We can use these annotations in a monitortest to start counting how many seconds we appear to lose etcd leadership for and what percentage of etcd requests fail during that time.