### PR TITLE
TRT-1854: UPSTREAM: <drop>: ./hack/update-vendor.sh for openshift-tests-extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,11 +48,11 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/mrunalp/fileutils v0.5.1
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
-	github.com/onsi/ginkgo/v2 v2.20.2
+	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/runc v1.2.1
 	github.com/opencontainers/selinux v1.11.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250128181728-a95ca461cacf
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
 	github.com/openshift/api v0.0.0-20250124212313-a770960d61e0
 	github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250128181728-a95ca461cacf h1:xAdvYS3qDIUFbNv94/EQ6Fu6WS/TlaAt9TSwbTUBJQU=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250128181728-a95ca461cacf/go.mod h1:kXuC+wKAGTHl4J+sdweWnhO97DfM7OuEturAHZNczAg=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710 h1:/nhlfQ5nOCMkLRshi88UM8cAyhhRM+aM/ohe/wwgP6Q=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710/go.mod h1:Ag89ggOpS/66wVeBawzEWLfplYI7YLFx6GW6EW/pgVQ=
 github.com/openshift/api v0.0.0-20250124212313-a770960d61e0 h1:dCvNfygMrPLVNQ06bpHXrxKfrXHiprO4+etHrRUqI8g=
 github.com/openshift/api v0.0.0-20250124212313-a770960d61e0/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce h1:w0Up6YV1APcn20v/1h5IfuToz96o2pVqZyjzbw0yotU=

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/moby/spdystream v0.5.0
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
-	github.com/onsi/ginkgo/v2 v2.20.2
+	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.30.0

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/onsi/ginkgo/v2 v2.20.2 // indirect
+	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/moby/term v0.5.0
-	github.com/onsi/ginkgo/v2 v2.20.2
+	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday/v2 v2.1.0

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun"
@@ -17,5 +18,6 @@ func DefaultExtensionCommands(registry *extension.Registry) []*cobra.Command {
 		cmdlist.NewListCommand(registry),
 		cmdinfo.NewInfoCommand(registry),
 		cmdupdate.NewUpdateCommand(registry),
+		cmdimages.NewImagesCommand(registry),
 	}
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
@@ -1,0 +1,36 @@
+package cmdimages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewImagesCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "images",
+		Short:        "List test images",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			extension := registry.Get(componentFlags.Component)
+			if extension == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+			images, err := json.Marshal(extension.Images)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", images)
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
@@ -125,6 +125,11 @@ func (e *Extension) AddSuite(suite Suite) *Extension {
 	return e
 }
 
+func (e *Extension) RegisterImage(image Image) *Extension {
+	e.Images = append(e.Images, image)
+	return e
+}
+
 func (e *Extension) FindSpecsByName(names ...string) (et.ExtensionTestSpecs, error) {
 	var specs et.ExtensionTestSpecs
 	var notFound []string

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
@@ -29,6 +29,28 @@ func ArchitectureEquals(arch string) string {
 	return fmt.Sprintf(`architecture=="%s"`, arch)
 }
 
+func ExternalConnectivityEquals(externalConnectivity string) string {
+	return fmt.Sprintf(`externalConnectivity=="%s"`, externalConnectivity)
+}
+
+func OptionalCapabilitiesIncludeAny(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " || ")))
+}
+
+func OptionalCapabilitiesIncludeAll(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " && ")))
+}
+
+func OptionalCapabilityExists(optionalCapability string) string {
+	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
+}
+
 func InstallerEquals(installer string) string {
 	return fmt.Sprintf(`installer=="%s"`, installer)
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
@@ -79,6 +79,18 @@ func NameContains(name string) SelectFunction {
 	}
 }
 
+// NameContainsAll returns a function that selects specs whose name contains each of the provided contents strings
+func NameContainsAll(contents ...string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		for _, content := range contents {
+			if !strings.Contains(spec.Name, content) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // HasLabel returns a function that selects specs with the provided label
 func HasLabel(label string) SelectFunction {
 	return func(spec *ExtensionTestSpec) bool {
@@ -319,7 +331,8 @@ func (specs ExtensionTestSpecs) FilterByEnvironment(envFlags flags.Environmental
 			decls.NewVar("upgrade", decls.String),
 			decls.NewVar("topology", decls.String),
 			decls.NewVar("architecture", decls.String),
-			decls.NewVar("installer", decls.String),
+			decls.NewVar("externalConnectivity", decls.String),
+			decls.NewVar("optionalCapabilities", decls.NewListType(decls.String)),
 			decls.NewVar("facts", decls.NewMapType(decls.String, decls.String)),
 			decls.NewVar("fact_keys", decls.NewListType(decls.String)),
 			decls.NewVar("version", decls.String),
@@ -333,16 +346,17 @@ func (specs ExtensionTestSpecs) FilterByEnvironment(envFlags flags.Environmental
 		factKeys = append(factKeys, k)
 	}
 	vars := map[string]interface{}{
-		"platform":     envFlags.Platform,
-		"network":      envFlags.Network,
-		"networkStack": envFlags.NetworkStack,
-		"upgrade":      envFlags.Upgrade,
-		"topology":     envFlags.Topology,
-		"architecture": envFlags.Architecture,
-		"installer":    envFlags.Installer,
-		"facts":        envFlags.Facts,
-		"fact_keys":    factKeys,
-		"version":      envFlags.Version,
+		"platform":             envFlags.Platform,
+		"network":              envFlags.Network,
+		"networkStack":         envFlags.NetworkStack,
+		"upgrade":              envFlags.Upgrade,
+		"topology":             envFlags.Topology,
+		"architecture":         envFlags.Architecture,
+		"externalConnectivity": envFlags.ExternalConnectivity,
+		"optionalCapabilities": envFlags.OptionalCapabilities,
+		"facts":                envFlags.Facts,
+		"fact_keys":            factKeys,
+		"version":              envFlags.Version,
 	}
 
 	for _, spec := range specs {

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -17,6 +17,8 @@ type Extension struct {
 	// Suites that the extension wants to advertise/participate in.
 	Suites []Suite `json:"suites"`
 
+	Images []Image `json:"images"`
+
 	// Private data
 	specs         extensiontests.ExtensionTestSpecs
 	obsoleteTests sets.Set[string]
@@ -52,4 +54,11 @@ type Suite struct {
 	Parents []string `json:"parents,omitempty"`
 	// Qualifiers are CEL expressions that are OR'd together for test selection that are members of the suite.
 	Qualifiers []string `json:"qualifiers,omitempty"`
+}
+
+type Image struct {
+	Index    int    `json:"index"`
+	Registry string `json:"registry"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -429,7 +429,7 @@ github.com/munnerz/goautoneg
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 ## explicit
 github.com/mxk/go-flowrate/flowrate
-# github.com/onsi/ginkgo/v2 v2.20.2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
+# github.com/onsi/ginkgo/v2 v2.21.0 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
 ## explicit; go 1.22.0
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config
@@ -489,9 +489,10 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250128181728-a95ca461cacf
-## explicit; go 1.22.0
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
+## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun


### PR DESCRIPTION
Bump to pull in new changes from `openshift-tests-extension`. These will be necessary to translate current test annotations the new environment flags.