### PR TITLE
TRT-1854: translate test annotations to use: `include`/`exclude` CEL, labels, filtering

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// filterOutDisabledSpecs returns the specs with those that are disabled removed from the list
+func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
+	var disabledByReason = map[string][]string{
+		"Alpha": { // alpha features that are not gated
+			"[Feature:StorageVersionAPI]",
+			"[Feature:InPlacePodVerticalScaling]",
+			"[Feature:ServiceCIDRs]",
+			"[Feature:ClusterTrustBundle]",
+			"[Feature:SELinuxMount]",
+			"[FeatureGate:SELinuxMount]",
+			"[Feature:UserNamespacesPodSecurityStandards]",
+			"[Feature:UserNamespacesSupport]", // disabled Beta
+			"[Feature:DynamicResourceAllocation]",
+			"[Feature:VolumeAttributesClass]", // disabled Beta
+			"[sig-cli] Kubectl client Kubectl prune with applyset should apply and prune objects", // Alpha feature since k8s 1.27
+			// 4.19
+			"[Feature:PodLevelResources]",
+			"[Feature:SchedulerAsyncPreemption]",
+			"[Feature:RelaxedDNSSearchValidation]",
+			"[Feature:PodLogsQuerySplitStreams]",
+			"[Feature:PodLifecycleSleepActionAllowZero]",
+			"[Feature:volumegroupsnapshot]",
+		},
+		// tests for features that are not implemented in openshift
+		"Unimplemented": {
+			"Monitoring",                               // Not installed, should be
+			"Cluster level logging",                    // Not installed yet
+			"Kibana",                                   // Not installed
+			"Ubernetes",                                // Can't set zone labels today
+			"kube-ui",                                  // Not installed by default
+			"Kubernetes Dashboard",                     // Not installed by default (also probably slow image pull)
+			"should proxy to cadvisor",                 // we don't expose cAdvisor port directly for security reasons
+			"[Feature:BootstrapTokens]",                // we don't serve cluster-info configmap
+			"[Feature:KubeProxyDaemonSetMigration]",    // upgrades are run separately
+			"[Feature:BoundServiceAccountTokenVolume]", // upgrades are run separately
+			"[Feature:StatefulUpgrade]",                // upgrades are run separately
+		},
+		// tests that rely on special configuration that we do not yet support
+		"SpecialConfig": {
+			// GPU node needs to be available
+			"[Feature:GPUDevicePlugin]",
+			"[sig-scheduling] GPUDevicePluginAcrossRecreate [Feature:Recreate]",
+
+			"[Feature:LocalStorageCapacityIsolation]", // relies on a separate daemonset?
+			"[sig-cloud-provider-gcp]",                // these test require a different configuration - note that GCE tests from the sig-cluster-lifecycle were moved to the sig-cloud-provider-gcpcluster lifecycle see https://github.com/kubernetes/kubernetes/commit/0b3d50b6dccdc4bbd0b3e411c648b092477d79ac#diff-3b1910d08fb8fd8b32956b5e264f87cb
+
+			"kube-dns-autoscaler", // Don't run kube-dns
+			"should check if Kubernetes master services is included in cluster-info", // Don't run kube-dns
+			"DNS configMap", // this tests dns federation configuration via configmap, which we don't support yet
+
+			"NodeProblemDetector",                   // requires a non-master node to run on
+			"Advanced Audit should audit API calls", // expects to be able to call /logs
+
+			"Firewall rule should have correct firewall rules for e2e cluster", // Upstream-install specific
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=2079958
+			"[sig-network] [Feature:Topology Hints] should distribute endpoints evenly",
+
+			// Tests require SSH configuration and is part of the parallel suite, which does not create the bastion
+			// host. Enabling the test would result in the  bastion being created for every parallel test execution.
+			// Given that we have existing oc and WMCO tests that cover this functionality, we can safely disable it.
+			"[Feature:NodeLogQuery]",
+		},
+		// tests that are known broken and need to be fixed upstream or in openshift
+		// always add an issue here
+		"Broken": {
+			"mount an API token into pods",                              // We add 6 secrets, not 1
+			"ServiceAccounts should ensure a single API token exists",   // We create lots of secrets
+			"unchanging, static URL paths for kubernetes api services",  // the test needs to exclude URLs that are not part of conformance (/logs)
+			"Services should be able to up and down services",           // we don't have wget installed on nodes
+			"KubeProxy should set TCP CLOSE_WAIT timeout",               // the test require communication to port 11302 in the cluster nodes
+			"should check kube-proxy urls",                              // previously this test was skipped b/c we reported -1 as the number of nodes, now we report proper number and test fails
+			"SSH",                                                       // TRIAGE
+			"should implement service.kubernetes.io/service-proxy-name", // this is an optional test that requires SSH. sig-network
+			"recreate nodes and ensure they function upon restart",      // https://bugzilla.redhat.com/show_bug.cgi?id=1756428
+			"[Driver: iscsi]",                                           // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
+
+			"RuntimeClass should reject",
+
+			"Services should implement service.kubernetes.io/headless",                    // requires SSH access to function, needs to be refactored
+			"ClusterDns [Feature:Example] should create pod that uses dns",                // doesn't use bindata, not part of kube test binary
+			"Simple pod should return command exit codes should handle in-cluster config", // kubectl cp doesn't work or is not preserving executable bit, we have this test already
+
+			// TODO(node): configure the cri handler for the runtime class to make this work
+			"should run a Pod requesting a RuntimeClass with a configured handler",
+			"should reject a Pod requesting a RuntimeClass with conflicting node selector",
+			"should run a Pod requesting a RuntimeClass with scheduling",
+
+			// A fix is in progress: https://github.com/openshift/origin/pull/24709
+			"Multi-AZ Clusters should spread the pods of a replication controller across zones",
+
+			// Upstream assumes all control plane pods are in kube-system namespace and we should revert the change
+			// https://github.com/kubernetes/kubernetes/commit/176c8e219f4c7b4c15d34b92c50bfa5ba02b3aba#diff-28a3131f96324063dd53e17270d435a3b0b3bd8f806ee0e33295929570eab209R78
+			"MetricsGrabber should grab all metrics from a Kubelet",
+			"MetricsGrabber should grab all metrics from API server",
+			"MetricsGrabber should grab all metrics from a ControllerManager",
+			"MetricsGrabber should grab all metrics from a Scheduler",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1906808
+			"ServiceAccounts should support OIDC discovery of service account issuer",
+
+			// NFS umount is broken in kernels 5.7+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1854379
+			"[sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1986306
+			"[sig-cli] Kubectl client kubectl wait should ignore not found error with --for=delete",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1980141
+			"Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector",
+			"Netpol NetworkPolicy between server and client should enforce policy to allow traffic from pods within server namespace based on PodSelector",
+			"Netpol NetworkPolicy between server and client should enforce policy based on NamespaceSelector with MatchExpressions",
+			"Netpol NetworkPolicy between server and client should enforce policy based on PodSelector with MatchExpressions",
+			"Netpol NetworkPolicy between server and client should enforce policy based on PodSelector or NamespaceSelector",
+			"Netpol NetworkPolicy between server and client should deny ingress from pods on other namespaces",
+			"Netpol NetworkPolicy between server and client should enforce updated policy",
+			"Netpol NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors",
+			"Netpol NetworkPolicy between server and client should enforce policy based on any PodSelectors",
+			"Netpol NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector",
+			"Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should support a 'default-deny-ingress' policy",
+			"Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy based on Ports",
+			"Netpol [LinuxOnly] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector",
+
+			"Topology Hints should distribute endpoints evenly",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1908645
+			"[sig-network] Networking Granular Checks: Services should function for service endpoints using hostNetwork",
+			"[sig-network] Networking Granular Checks: Services should function for pod-Service(hostNetwork)",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1952460
+			"[sig-network] Firewall rule control plane should not expose well-known ports",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1988272
+			"[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6]",
+			"[sig-network] Networking should provider Internet connection for containers using DNS",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1957894
+			"[sig-node] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1952457
+			"[sig-node] crictl should be able to run crictl on the node",
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1953478
+			"[sig-storage] Dynamic Provisioning Invalid AWS KMS key should report an error and create no PV",
+
+			// https://issues.redhat.com/browse/OCPBUGS-34577
+			"[sig-storage] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs",
+
+			// https://issues.redhat.com/browse/OCPBUGS-34594
+			"[sig-node] [Feature:PodLifecycleSleepAction] when create a pod with lifecycle hook using sleep action valid prestop hook using sleep action",
+
+			// https://issues.redhat.com/browse/OCPBUGS-38839
+			"[sig-network] [Feature:Traffic Distribution] when Service has trafficDistribution=PreferClose should route traffic to an endpoint that is close to the client",
+		},
+		// tests that need to be temporarily disabled while the rebase is in progress.
+		"RebaseInProgress": {
+			// https://issues.redhat.com/browse/OCPBUGS-7297
+			"DNS HostNetwork should resolve DNS of partial qualified names for services on hostNetwork pods with dnsPolicy",
+
+			// https://issues.redhat.com/browse/OCPBUGS-45275
+			"[sig-network] Connectivity Pod Lifecycle should be able to connect to other Pod from a terminating Pod",
+
+			// https://issues.redhat.com/browse/OCPBUGS-17194
+			"[sig-node] ImageCredentialProvider [Feature:KubeletCredentialProviders] should be able to create pod with image credentials fetched from external credential provider",
+
+			// https://issues.redhat.com/browse/OCPBUGS-45273
+			"[sig-network] Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes",
+		},
+		// tests that may work, but we don't support them
+		"Unsupported": {
+			"[Driver: rbd]",             // OpenShift 4.x does not support Ceph RBD (use CSI instead)
+			"[Driver: ceph]",            // OpenShift 4.x does not support CephFS (use CSI instead)
+			"[Driver: gluster]",         // OpenShift 4.x does not support Gluster
+			"Volumes GlusterFS",         // OpenShift 4.x does not support Gluster
+			"GlusterDynamicProvisioner", // OpenShift 4.x does not support Gluster
+
+			// Also, our CI doesn't support topology, so disable those tests
+			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (delayed binding)] topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies",
+			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (delayed binding)] topology should provision a volume and schedule a pod with AllowedTopologies",
+			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (immediate binding)] topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies",
+			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (immediate binding)] topology should provision a volume and schedule a pod with AllowedTopologies",
+		},
+	}
+
+	var disabledSpecs et.ExtensionTestSpecs
+	for _, disabledList := range disabledByReason {
+		var selectFunctions []et.SelectFunction
+		for _, disabledName := range disabledList {
+			selectFunctions = append(selectFunctions, et.NameContains(disabledName))
+		}
+
+		disabledSpecs = append(disabledSpecs, specs.SelectAny(selectFunctions)...)
+	}
+
+	disabledNames := sets.New[string]()
+	for _, disabledSpec := range disabledSpecs {
+		disabledNames.Insert(disabledSpec.Name)
+	}
+
+	enabledSpecs := specs[:0]
+	for _, spec := range specs {
+		if !disabledNames.Has(spec.Name) {
+			enabledSpecs = append(enabledSpecs, spec)
+		}
+	}
+
+	return enabledSpecs
+}

--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -1,0 +1,231 @@
+package main
+
+import et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+
+// addEnvironmentSelectors adds the environmentSelector field to appropriate specs to facilitate including or excluding
+// them based on attributes of the cluster they are running on
+func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
+	filterByPlatform(specs)
+	filterByExternalConnectivity(specs)
+	filterByTopology(specs)
+	filterByNoOptionalCapabilities(specs)
+	filterByNetwork(specs)
+
+	// LoadBalancer tests in 1.31 require explicit platform-specific skips
+	// https://issues.redhat.com/browse/OCPBUGS-38840
+	specs.SelectAny([]et.SelectFunction{ // Since these must use "NameContainsAll" they cannot be included in filterByPlatform
+		et.NameContainsAll("[sig-network] LoadBalancers [Feature:LoadBalancer]", "UDP"),
+		et.NameContainsAll("[sig-network] LoadBalancers [Feature:LoadBalancer]", "session affinity"),
+	}).Exclude(et.PlatformEquals("aws"))
+}
+
+// filterByPlatform is a helper function to do, simple, "NameContains" filtering on tests by platform
+func filterByPlatform(specs et.ExtensionTestSpecs) {
+	var platformExclusions = map[string][]string{
+		"alibabacloud": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"azure": {
+			"Networking should provide Internet connection for containers", // Azure does not allow ICMP traffic to internet.
+			// Azure CSI migration changed how we treat regions without zones.
+			// See https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2066865
+			"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (immediate binding)] topology should provision a volume and schedule a pod with AllowedTopologies",
+			"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (delayed binding)] topology should provision a volume and schedule a pod with AllowedTopologies",
+		},
+		"baremetal": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"gce": {
+			// Requires creation of a different compute instance in a different zone and is not compatible with volumeBindingMode of WaitForFirstConsumer which we use in 4.x
+			"[sig-storage] Multi-AZ Cluster Volumes should only be allowed to provision PDs in zones where nodes exist",
+			// The following tests try to ssh directly to a node. None of our nodes have external IPs
+			"[k8s.io] [sig-node] crictl should be able to run crictl on the node",
+			"[sig-storage] Flexvolumes should be mountable",
+			"[sig-storage] Detaching volumes should not work when mount is in progress",
+			// We are using ovn-kubernetes to conceal metadata
+			"[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1740959
+			"[sig-api-machinery] AdmissionWebhook should be able to deny pod and configmap creation",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1745720
+			"[sig-storage] CSI Volumes [Driver: pd.csi.storage.gke.io]",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1749882
+			"[sig-storage] CSI Volumes CSI Topology test using GCE PD driver [Serial]",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1751367
+			"gce-localssd-scsi-fs",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1750851
+			// should be serial if/when it's re-enabled
+			"[HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver)",
+			"[Feature:CustomMetricsAutoscaling]",
+		},
+		"ibmcloud": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"ibmroks": {
+			// Calico is allowing the request to timeout instead of returning 'REFUSED'
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1825021 - ROKS: calico SDN results in a request timeout when accessing services with no endpoints
+			"[sig-network] Services should be rejected when no endpoints exist",
+			// Nodes in ROKS have access to secrets in the cluster to handle encryption
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1825013 - ROKS: worker nodes have access to secrets in the cluster
+			"[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error",
+			"[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error",
+			"[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed",
+			"[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error",
+			"[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error",
+			// Access to node external address is blocked from pods within a ROKS cluster by Calico
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1825016 - e2e: NodeAuthenticator tests use both external and internal addresses for node
+			"[sig-auth] [Feature:NodeAuthenticator] The kubelet's main port 10250 should reject requests with no credentials",
+			"[sig-auth] [Feature:NodeAuthenticator] The kubelet can delegate ServiceAccount tokens to the API server",
+			// Mode returned by RHEL7 worker contains an extra character not expected by the test: dgtrwx vs dtrwx
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1825024 - e2e: Failing test - HostPath should give a volume the correct mode
+			"[sig-storage] HostPath should give a volume the correct mode",
+		},
+		"kubevirt": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"nutanix": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"openstack": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"ovirt": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+		"vsphere": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-38840
+			"[Feature:LoadBalancer]",
+		},
+	}
+
+	for platform, exclusions := range platformExclusions {
+		var selectFunctions []et.SelectFunction
+		for _, exclusion := range exclusions {
+			selectFunctions = append(selectFunctions, et.NameContains(exclusion))
+		}
+
+		specs.SelectAny(selectFunctions).Exclude(et.PlatformEquals(platform))
+	}
+}
+
+// filterByExternalConnectivity is a helper function to do, simple, "NameContains" filtering on tests by external connectivity
+func filterByExternalConnectivity(specs et.ExtensionTestSpecs) {
+	var externalConnectivityExclusions = map[string][]string{
+		// Tests that don't pass on disconnected, either due to requiring
+		// internet access for GitHub (e.g. many of the s2i builds), or
+		// because of pullthrough not supporting ICSP (https://bugzilla.redhat.com/show_bug.cgi?id=1918376)
+		"Disconnected": {
+			"[sig-network] Networking should provide Internet connection for containers",
+		},
+		// These tests are skipped when openshift-tests needs to use a proxy to reach the
+		// cluster -- either because the test won't work while proxied, or because the test
+		// itself is testing a functionality using it's own proxy.
+		"Proxy": {
+			// These tests setup their own proxy, which won't work when we need to access the
+			// cluster through a proxy.
+			"[sig-cli] Kubectl client Simple pod should support exec through an HTTP proxy",
+			"[sig-cli] Kubectl client Simple pod should support exec through kubectl proxy",
+			// Kube currently uses the x/net/websockets pkg, which doesn't work with proxies.
+			// See: https://github.com/kubernetes/kubernetes/pull/103595
+			"[sig-node] Pods should support retrieving logs from the container over websockets",
+			"[sig-cli] Kubectl Port forwarding With a server listening on localhost should support forwarding over websockets",
+			"[sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets",
+			"[sig-node] Pods should support remote command execution over websockets",
+			// These tests are flacky and require internet access
+			// See https://bugzilla.redhat.com/show_bug.cgi?id=2019375
+			"[sig-network] DNS should resolve DNS of partial qualified names for services",
+			"[sig-network] DNS should provide DNS for the cluster",
+			// This test does not work when using in-proxy cluster, see https://bugzilla.redhat.com/show_bug.cgi?id=2084560
+			"[sig-network] Networking should provide Internet connection for containers",
+		},
+	}
+
+	for externalConnectivity, exclusions := range externalConnectivityExclusions {
+		var selectFunctions []et.SelectFunction
+		for _, exclusion := range exclusions {
+			selectFunctions = append(selectFunctions, et.NameContains(exclusion))
+		}
+
+		specs.SelectAny(selectFunctions).Exclude(et.ExternalConnectivityEquals(externalConnectivity))
+	}
+}
+
+// filterByTopology is a helper function to do, simple, "NameContains" filtering on tests by topology
+func filterByTopology(specs et.ExtensionTestSpecs) {
+	var topologyExclusions = map[string][]string{
+		"SingleReplicaTopology": {
+			"[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]",
+			"[sig-node] NoExecuteTaintManager Single Pod [Serial] doesn't evict pod with tolerations from tainted nodes",
+			"[sig-node] NoExecuteTaintManager Single Pod [Serial] eventually evict pod with finite tolerations from tainted nodes",
+			"[sig-node] NoExecuteTaintManager Single Pod [Serial] evicts pods from tainted nodes",
+			"[sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance]",
+			"[sig-node] NoExecuteTaintManager Single Pod [Serial] pods evicted from tainted nodes have pod disruption condition",
+			"[sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]",
+			"[sig-node] NoExecuteTaintManager Multiple Pods [Serial] only evicts pods without tolerations from tainted nodes",
+			"[sig-cli] Kubectl client Kubectl taint [Serial] should remove all the taints with the same key off a node",
+			"[sig-network] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on different nodes",
+			"[sig-network] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same nodes",
+			"[sig-architecture] Conformance Tests should have at least two untainted nodes",
+		},
+	}
+
+	for topology, exclusions := range topologyExclusions {
+		var selectFunctions []et.SelectFunction
+		for _, exclusion := range exclusions {
+			selectFunctions = append(selectFunctions, et.NameContains(exclusion))
+		}
+
+		specs.SelectAny(selectFunctions).Exclude(et.TopologyEquals(topology))
+	}
+}
+
+// filterByNoOptionalCapabilities is a helper function to facilitate adding environment selectors for tests which can't
+// be run/don't make sense to run against a cluster with all optional capabilities disabled
+func filterByNoOptionalCapabilities(specs et.ExtensionTestSpecs) {
+	var exclusions = []string{
+		// Requires CSISnapshot capability
+		"[Feature:VolumeSnapshotDataSource]",
+		// Requires Storage capability
+		"[Driver: aws]",
+		"[Feature:StorageProvider]",
+	}
+
+	var selectFunctions []et.SelectFunction
+	for _, exclusion := range exclusions {
+		selectFunctions = append(selectFunctions, et.NameContains(exclusion))
+	}
+	specs.SelectAny(selectFunctions).Exclude(et.NoOptionalCapabilitiesExist())
+}
+
+// filterByNetwork is a helper function to do, simple, "NameContains" filtering on tests by network
+func filterByNetwork(specs et.ExtensionTestSpecs) {
+	var networkExclusions = map[string][]string{
+		"OVNKubernetes": {
+			"NetworkPolicy",
+			"named port",
+		},
+	}
+
+	for network, exclusions := range networkExclusions {
+		var selectFunctions []et.SelectFunction
+		for _, exclusion := range exclusions {
+			selectFunctions = append(selectFunctions, et.NameContains(exclusion))
+		}
+
+		specs.SelectAny(selectFunctions).Exclude(et.NetworkEquals(network))
+	}
+}

--- a/openshift-hack/cmd/k8s-tests-ext/labels.go
+++ b/openshift-hack/cmd/k8s-tests-ext/labels.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+)
+
+func addLabelsToSpecs(specs et.ExtensionTestSpecs) {
+	var namesByLabel = map[string][]string{
+		// tests too slow to be part of conformance
+		"Slow": {
+			"[sig-scalability]",                            // disable from the default set for now
+			"should create and stop a working application", // Inordinately slow tests
+
+			"[Feature:PerformanceDNS]", // very slow
+
+			"validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", // 5m, really?
+		},
+		// tests that are known flaky
+		"Flaky": {
+			"Job should run a job to completion when tasks sometimes fail and are not locally restarted", // seems flaky, also may require too many resources
+			// TODO(node): test works when run alone, but not in the suite in CI
+			"[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods",
+		},
+		// tests that must be run without competition
+		"Serial": {
+			"[Disruptive]",
+			"[Feature:Performance]", // requires isolation
+
+			"Service endpoints latency", // requires low latency
+			"Clean up pods on node",     // schedules up to max pods per node
+			"DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume", // test is very disruptive to other tests
+
+			"Should be able to support the 1.7 Sample API Server using the current Aggregator", // down apiservices break other clients today https://bugzilla.redhat.com/show_bug.cgi?id=1623195
+
+			"[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods",
+
+			"should prevent Ingress creation if more than 1 IngressClass marked as default", // https://bugzilla.redhat.com/show_bug.cgi?id=1822286
+
+			"[sig-network] IngressClass [Feature:Ingress] should set default value on new IngressClass", //https://bugzilla.redhat.com/show_bug.cgi?id=1833583
+		},
+	}
+
+	for label, names := range namesByLabel {
+		var selectFunctions []et.SelectFunction
+		for _, name := range names {
+			selectFunctions = append(selectFunctions, et.NameContains(name))
+		}
+
+		//TODO: once annotation logic has been removed, it might also be necessary to annotate the test name with the label as well
+		specs.SelectAny(selectFunctions).AddLabel(label)
+	}
+}


### PR DESCRIPTION
`openshift-tests-extension` introduces a new way to skip upstream tests based on environment flags and `include`/`exclude` fields present on the listed tests. This PR translates the existing annotations to that functionality, but leaves them in place. They will be removed in a later PR.