### PR TITLE
TRT-1854: fix OVNKubernetes network skips

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -17,6 +17,10 @@ func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
 		et.NameContainsAll("[sig-network] LoadBalancers [Feature:LoadBalancer]", "UDP"),
 		et.NameContainsAll("[sig-network] LoadBalancers [Feature:LoadBalancer]", "session affinity"),
 	}).Exclude(et.PlatformEquals("aws"))
+
+	specs.SelectAny([]et.SelectFunction{ // Since these must use "NameContainsAll" they cannot be included in filterByNetwork
+		et.NameContainsAll("NetworkPolicy", "named port"),
+	}).Exclude(et.NetworkEquals("OVNKubernetes"))
 }
 
 // filterByPlatform is a helper function to do, simple, "NameContains" filtering on tests by platform
@@ -213,12 +217,7 @@ func filterByNoOptionalCapabilities(specs et.ExtensionTestSpecs) {
 
 // filterByNetwork is a helper function to do, simple, "NameContains" filtering on tests by network
 func filterByNetwork(specs et.ExtensionTestSpecs) {
-	var networkExclusions = map[string][]string{
-		"OVNKubernetes": {
-			"NetworkPolicy",
-			"named port",
-		},
-	}
+	var networkExclusions = map[string][]string{}
 
 	for network, exclusions := range networkExclusions {
 		var selectFunctions []et.SelectFunction


### PR DESCRIPTION
This was originally improperly translated from the entry in rules.go:
https://github.com/openshift/kubernetes/blob/d365efdad4f566821463becaf0d5551a1a5c322f/openshift-hack/e2e/annotate/rules.go#L393-L397

This resulted in ~33 specs being skipped for OVNKubernetes that should not be