### PR TITLE
No-JIRA: Fix conditional labels when in different folder structure than expected

### DIFF
--- a/openshift-hack/e2e/annotate/annotate.go
+++ b/openshift-hack/e2e/annotate/annotate.go
@@ -231,26 +231,12 @@ func (r *ginkgoTestRenamer) generateRename(name string, node types.TestSpec) {
 			newLabels += " [Suite:openshift/conformance/parallel]"
 		}
 	}
-	codeLocations := node.CodeLocations()
-	if isGoModulePath(codeLocations[len(codeLocations)-1].FileName, "k8s.io/kubernetes", "test/e2e") {
-		newLabels += " [Suite:k8s]"
-	}
+	newLabels += " [Suite:k8s]"
 
 	if err := checkBalancedBrackets(newName); err != nil {
 		r.errors = append(r.errors, err.Error())
 	}
 	r.output[name] = newLabels
-}
-
-// isGoModulePath returns true if the packagePath reported by reflection is within a
-// module and given module path. When go mod is in use, module and modulePath are not
-// contiguous as they were in older golang versions with vendoring, so naive contains
-// tests fail.
-//
-// historically: ".../vendor/k8s.io/kubernetes/test/e2e"
-// go.mod:       "k8s.io/kubernetes@0.18.4/test/e2e"
-func isGoModulePath(packagePath, module, modulePath string) bool {
-	return regexp.MustCompile(fmt.Sprintf(`\b%s(@[^/]*|)/%s\b`, regexp.QuoteMeta(module), regexp.QuoteMeta(modulePath))).MatchString(packagePath)
 }
 
 // checkBalancedBrackets ensures that square brackets are balanced in generated test


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fix conditional labels when in a different folder structure than expected.

I have my Kubernetes repo in the path `openshift/kubernetes`. When using `openshift-hack/update-test-annotations.sh` this would regenerate all of the test labels without the `[Suite:k8s.io]`. This is because the code expects it to be on the path `k8s.io/kubernetes` but because it is not, it thinks there are no kubernetes suite tests. We have only kubernetes tests here. I believe we can just omit the part where we add the label on condition. If this proves to be a problem, we should think of a different solution than expecting an absolute path that is not the repository name.

This was half day work trying to figure out why it worked in a container and not on the host (because I chose the `registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19` it was indistinguishable). But this will be a problem for all other environments and containers. 

Heads up to @jsafrane for helping me with this.

cc @bertinatto
Might know more where else this is used? And if it breaks anything else. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
