### PR TITLE
STOR-2285: Update group snapshot test rules

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -26,7 +26,6 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			"[Feature:RelaxedDNSSearchValidation]",
 			"[Feature:PodLogsQuerySplitStreams]",
 			"[Feature:PodLifecycleSleepActionAllowZero]",
-			"[Feature:volumegroupsnapshot]",
 			"[Feature:OrderedNamespaceDeletion]", // disabled Beta
 		},
 		// tests for features that are not implemented in openshift
@@ -68,6 +67,11 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			// host. Enabling the test would result in the  bastion being created for every parallel test execution.
 			// Given that we have existing oc and WMCO tests that cover this functionality, we can safely disable it.
 			"[Feature:NodeLogQuery]",
+
+			// volumegroupsnapshot in csi-hostpath tests requires changes in the test yaml files,
+			// which are done by a script upstream. In OCP, we added a separate driver csi-hostpath-groupsnapshot,
+			// that will not be skipped by any rule here.
+			"[Driver: csi-hostpath] [Testpattern:  (delete policy)] volumegroupsnapshottable [Feature:volumegroupsnapshot]",
 		},
 		// tests that are known broken and need to be fixed upstream or in openshift
 		// always add an issue here


### PR DESCRIPTION
Update group snapshot test rules to be in sync with openshift-hack/e2e/annotate.
    
We want group snapshot tests disabled only with csi-hostpath test driver. That one needs a special config - a change in the csi-hostpath CSI driver yaml files + a feature gate enabled.
    
The others (namely csi-hostpath-groupsnapshot) should be enabled. That one has the yaml file change + `[OCPFeatureGate:VolumeGroupSnapshot]`.

With this PR, I can see:

```
./k8s-tests-ext list | grep "csi-hostpath.*Feature:volumegroupsnapshot"
    "name": "[sig-storage] OCP CSI Volumes [Driver: csi-hostpath-groupsnapshot] [OCPFeatureGate:VolumeGroupSnapshot] [Testpattern:  (delete policy)] volumegroupsnapshottable [Feature:volumegroupsnapshot] VolumeGroupSnapshottable should create snapshots for multiple volumes in a pod [Suite:openshift/conformance/parallel] [Suite:k8s]",
```

Which is what I want. Before this PR, the command returns empty output and no group snapshots are tested.