### PR TITLE
[release-4.15] OCPBUGS-53139: UPSTREAM: 129180: prevent unnecessary resolving of iscsi/fc devices to dm

### DIFF
--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -31,8 +31,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent
+// FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent. If called with a device
+// already resolved to devicemapper, do nothing.
 func (handler *deviceHandler) FindMultipathDeviceForDevice(device string) string {
+	if strings.HasPrefix(device, "/dev/dm-") {
+		return device
+	}
+
 	io := handler.getIo
 	disk, err := findDeviceForPath(device, io)
 	if err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
@@ -331,7 +331,10 @@ func TestFindSANameForDisk(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Skipping this test due to failing ci but not removing to keep for future reference if needed
+// GH Issue: https://github.com/kubernetes/kubernetes/issues/129007
 func TestCreateBlobDisk(t *testing.T) {
+	t.Skip("skipping test due some Azure API changes and failing ci")
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	b := GetTestBlobDiskController(t)


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/kubernetes/pull/2171