### PR TITLE
OCPBUGS-45359: Bump CSI sidecars to fix resizing tests

### DIFF
--- a/test/e2e/storage/csimock/csi_volume_expansion.go
+++ b/test/e2e/storage/csimock/csi_volume_expansion.go
@@ -181,11 +181,6 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					framework.ExpectNoError(err, "While waiting for pvc to have fs resizing condition")
 					pvc = npvc
 
-					inProgressConditions := pvc.Status.Conditions
-					if len(inProgressConditions) > 0 {
-						gomega.Expect(inProgressConditions[0].Type).To(gomega.Equal(v1.PersistentVolumeClaimFileSystemResizePending), "pvc must have fs resizing condition")
-					}
-
 					ginkgo.By("Deleting the previously created pod")
 					if test.simulatedCSIDriverError == expansionFailedMissingStagingPath {
 						e2epod.DeletePodOrFail(ctx, m.cs, pod.Namespace, pod.Name)

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: csi-gce-pd-controller-sa
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -73,7 +73,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -102,7 +102,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -276,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -304,13 +304,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -34,7 +34,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -35,7 +35,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
We still can't rely on first condition being fs-expansion pending condition

Also, we don't really need this check here, because code above already checks for fs expansion

Fixes https://issues.redhat.com/browse/OCPBUGS-45359