### PR TITLE
OCPBUGS-54318: UPSTREAM: 131236: RWX tests should create RWX volumes

### DIFF
--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -466,7 +466,14 @@ func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, p
 
 		// Create volume
 		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
-		resource := storageframework.CreateVolumeResource(ctx, l.driver, l.config, pattern, testVolumeSizeRange)
+		resource := storageframework.CreateVolumeResourceWithAccessModes(
+			ctx,
+			l.driver,
+			l.config,
+			pattern,
+			testVolumeSizeRange,
+			[]v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			nil /* vacName */)
 		l.resources = append(l.resources, resource)
 
 		// Test access to the volume from pods on different node


### PR DESCRIPTION
The test that checks that a volume can be accessed from multiple nodes should create ReadWriteMany volume and not ReadWriteOnce.

cc @openshift/storage 