### PR TITLE
OCPBUGS-55335: apiserver: remove the requirement for LoopbackClientConfig

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -829,9 +829,6 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 			return nil, fmt.Errorf("refusing to create new apiserver %q with support for media type %q (allowed media types are: %s)", name, info.MediaType, strings.Join(allowedMediaTypes, ", "))
 		}
 	}
-	if c.LoopbackClientConfig == nil {
-		return nil, fmt.Errorf("Genericapiserver.New() called with config.LoopbackClientConfig == nil")
-	}
 	if c.EquivalentResourceRegistry == nil {
 		return nil, fmt.Errorf("Genericapiserver.New() called with config.EquivalentResourceRegistry == nil")
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

This setting is verifying that apiserver always have a config to connect to itself via loopback connection. This config includes a certificate key pair generated on the fly and stored in memory.

This function is also used by library-go to create any controller (i.e. operator). The controllers don't need loopback connections to function, so it generates certificate keypairs and doesn't use them.

Removing the requirement for LoopbackClientConfig won't affect how apiservers functions (all of them have it created and that doesn't change) and it allows library-go controllers to avoid creating in-memory certificate keypair not included in TLS registry

