### PR TITLE
Fix KUBE_BUILD_IMAGE_CROSS_TAG mismatch when KUBE_CROSS_VERSION is passed

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -39,7 +39,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Constants
 readonly KUBE_BUILD_IMAGE_REPO=kube-build
-KUBE_BUILD_IMAGE_CROSS_TAG="$(cat "${KUBE_ROOT}/build/build-image/cross/VERSION")"
+KUBE_BUILD_IMAGE_CROSS_TAG="${KUBE_CROSS_VERSION:-"$(cat "${KUBE_ROOT}/build/build-image/cross/VERSION")"}"
 readonly KUBE_BUILD_IMAGE_CROSS_TAG
 
 readonly KUBE_DOCKER_REGISTRY="${KUBE_DOCKER_REGISTRY:-registry.k8s.io}"


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `kube-build` image which has `kube-cross` as base image has a version mismatch when `KUBE_CROSS_VERSION` value is passed while building binaries.

For example:
```
[root@raji-x86-workspace1 kubernetes]#  make quick-release KUBE_CROSS_VERSION=v1.32.0-go1.23.6-bullseye.0
+++ [0313 08:15:47] Verifying Prerequisites....
+++ [0313 08:15:48] Building Docker image kube-build:build-c08a296a0e-5-v1.33.0-go1.24.0-bullseye.0
+++ [0313 08:17:39] Creating data container kube-build-data-c08a296a0e-5-v1.33.0-go1.24.0-bullseye.0
+++ [0313 08:17:39] Syncing sources to container
+++ [0313 08:17:57] Running build command...
go: downloading go1.24.0 (linux/amd64)
+++ [0313 08:18:35] Building go targets for linux/amd64
    k8s.io/apiextensions-apiserver (static)
    k8s.io/component-base/logs/kube-log-runner (static)
    k8s.io/kube-aggregator (static)
    k8s.io/kubernetes/cluster/gce/gci/mounter (static)
    k8s.io/kubernetes/cmd/kube-apiserver (static)
    k8s.io/kubernetes/cmd/kube-controller-manager (static)
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kube-scheduler (static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
+++ [0313 08:22:08] Building go targets for linux/amd64
    k8s.io/component-base/logs/kube-log-runner (static)
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
+++ [0313 08:22:41] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kubectl (static)
    k8s.io/kubernetes/cmd/kubectl-convert (static)
+++ [0313 08:23:06] Building go targets for linux/amd64
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
    k8s.io/kubernetes/test/conformance/image/go-runner (non-static)
    k8s.io/kubernetes/test/e2e/e2e.test (test)

[root@raji-x86-workspace1 kubernetes]# 
```
In the above trace, though the `KUBE_CROSS_VERSION` version passed is `v1.32.0-go1.23.6-bullseye.0`, in the trace we see `Building Docker image kube-build:build-c08a296a0e-5-v1.33.0-go1.24.0-bullseye.0`.
The kube-build image actually has `GOLANG_VERSION` is `1.23.6` with a misleading tag that says go1.24.
```
[root@raji-x86-workspace1 kubernetes]# docker image inspect kube-build:build-c08a296a0e-5-v1.33.0-go1.24.0-bullseye.0 | grep GOLANG
                "GOLANG_VERSION=1.23.6",
[root@raji-x86-workspace1 kubernetes]#
```

This is because the `kube-build` image tag is harcorded [here](https://github.com/kubernetes/kubernetes/blob/master/build/common.sh#L42) to pickup value from this [file](https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION), inspite of there being an option to PASS `KUBE_CROSS_VERSION`.

This change would make `kube-build` image tag same as `kube-cross` image tag if passed.