### PR TITLE
TRT-1854: Update openshift-tests-extension version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/runc v1.2.1
 	github.com/opencontainers/selinux v1.11.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
 	github.com/openshift/api v0.0.0-20250129162653-107848b719c5
 	github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710 h1:/nhlfQ5nOCMkLRshi88UM8cAyhhRM+aM/ohe/wwgP6Q=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710/go.mod h1:Ag89ggOpS/66wVeBawzEWLfplYI7YLFx6GW6EW/pgVQ=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45 h1:hXpbYtP3iTh8oy/RKwKkcMziwchY3fIk95ciczf7cOA=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20250129162653-107848b719c5 h1:PzJJmofv/P9R1JUxO8X6tAMxKACVS6Quxo/xBzMkSmI=
 github.com/openshift/api v0.0.0-20250129162653-107848b719c5/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce h1:w0Up6YV1APcn20v/1h5IfuToz96o2pVqZyjzbw0yotU=

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/version"
 )
 

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
@@ -51,6 +51,10 @@ func OptionalCapabilityExists(optionalCapability string) string {
 	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
 }
 
+func NoOptionalCapabilitiesExist() string {
+	return "size(optionalCapabilities) == 0"
+}
+
 func InstallerEquals(installer string) string {
 	return fmt.Sprintf(`installer=="%s"`, installer)
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
@@ -456,14 +456,26 @@ func (specs ExtensionTestSpecs) Exclude(excludeCEL string) ExtensionTestSpecs {
 	return specs
 }
 
-// Include adds the specified CEL expression to explicitly include tests by environment
+// Include adds the specified CEL expression to explicitly include tests by environment.
+// If there is already an "include" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Include(includeCEL string) *ExtensionTestSpec {
+	existingInclude := spec.EnvironmentSelector.Include
+	if existingInclude != "" {
+		includeCEL = fmt.Sprintf("(%s) || (%s)", existingInclude, includeCEL)
+	}
+
 	spec.EnvironmentSelector.Include = includeCEL
 	return spec
 }
 
-// Exclude adds the specified CEL expression to explicitly exclude tests by environment
+// Exclude adds the specified CEL expression to explicitly exclude tests by environment.
+// If there is already an "exclude" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Exclude(excludeCEL string) *ExtensionTestSpec {
+	existingExclude := spec.EnvironmentSelector.Exclude
+	if existingExclude != "" {
+		excludeCEL = fmt.Sprintf("(%s) || (%s)", existingExclude, excludeCEL)
+	}
+
 	spec.EnvironmentSelector.Exclude = excludeCEL
 	return spec
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
@@ -1,9 +1,8 @@
 package extensiontests
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 )
 
 type Lifecycle string

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -1,9 +1,8 @@
 package extension
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 )
 
 const CurrentExtensionAPIVersion = "v1.0"

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
@@ -10,8 +10,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	ext "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 )

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/LICENSE
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/README.md
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/README.md
@@ -1,0 +1,3 @@
+This package is copy/pasted from [k8s.io/apimachinery](https://github.com/kubernetes/apimachinery/tree/master/pkg/util/sets) 
+to avoid a circular dependency with `openshift/kubernetes` as it requires OTE and, without having done this, 
+OTE would require `kubernetes/kubernetes`.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/byte.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/byte.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Byte is a set of bytes, implemented via map[byte]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[byte]{}
+// s2 := New[byte]()
+type Byte map[byte]Empty
+
+// NewByte creates a Byte from a list of values.
+func NewByte(items ...byte) Byte {
+	return Byte(New[byte](items...))
+}
+
+// ByteKeySet creates a Byte from a keys of a map[byte](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func ByteKeySet[T any](theMap map[byte]T) Byte {
+	return Byte(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Byte) Insert(items ...byte) Byte {
+	return Byte(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Byte) Delete(items ...byte) Byte {
+	return Byte(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Byte) Has(item byte) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Byte) HasAll(items ...byte) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Byte) HasAny(items ...byte) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Byte) Clone() Byte {
+	return Byte(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Byte) Difference(s2 Byte) Byte {
+	return Byte(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Byte) SymmetricDifference(s2 Byte) Byte {
+	return Byte(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Byte) Union(s2 Byte) Byte {
+	return Byte(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Byte) Intersection(s2 Byte) Byte {
+	return Byte(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Byte) IsSuperset(s2 Byte) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Byte) Equal(s2 Byte) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted byte slice.
+func (s Byte) List() []byte {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Byte) UnsortedList() []byte {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Byte) PopAny() (byte, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Byte) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/doc.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sets has generic set and specified sets. Generic set will
+// replace specified ones over time. And specific ones are deprecated.
+package sets // import "github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/empty.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/empty.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Empty is public since it is used by some internal API objects for conversions between external
+// string arrays and internal sets, and conversion logic requires public types today.
+type Empty struct{}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int is a set of ints, implemented via map[int]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int]{}
+// s2 := New[int]()
+type Int map[int]Empty
+
+// NewInt creates a Int from a list of values.
+func NewInt(items ...int) Int {
+	return Int(New[int](items...))
+}
+
+// IntKeySet creates a Int from a keys of a map[int](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func IntKeySet[T any](theMap map[int]T) Int {
+	return Int(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int) Insert(items ...int) Int {
+	return Int(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int) Delete(items ...int) Int {
+	return Int(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int) Has(item int) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int) HasAll(items ...int) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int) HasAny(items ...int) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int) Clone() Int {
+	return Int(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int) Difference(s2 Int) Int {
+	return Int(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int) SymmetricDifference(s2 Int) Int {
+	return Int(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int) Union(s2 Int) Int {
+	return Int(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int) Intersection(s2 Int) Int {
+	return Int(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int) IsSuperset(s2 Int) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int) Equal(s2 Int) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int slice.
+func (s Int) List() []int {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int) UnsortedList() []int {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int) PopAny() (int, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int32.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int32.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int32 is a set of int32s, implemented via map[int32]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int32]{}
+// s2 := New[int32]()
+type Int32 map[int32]Empty
+
+// NewInt32 creates a Int32 from a list of values.
+func NewInt32(items ...int32) Int32 {
+	return Int32(New[int32](items...))
+}
+
+// Int32KeySet creates a Int32 from a keys of a map[int32](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func Int32KeySet[T any](theMap map[int32]T) Int32 {
+	return Int32(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int32) Insert(items ...int32) Int32 {
+	return Int32(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int32) Delete(items ...int32) Int32 {
+	return Int32(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int32) Has(item int32) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int32) HasAll(items ...int32) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int32) HasAny(items ...int32) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int32) Clone() Int32 {
+	return Int32(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int32) Difference(s2 Int32) Int32 {
+	return Int32(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int32) SymmetricDifference(s2 Int32) Int32 {
+	return Int32(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int32) Union(s2 Int32) Int32 {
+	return Int32(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int32) Intersection(s2 Int32) Int32 {
+	return Int32(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int32) IsSuperset(s2 Int32) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int32) Equal(s2 Int32) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int32 slice.
+func (s Int32) List() []int32 {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int32) UnsortedList() []int32 {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int32) PopAny() (int32, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int32) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int64.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int64.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int64 is a set of int64s, implemented via map[int64]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int64]{}
+// s2 := New[int64]()
+type Int64 map[int64]Empty
+
+// NewInt64 creates a Int64 from a list of values.
+func NewInt64(items ...int64) Int64 {
+	return Int64(New[int64](items...))
+}
+
+// Int64KeySet creates a Int64 from a keys of a map[int64](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func Int64KeySet[T any](theMap map[int64]T) Int64 {
+	return Int64(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int64) Insert(items ...int64) Int64 {
+	return Int64(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int64) Delete(items ...int64) Int64 {
+	return Int64(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int64) Has(item int64) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int64) HasAll(items ...int64) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int64) HasAny(items ...int64) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int64) Clone() Int64 {
+	return Int64(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int64) Difference(s2 Int64) Int64 {
+	return Int64(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int64) SymmetricDifference(s2 Int64) Int64 {
+	return Int64(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int64) Union(s2 Int64) Int64 {
+	return Int64(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int64) Intersection(s2 Int64) Int64 {
+	return Int64(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int64) IsSuperset(s2 Int64) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int64) Equal(s2 Int64) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int64 slice.
+func (s Int64) List() []int64 {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int64) UnsortedList() []int64 {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int64) PopAny() (int64, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int64) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/set.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/set.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"cmp"
+	"sort"
+)
+
+// Set is a set of the same type elements, implemented via map[comparable]struct{} for minimal memory consumption.
+type Set[T comparable] map[T]Empty
+
+// cast transforms specified set to generic Set[T].
+func cast[T comparable](s map[T]Empty) Set[T] { return s }
+
+// New creates a Set from a list of values.
+// NOTE: type param must be explicitly instantiated if given items are empty.
+func New[T comparable](items ...T) Set[T] {
+	ss := make(Set[T], len(items))
+	ss.Insert(items...)
+	return ss
+}
+
+// KeySet creates a Set from a keys of a map[comparable](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func KeySet[T comparable, V any](theMap map[T]V) Set[T] {
+	ret := make(Set[T], len(theMap))
+	for keyValue := range theMap {
+		ret.Insert(keyValue)
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s Set[T]) Insert(items ...T) Set[T] {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+func Insert[T comparable](set Set[T], items ...T) Set[T] {
+	return set.Insert(items...)
+}
+
+// Delete removes all items from the set.
+func (s Set[T]) Delete(items ...T) Set[T] {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+func (s Set[T]) Clear() Set[T] {
+	clear(s)
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Set[T]) Has(item T) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Set[T]) HasAll(items ...T) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Set[T]) HasAny(items ...T) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Set[T]) Clone() Set[T] {
+	result := make(Set[T], len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Set[T]) Difference(s2 Set[T]) Set[T] {
+	result := New[T]()
+	for key := range s1 {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
+	return s1.Difference(s2).Union(s2.Difference(s1))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Set[T]) Union(s2 Set[T]) Set[T] {
+	result := s1.Clone()
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Set[T]) Intersection(s2 Set[T]) Set[T] {
+	var walk, other Set[T]
+	result := New[T]()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Set[T]) IsSuperset(s2 Set[T]) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Set[T]) Equal(s2 Set[T]) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+type sortableSliceOfGeneric[T cmp.Ordered] []T
+
+func (g sortableSliceOfGeneric[T]) Len() int           { return len(g) }
+func (g sortableSliceOfGeneric[T]) Less(i, j int) bool { return less[T](g[i], g[j]) }
+func (g sortableSliceOfGeneric[T]) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+// List returns the contents as a sorted T slice.
+//
+// This is a separate function and not a method because not all types supported
+// by Generic are ordered and only those can be sorted.
+func List[T cmp.Ordered](s Set[T]) []T {
+	res := make(sortableSliceOfGeneric[T], 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Set[T]) UnsortedList() []T {
+	res := make([]T, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// PopAny returns a single element from the set.
+func (s Set[T]) PopAny() (T, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue T
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s Set[T]) Len() int {
+	return len(s)
+}
+
+func less[T cmp.Ordered](lhs, rhs T) bool {
+	return lhs < rhs
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/string.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/string.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[string]{}
+// s2 := New[string]()
+type String map[string]Empty
+
+// NewString creates a String from a list of values.
+func NewString(items ...string) String {
+	return String(New[string](items...))
+}
+
+// StringKeySet creates a String from a keys of a map[string](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func StringKeySet[T any](theMap map[string]T) String {
+	return String(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s String) Insert(items ...string) String {
+	return String(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s String) Delete(items ...string) String {
+	return String(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s String) Has(item string) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s String) HasAll(items ...string) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s String) HasAny(items ...string) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s String) Clone() String {
+	return String(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 String) Difference(s2 String) String {
+	return String(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 String) SymmetricDifference(s2 String) String {
+	return String(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 String) Union(s2 String) String {
+	return String(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 String) Intersection(s2 String) String {
+	return String(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 String) IsSuperset(s2 String) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 String) Equal(s2 String) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted string slice.
+func (s String) List() []string {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s String) UnsortedList() []string {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s String) PopAny() (string, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s String) Len() int {
+	return len(s)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250205124614-2f0f92f05710
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
 ## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
@@ -502,6 +502,7 @@ github.com/openshift-eng/openshift-tests-extension/pkg/extension
 github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests
 github.com/openshift-eng/openshift-tests-extension/pkg/flags
 github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo
+github.com/openshift-eng/openshift-tests-extension/pkg/util/sets
 github.com/openshift-eng/openshift-tests-extension/pkg/version
 # github.com/openshift/api v0.0.0-20250129162653-107848b719c5
 ## explicit; go 1.23.0


### PR DESCRIPTION
Re-vendoring `openshift-tests-extension` to pull in some useful helper methods needed to translate the existing test skips to the new environment flags.