### PR TITLE
NO-JIRA: Initialize testContext before enumerating tests

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -49,6 +49,12 @@ func main() {
 	kubeTestsExtension := e.NewExtension("openshift", "payload", "hyperkube")
 	extensionRegistry.Register(kubeTestsExtension)
 
+	// Initialization for kube ginkgo test framework needs to run before all tests are discovered.
+	// Some tests use the testContext to generate e2e tests.
+	if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
+		panic(err)
+	}
+
 	// Carve up the kube tests into our openshift suites...
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
@@ -81,13 +87,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	// Initialization for kube ginkgo test framework needs to run before all tests execute
-	specs.AddBeforeAll(func() {
-		if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
-			panic(err)
-		}
-	})
 
 	// Annotations get appended to test names, these are additions to upstream
 	// tests for controlling skips, suite membership, etc.


### PR DESCRIPTION
testContext must be populated before *enumerating* e2e tests, it's too late to populate it before *running* them.

At least upstream `e2e.test` does so and my Kubernets 1.33 test (= future 4.20) counts with that. It uses the [`TestContext.NodeOSDistro`](https://github.com/kubernetes/kubernetes/blob/b363f196c517c8e069e2b91995accf3afd389bb9/test/e2e/storage/csimock/csi_selinux_mount.go#L932C50-L932C74) in `ginkgo.Context()` [here](https://github.com/kubernetes/kubernetes/blob/b363f196c517c8e069e2b91995accf3afd389bb9/test/e2e/storage/csimock/csi_selinux_mount.go#L91).

`k8s-tests` already did this, just `k8s-tests-ext` is different now.

Improve overall error handling in k8s-test-ext:

* remove `panic()` and print some context around the errors.
* print a specific error on empty KUBECONFIG / KUBERNETES_MASTER


Examples:

* empty KUBECONFIG:
    ` F0303 18:45:40.863889 3264068 k8s-tests.go:63] Failed to initialize Kubernetes client. Is KUBECONFIG set? Full error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable`

* KUBECONFIG pointing to a missing file:
    `F0303 18:47:24.093819 3264652 k8s-tests.go:65] Failed to initialize test framework: stat /home/jsafrane/some/non-existing/file: no such file or directory`