### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Mark admissionregistration.k8s.io/v1beta1 as deprecated.

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
@@ -9,6 +9,12 @@ import (
 var DeprecatedAPIRemovedRelease = map[schema.GroupVersionResource]uint{
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}:                 32,
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}: 32,
+
+	// 4.17 shipped with admissionregistration.k8s.io/v1beta1 served under the default featureset.
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}:   33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:     33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicies"}:       33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicybindings"}: 33,
 }
 
 // removedRelease of a specified resource.version.group.


### PR DESCRIPTION
We inadvertently began serving these in the default feature set beginning with 4.17.0. We intend to stop serving them in 4.20.0 and to treat this as a typical deprecated API removal.
