### PR TITLE
OCPBUGS-45241: UPSTREAM: <carry>: Re-enable temporarily disabled port-forward test

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -749,7 +749,7 @@ var Annotations = map[string]string{
 
 	"[sig-autoscaling] [Feature:HPA] [Serial] [Slow] Horizontal pod autoscaling (non-default behavior) with short downscale stabilization window should scale down soon after the stabilization period": " [Suite:k8s]",
 
-	"[sig-cli] Kubectl Port forwarding Shutdown client connection while the remote stream is writing data to the port-forward connection port-forward should keep working after detect broken connection": " [Disabled:RebaseInProgress] [Suite:k8s]",
+	"[sig-cli] Kubectl Port forwarding Shutdown client connection while the remote stream is writing data to the port-forward connection port-forward should keep working after detect broken connection": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets": " [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -176,9 +176,6 @@ var (
 			// https://issues.redhat.com/browse/OCPBUGS-45273
 			`\[sig-network\] Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes`,
 
-			// https://issues.redhat.com/browse/OCPBUGS-45273
-			`\[sig-cli\] Kubectl Port forwarding Shutdown client connection while the remote stream is writing data to the port-forward connection port-forward should keep working after detect broken connection`,
-
 			// https://issues.redhat.com/browse/OCPBUGS-45274
 			// https://github.com/kubernetes/kubernetes/issues/129056
 			`\[sig-node\] PodRejectionStatus Kubelet should reject pod when the node didn't have enough resource`,


### PR DESCRIPTION
This test was disabled temporarily during rebase process, because it requires to have newer versions of crio and oc. Now, these components have been based on 1.32.

This PR re-enables port-forward tests.