### PR TITLE
OCPBUGS-54339: UPSTREAM: 129808: e2e: bump port-forward timeout

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -637,7 +637,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 
 			ginkgo.By("Send a http request to verify port-forward working")
 			client := http.Client{
-				Timeout: 10 * time.Second,
+				Timeout: 15 * time.Second,
 			}
 			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
 			framework.ExpectNoError(err, "couldn't get http response from port-forward")


### PR DESCRIPTION
This test is a new test in upstream Kubernetes added in 1.32 (OCP 4.19) and it is marked as flaky also in upstream. 

There is a PR in upstream to mitigate the flakiness by increasing the timeout value from 10 seconds to 15 seconds which has landed on 1.33 but not backported to 1.32. This still does not guarantee fixing the failure because there are many type of cluster that may suffer from some latencies (as we experienced now temporarily in metal clusters). However, carrying the new timeout value in downstream would help us.