### PR TITLE
OCPBUGS-48177: UPSTREAM: <carry>: disable etcd readiness checks by default

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -355,7 +355,7 @@ func (s *EtcdOptions) maybeApplyResourceTransformers(c *server.Config) (err erro
 
 func addHealthChecksWithoutLivez(c *server.Config, healthChecks ...healthz.HealthChecker) {
 	c.HealthzChecks = append(c.HealthzChecks, healthChecks...)
-	c.ReadyzChecks = append(c.ReadyzChecks, healthChecks...)
+	c.AddReadyzChecks(healthChecks...)
 }
 
 func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -262,6 +262,17 @@ func TestParseWatchCacheSizes(t *testing.T) {
 	}
 }
 
+func excludeEtcdReadyzChecks(readyzChecks []string) []string {
+	includedReadyzChecks := []string{}
+	for _, checkName := range readyzChecks {
+		if checkName == "etcd" || checkName == "etcd-readiness" {
+			continue
+		}
+		includedReadyzChecks = append(includedReadyzChecks, checkName)
+	}
+	return includedReadyzChecks
+}
+
 func TestKMSHealthzEndpoint(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv1, true)
 
@@ -367,7 +378,9 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			}
 
 			healthChecksAreEqual(t, tc.wantHealthzChecks, serverConfig.HealthzChecks, "healthz")
-			healthChecksAreEqual(t, tc.wantReadyzChecks, serverConfig.ReadyzChecks, "readyz")
+			// Remove the excluded checks here to reduce the carry patch changes in case
+			// the changes drifts too much during rebases and similar scope-like changes.
+			healthChecksAreEqual(t, excludeEtcdReadyzChecks(tc.wantReadyzChecks), serverConfig.ReadyzChecks, "readyz")
 			healthChecksAreEqual(t, tc.wantLivezChecks, serverConfig.LivezChecks, "livez")
 		})
 	}
@@ -407,7 +420,9 @@ func TestReadinessCheck(t *testing.T) {
 				t.Fatalf("Failed to add healthz error: %v", err)
 			}
 
-			healthChecksAreEqual(t, tc.wantReadyzChecks, serverConfig.ReadyzChecks, "readyz")
+			// Remove the excluded checks here to reduce the carry patch changes in case
+			// the changes drifts too much during rebases and similar scope-like changes.
+			healthChecksAreEqual(t, excludeEtcdReadyzChecks(tc.wantReadyzChecks), serverConfig.ReadyzChecks, "readyz")
 			healthChecksAreEqual(t, tc.wantHealthzChecks, serverConfig.HealthzChecks, "healthz")
 			healthChecksAreEqual(t, tc.wantLivezChecks, serverConfig.LivezChecks, "livez")
 		})

--- a/test/e2e/apimachinery/health_handlers.go
+++ b/test/e2e/apimachinery/health_handlers.go
@@ -82,7 +82,6 @@ var (
 	requiredReadyzChecks = sets.NewString(
 		"[+]ping ok",
 		"[+]log ok",
-		"[+]etcd ok",
 		"[+]informer-sync ok",
 		"[+]poststarthook/start-apiserver-admission-initializer ok",
 		"[+]poststarthook/generic-apiserver-start-informers ok",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Explicitly exclude etcd and etcd-readiness checks (OCPBUGS-48177) and have etcd operator take responsibility for properly reporting etcd readiness. Justification: kube-apiserver instances get removed from a load balancer when etcd starts to report not ready (as will KA's /readyz). Client connections can withstand etcd unreadiness longer than the readiness timeout is. Thus, it is not necessary to drop connections in case etcd resumes its readiness before a client connection times out naturally. This is a downstream patch only as OpenShift's way of using etcd is unique.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
- Each health check is also registered as a readyz check. Thus registration of both `etcd` and `etcd-readiness` checks can't be just simply commented out/removed.
- The logic for excluding checks through ?exclude=<checkname> URL construct does not distinguish between health, livez and readyz checks. So patching the code on the level of [getExcludedChecks](https://github.com/openshift/kubernetes/blob/4b2db1ec33faa3ffc305e5ffa7376908cc955370/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go#L234-L240) would require to extend underlying `handleRootHealth` and `InstallPathHandlerWithHealthyFunc` with extra arguments to inject the list of excluded checks.
- I choose the middle ground of letting both checks to be added through `AddReadyzChecks`. Yet excluded from the final addition addition since `AddReadyzChecks` can be invoked from multiple places.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
