### PR TITLE
OCPBUGS-55631: UPSTREAM: 131495: Handle unsupported node expansion for RWX volumes

### DIFF
--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -140,6 +140,18 @@ func TestNodeExpander(t *testing.T) {
 			expectedStatusSize:       resource.MustParse("2G"),
 		},
 		{
+			name:                          "RWX pv.spec.cap = pvc.status.cap, resizeStatus='', desiredSize > actualSize, reize_op=unsupported",
+			pvc:                           addAccessMode(getTestPVC(volumetesting.FailWithUnSupportedVolumeName, "2G", "2G", "2G", nil), v1.ReadWriteMany),
+			pv:                            getTestPV(volumetesting.FailWithUnSupportedVolumeName, "2G"),
+			recoverVolumeExpansionFailure: true,
+			expectError:                   false,
+			expectedResizeStatus:          "",
+			expectResizeCall:              false,
+			assumeResizeOpAsFinished:      true,
+			expectFinalErrors:             false,
+			expectedStatusSize:            resource.MustParse("2G"),
+		},
+		{
 			name:                          "pv.spec.cap > pvc.status.cap, resizeStatus=node_expansion_pending, featuregate=disabled",
 			pvc:                           getTestPVC("test-vol0", "2G", "1G", "2G", &nodeResizePending),
 			pv:                            getTestPV("test-vol0", "2G"),


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-55631