### PR TITLE
[4.18] OCPBUGS-49437: Fix Portworx plugin's CSI translation to copy secret name & namespace

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/portworx.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/portworx.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -27,6 +28,29 @@ import (
 const (
 	PortworxVolumePluginName = "kubernetes.io/portworx-volume"
 	PortworxDriverName       = "pxd.portworx.com"
+
+	OpenStorageAuthSecretNameKey      = "openstorage.io/auth-secret-name"
+	OpenStorageAuthSecretNamespaceKey = "openstorage.io/auth-secret-namespace"
+
+	csiParameterPrefix = "csi.storage.k8s.io/"
+
+	prefixedProvisionerSecretNameKey      = csiParameterPrefix + "provisioner-secret-name"
+	prefixedProvisionerSecretNamespaceKey = csiParameterPrefix + "provisioner-secret-namespace"
+
+	prefixedControllerPublishSecretNameKey      = csiParameterPrefix + "controller-publish-secret-name"
+	prefixedControllerPublishSecretNamespaceKey = csiParameterPrefix + "controller-publish-secret-namespace"
+
+	prefixedNodeStageSecretNameKey      = csiParameterPrefix + "node-stage-secret-name"
+	prefixedNodeStageSecretNamespaceKey = csiParameterPrefix + "node-stage-secret-namespace"
+
+	prefixedNodePublishSecretNameKey      = csiParameterPrefix + "node-publish-secret-name"
+	prefixedNodePublishSecretNamespaceKey = csiParameterPrefix + "node-publish-secret-namespace"
+
+	prefixedControllerExpandSecretNameKey      = csiParameterPrefix + "controller-expand-secret-name"
+	prefixedControllerExpandSecretNamespaceKey = csiParameterPrefix + "controller-expand-secret-namespace"
+
+	prefixedNodeExpandSecretNameKey      = csiParameterPrefix + "node-expand-secret-name"
+	prefixedNodeExpandSecretNamespaceKey = csiParameterPrefix + "node-expand-secret-namespace"
 )
 
 var _ InTreePlugin = &portworxCSITranslator{}
@@ -43,7 +67,34 @@ func (p portworxCSITranslator) TranslateInTreeStorageClassToCSI(sc *storagev1.St
 	if sc == nil {
 		return nil, fmt.Errorf("sc is nil")
 	}
+
+	var params = map[string]string{}
+	for k, v := range sc.Parameters {
+		switch strings.ToLower(k) {
+		case OpenStorageAuthSecretNameKey:
+			params[prefixedProvisionerSecretNameKey] = v
+			params[prefixedControllerPublishSecretNameKey] = v
+			params[prefixedNodePublishSecretNameKey] = v
+			params[prefixedNodeStageSecretNameKey] = v
+			params[prefixedControllerExpandSecretNameKey] = v
+			params[prefixedNodeExpandSecretNameKey] = v
+		case OpenStorageAuthSecretNamespaceKey:
+			params[prefixedProvisionerSecretNamespaceKey] = v
+			params[prefixedControllerPublishSecretNamespaceKey] = v
+			params[prefixedNodePublishSecretNamespaceKey] = v
+			params[prefixedNodeStageSecretNamespaceKey] = v
+			params[prefixedControllerExpandSecretNamespaceKey] = v
+			params[prefixedNodeExpandSecretNamespaceKey] = v
+		default:
+			// All other parameters can be copied as is
+			params[k] = v
+		}
+	}
+	if len(params) > 0 {
+		sc.Parameters = params
+	}
 	sc.Provisioner = PortworxDriverName
+
 	return sc, nil
 }
 
@@ -86,11 +137,26 @@ func (p portworxCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (
 	if pv == nil || pv.Spec.PortworxVolume == nil {
 		return nil, fmt.Errorf("pv is nil or PortworxVolume not defined on pv")
 	}
+	var secretRef *v1.SecretReference
+
+	if metav1.HasAnnotation(pv.ObjectMeta, OpenStorageAuthSecretNameKey) &&
+		metav1.HasAnnotation(pv.ObjectMeta, OpenStorageAuthSecretNamespaceKey) {
+		secretRef = &v1.SecretReference{
+			Name:      pv.Annotations[OpenStorageAuthSecretNameKey],
+			Namespace: pv.Annotations[OpenStorageAuthSecretNamespaceKey],
+		}
+	}
+
 	csiSource := &v1.CSIPersistentVolumeSource{
-		Driver:           PortworxDriverName,
-		VolumeHandle:     pv.Spec.PortworxVolume.VolumeID,
-		FSType:           pv.Spec.PortworxVolume.FSType,
-		VolumeAttributes: make(map[string]string), // copy access mode
+		Driver:                     PortworxDriverName,
+		VolumeHandle:               pv.Spec.PortworxVolume.VolumeID,
+		FSType:                     pv.Spec.PortworxVolume.FSType,
+		VolumeAttributes:           make(map[string]string), // copy access mode
+		ControllerPublishSecretRef: secretRef,
+		NodeStageSecretRef:         secretRef,
+		NodePublishSecretRef:       secretRef,
+		ControllerExpandSecretRef:  secretRef,
+		NodeExpandSecretRef:        secretRef,
 	}
 	pv.Spec.PortworxVolume = nil
 	pv.Spec.CSI = csiSource

--- a/staging/src/k8s.io/csi-translation-lib/plugins/portworx_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/portworx_test.go
@@ -68,6 +68,35 @@ func TestTranslatePortworxInTreeStorageClassToCSI(t *testing.T) {
 			},
 			errorExp: false,
 		},
+		{
+			name: "with secret params",
+			inTreeSC: &storage.StorageClass{
+				Parameters: map[string]string{
+					"repl":                                 "1",
+					"openstorage.io/auth-secret-name":      "test-secret",
+					"openstorage.io/auth-secret-namespace": "test-namespace",
+				},
+			},
+			csiSC: &storage.StorageClass{
+				Parameters: map[string]string{
+					"repl": "1",
+					"csi.storage.k8s.io/provisioner-secret-name":             "test-secret",
+					"csi.storage.k8s.io/provisioner-secret-namespace":        "test-namespace",
+					"csi.storage.k8s.io/controller-publish-secret-name":      "test-secret",
+					"csi.storage.k8s.io/controller-publish-secret-namespace": "test-namespace",
+					"csi.storage.k8s.io/node-stage-secret-name":              "test-secret",
+					"csi.storage.k8s.io/node-stage-secret-namespace":         "test-namespace",
+					"csi.storage.k8s.io/node-publish-secret-name":            "test-secret",
+					"csi.storage.k8s.io/node-publish-secret-namespace":       "test-namespace",
+					"csi.storage.k8s.io/controller-expand-secret-name":       "test-secret",
+					"csi.storage.k8s.io/controller-expand-secret-namespace":  "test-namespace",
+					"csi.storage.k8s.io/node-expand-secret-name":             "test-secret",
+					"csi.storage.k8s.io/node-expand-secret-namespace":        "test-namespace",
+				},
+				Provisioner: PortworxDriverName,
+			},
+			errorExp: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Logf("Testing %v", tc.name)
@@ -218,6 +247,81 @@ func TestTranslatePortworxInTreePVToCSI(t *testing.T) {
 							VolumeHandle:     "ID1111",
 							FSType:           "type",
 							VolumeAttributes: make(map[string]string),
+						},
+					},
+				},
+			},
+			errExpected: false,
+		},
+		{
+			name: "with secret annotations",
+			inTree: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pxd.portworx.com",
+					Annotations: map[string]string{
+						"openstorage.io/auth-secret-name":      "test-secret",
+						"openstorage.io/auth-secret-namespace": "test-namespace",
+					},
+				},
+				Spec: v1.PersistentVolumeSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					ClaimRef: &v1.ObjectReference{
+						Name:      "test-pvc",
+						Namespace: "default",
+					},
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						PortworxVolume: &v1.PortworxVolumeSource{
+							VolumeID: "ID1111",
+							FSType:   "type",
+							ReadOnly: false,
+						},
+					},
+				},
+			},
+			csi: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pxd.portworx.com",
+					Annotations: map[string]string{
+						"openstorage.io/auth-secret-name":      "test-secret",
+						"openstorage.io/auth-secret-namespace": "test-namespace",
+					},
+				},
+				Spec: v1.PersistentVolumeSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					ClaimRef: &v1.ObjectReference{
+						Name:      "test-pvc",
+						Namespace: "default",
+					},
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						CSI: &v1.CSIPersistentVolumeSource{
+							Driver:           PortworxDriverName,
+							VolumeHandle:     "ID1111",
+							FSType:           "type",
+							VolumeAttributes: make(map[string]string),
+							ControllerPublishSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodeStageSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodePublishSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							ControllerExpandSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
+							NodeExpandSecretRef: &v1.SecretReference{
+								Name:      "test-secret",
+								Namespace: "test-namespace",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-49437

Clean `git cherry-pick ae081128a3339ede070f281de76e1a75a0669fab` + updated commit message.

/hold for https://github.com/openshift/kubernetes/pull/2185 to merge
/cc @openshift/storage @sdodson
