### PR TITLE
OCPBUGS-54426: Fix implementation of ContainsCIDR to allow non-equal addresses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -231,8 +231,7 @@ func cidrContainsCIDR(arg ref.Val, other ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 
-	equalMasked := cidr.Prefix.Masked() == netip.PrefixFrom(containsCIDR.Prefix.Addr(), cidr.Prefix.Bits())
-	return types.Bool(equalMasked && cidr.Prefix.Bits() <= containsCIDR.Prefix.Bits())
+	return types.Bool(cidr.Overlaps(containsCIDR.Prefix) && cidr.Prefix.Bits() <= containsCIDR.Prefix.Bits())
 }
 
 func prefixLength(arg ref.Val) ref.Val {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
@@ -152,8 +152,18 @@ func TestCIDR(t *testing.T) {
 			expectResult: trueVal,
 		},
 		{
+			name:         "contains CIDR ipv4 (CIDR) (/32)",
+			expr:         `cidr("192.168.0.0/24").containsCIDR(cidr("192.168.0.1/32"))`,
+			expectResult: trueVal,
+		},
+		{
 			name:         "does not contain IP ipv4 (CIDR)",
 			expr:         `cidr("192.168.0.0/24").containsCIDR(cidr("192.168.0.0/23"))`,
+			expectResult: falseVal,
+		},
+		{
+			name:         "does not contain IP ipv4 (CIDR) (/32)",
+			expr:         `cidr("192.168.0.0/24").containsCIDR(cidr("192.169.0.1/32"))`,
 			expectResult: falseVal,
 		},
 		{


### PR DESCRIPTION
This has already merged into the main and 1.33 branch of K/K, but we are waiting on cherry-pick approval for the 1.32 branch.

This updates the implementation of the CEL CIDR matching check which was rejecting some valid values.
