### PR TITLE
TRT-2103: Revert "NO-JIRA: UPSTREAM: <carry>: Mark admissionregistration.k8s.io/v1beta1 as deprecated."

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
@@ -9,12 +9,6 @@ import (
 var DeprecatedAPIRemovedRelease = map[schema.GroupVersionResource]uint{
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}:                 32,
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}: 32,
-
-	// 4.17 shipped with admissionregistration.k8s.io/v1beta1 served under the default featureset.
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}:   33,
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:     33,
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicies"}:       33,
-	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicybindings"}: 33,
 }
 
 // removedRelease of a specified resource.version.group.


### PR DESCRIPTION
Reverts openshift/kubernetes#2287 tracked by [TRT-2103](https://issues.redhat.com/browse/TRT-2103)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

4.20 nightly techpriew serial job failing with test:

[sig-arch][Late] clients should not use APIs that are removed in upcoming releases [apigroup:apiserver.openshift.io] [Suite:openshift/conformance/parallel]
{  fail [github.com/openshift/origin/test/extended/apiserver/api_requests.go:129]: user/system:serviceaccount:openshift-cluster-api:cluster-capi-operator accessed validatingadmissionpolicies.v1beta1.admissionregistration.k8s.io 2418 times
user/system:serviceaccount:openshift-cluster-api:cluster-capi-operator accessed validatingadmissionpolicybindings.v1beta1.admissionregistration.k8s.io 2418 times
Ginkgo exit error 1: exit with code 1}

Example job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-aws-ovn-techpreview/1920414382672580608

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

/payload-job periodic-ci-openshift-release-master-ci-4.20-e2e-aws-ovn-techpreview


CC: @benluddy @JoelSpeed 