### PR TITLE
UPSTREAM: <drop>: ./hack/update-vendor.sh for openshift-tests-extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/runc v1.2.1
 	github.com/opencontainers/selinux v1.11.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220165828-0c4a09a53ed1
 	github.com/openshift/api v0.0.0-20250124212313-a770960d61e0
 	github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710 h1:/nhlfQ5nOCMkLRshi88UM8cAyhhRM+aM/ohe/wwgP6Q=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710/go.mod h1:Ag89ggOpS/66wVeBawzEWLfplYI7YLFx6GW6EW/pgVQ=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220165828-0c4a09a53ed1 h1:bMGD7HP4Za7xDvbSbHyCuPHgFw0KhiH/vHM5+2+wDy0=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220165828-0c4a09a53ed1/go.mod h1:Ag89ggOpS/66wVeBawzEWLfplYI7YLFx6GW6EW/pgVQ=
 github.com/openshift/api v0.0.0-20250124212313-a770960d61e0 h1:dCvNfygMrPLVNQ06bpHXrxKfrXHiprO4+etHrRUqI8g=
 github.com/openshift/api v0.0.0-20250124212313-a770960d61e0/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce h1:w0Up6YV1APcn20v/1h5IfuToz96o2pVqZyjzbw0yotU=

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -10,7 +10,7 @@ godebug winsymlink=0
 
 require (
 	github.com/gogo/protobuf v1.3.2
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 )
 
 require (

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -21,7 +21,7 @@ require (
 	golang.org/x/text v0.19.0
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -29,7 +29,7 @@ require (
 	google.golang.org/protobuf v1.35.1
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/klog/v2 v2.130.1
 )
 

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.19.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -29,7 +29,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.26.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/sys v0.26.0
 	google.golang.org/grpc v1.65.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
 	k8s.io/cri-api v0.0.0

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -11,7 +11,7 @@ godebug winsymlink=0
 require (
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/klog/v2 v2.130.1
 )
 

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
 	k8s.io/klog/v2 v2.130.1

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -9,7 +9,7 @@ godebug default=go1.23
 godebug winsymlink=0
 
 require (
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/component-base v0.0.0
 )
 

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -11,7 +11,7 @@ godebug winsymlink=0
 require (
 	github.com/google/go-cmp v0.6.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/component-base v0.0.0
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -32,7 +32,7 @@ require (
 	golang.org/x/sys v0.26.0
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/cli-runtime v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 )

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -61,7 +61,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
-	k8s.io/apimachinery v0.0.0 // indirect
+	k8s.io/apimachinery v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -11,7 +11,7 @@ godebug winsymlink=0
 require (
 	golang.org/x/time v0.7.0
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/klog/v2 v2.130.1

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
@@ -51,6 +51,10 @@ func OptionalCapabilityExists(optionalCapability string) string {
 	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
 }
 
+func NoOptionalCapabilitiesExist() string {
+	return "size(optionalCapabilities) == 0"
+}
+
 func InstallerEquals(installer string) string {
 	return fmt.Sprintf(`installer=="%s"`, installer)
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
@@ -456,14 +456,26 @@ func (specs ExtensionTestSpecs) Exclude(excludeCEL string) ExtensionTestSpecs {
 	return specs
 }
 
-// Include adds the specified CEL expression to explicitly include tests by environment
+// Include adds the specified CEL expression to explicitly include tests by environment.
+// If there is already an "include" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Include(includeCEL string) *ExtensionTestSpec {
+	existingInclude := spec.EnvironmentSelector.Include
+	if existingInclude != "" {
+		includeCEL = fmt.Sprintf("(%s) || (%s)", existingInclude, includeCEL)
+	}
+
 	spec.EnvironmentSelector.Include = includeCEL
 	return spec
 }
 
-// Exclude adds the specified CEL expression to explicitly exclude tests by environment
+// Exclude adds the specified CEL expression to explicitly exclude tests by environment.
+// If there is already an "exclude" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Exclude(excludeCEL string) *ExtensionTestSpec {
+	existingExclude := spec.EnvironmentSelector.Exclude
+	if existingExclude != "" {
+		excludeCEL = fmt.Sprintf("(%s) || (%s)", existingExclude, excludeCEL)
+	}
+
 	spec.EnvironmentSelector.Exclude = excludeCEL
 	return spec
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220165828-0c4a09a53ed1
 ## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
@@ -1269,8 +1269,6 @@ gopkg.in/yaml.v3
 # k8s.io/api v0.32.1 => ./staging/src/k8s.io/api
 ## explicit; go 1.23.0
 # k8s.io/apiextensions-apiserver v0.32.1 => ./staging/src/k8s.io/apiextensions-apiserver
-## explicit; go 1.23.0
-# k8s.io/apimachinery v0.0.0 => ./staging/src/k8s.io/apimachinery
 ## explicit; go 1.23.0
 # k8s.io/apimachinery v0.32.1 => ./staging/src/k8s.io/apimachinery
 ## explicit; go 1.23.0


### PR DESCRIPTION
Need to re-vendor `openshift-tests-extension` to pull in updates to helper methods that will be useful in translating existing test skips.
