### PR TITLE
OCPBUGS-52477: Revert #2229: Initialize testContext before enumerating tests

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -18,10 +18,8 @@ import (
 	v "github.com/openshift-eng/openshift-tests-extension/pkg/version"
 
 	"k8s.io/client-go/pkg/version"
-	"k8s.io/client-go/tools/clientcmd"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/openshift-hack/e2e/annotate/generated"
 	"k8s.io/kubernetes/test/utils/image"
 
@@ -51,18 +49,10 @@ func main() {
 	kubeTestsExtension := e.NewExtension("openshift", "payload", "hyperkube")
 	extensionRegistry.Register(kubeTestsExtension)
 
-	providerJSON := os.Getenv("TEST_PROVIDER")
-	if providerJSON == "" {
-		klog.Fatal("TEST_PROVIDER must be set (example: export TEST_PROVIDER='{\"type\":\"local\"}')")
-	}
-
 	// Initialization for kube ginkgo test framework needs to run before all tests are discovered.
 	// Some tests use the testContext to generate e2e tests.
-	if err := initializeTestFramework(providerJSON); err != nil {
-		if clientcmd.IsEmptyConfig(err) {
-			klog.Fatalf("Failed to initialize Kubernetes client. Is KUBECONFIG set? Full error: %v", err)
-		}
-		klog.Fatalf("Failed to initialize test framework: %v", err)
+	if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
+		panic(err)
 	}
 
 	// Carve up the kube tests into our openshift suites...
@@ -95,7 +85,7 @@ func main() {
 	// Build our specs from ginkgo
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
-		klog.Fatalf("Failed to build test specs: %v", err)
+		panic(err)
 	}
 
 	// Annotations get appended to test names, these are additions to upstream

--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -49,12 +49,6 @@ func main() {
 	kubeTestsExtension := e.NewExtension("openshift", "payload", "hyperkube")
 	extensionRegistry.Register(kubeTestsExtension)
 
-	// Initialization for kube ginkgo test framework needs to run before all tests are discovered.
-	// Some tests use the testContext to generate e2e tests.
-	if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
-		panic(err)
-	}
-
 	// Carve up the kube tests into our openshift suites...
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
@@ -87,6 +81,13 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Initialization for kube ginkgo test framework needs to run before all tests execute
+	specs.AddBeforeAll(func() {
+		if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
+			panic(err)
+		}
+	})
 
 	// Annotations get appended to test names, these are additions to upstream
 	// tests for controlling skips, suite membership, etc.


### PR DESCRIPTION
Reverting https://github.com/openshift/kubernetes/pull/2229, it breaks nightlies. See the linked Jira for details.