### PR TITLE
OCPBUGS-55944: UPSTREAM: <carry>: unrevert: Mark admissionregistration.k8s.io/v1beta1 as deprecated.

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
@@ -9,6 +9,12 @@ import (
 var DeprecatedAPIRemovedRelease = map[schema.GroupVersionResource]uint{
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}:                 32,
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}: 32,
+
+	// 4.17 shipped with admissionregistration.k8s.io/v1beta1 served under the default featureset.
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}:   33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:     33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicies"}:       33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicybindings"}: 33,
 }
 
 // removedRelease of a specified resource.version.group.


### PR DESCRIPTION
This reverts commit 24bf6d5c82350ad98b9ebd61f392b35474d24630.
