### PR TITLE
UPSTREAM: <carry>: Initialize testContext before generating ginkgo tests

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -39,6 +39,10 @@ func main() {
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
 
+	if err := initializeCommonTestFramework(); err != nil {
+		panic(err)
+	}
+
 	// Get version info from kube
 	kubeVersion := version.Get()
 	v.GitTreeState = kubeVersion.GitTreeState
@@ -85,7 +89,7 @@ func main() {
 
 	// Initialization for kube ginkgo test framework needs to run before all tests execute
 	specs.AddBeforeAll(func() {
-		if err := initializeTestFramework(os.Getenv("TEST_PROVIDER")); err != nil {
+		if err := updateTestFrameworkForTests(os.Getenv("TEST_PROVIDER")); err != nil {
 			panic(err)
 		}
 	})

--- a/openshift-hack/cmd/k8s-tests-ext/provider.go
+++ b/openshift-hack/cmd/k8s-tests-ext/provider.go
@@ -40,16 +40,6 @@ func initializeCommonTestFramework() error {
 	testContext.MaxNodesToGather = 0
 	testContext.KubeConfig = os.Getenv("KUBECONFIG")
 
-	// allow the CSI tests to access test data, but only briefly
-	// TODO: ideally CSI would not use any of these test methods
-	// var err error
-	// exutil.WithCleanup(func() { err = initCSITests(dryRun) })
-	// TODO: for now I'm only initializing CSI directly, but we probably need that
-	// WithCleanup here as well
-	if err := initCSITests(); err != nil {
-		return err
-	}
-
 	if ad := os.Getenv("ARTIFACT_DIR"); len(strings.TrimSpace(ad)) == 0 {
 		os.Setenv("ARTIFACT_DIR", filepath.Join(os.TempDir(), "artifacts"))
 	}
@@ -125,6 +115,16 @@ func updateTestFrameworkForTests(provider string) error {
 	framework.AfterReadingAllFlags(testContext)
 	testContext.DumpLogsOnFailure = true
 	testContext.ReportDir = os.Getenv("TEST_JUNIT_DIR")
+
+	// allow the CSI tests to access test data, but only briefly
+	// TODO: ideally CSI would not use any of these test methods
+	// var err error
+	// exutil.WithCleanup(func() { err = initCSITests(dryRun) })
+	// TODO: for now I'm only initializing CSI directly, but we probably need that
+	// WithCleanup here as well
+	if err := initCSITests(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
SELinux tests require testContext to be initialized before ginkgo discovers their closures (i.e. before `kubeTestsExtension.AddSuite()` is called).

Split the testContext initialization in two parts:

`initializeCommonTestFramework()` files the fields that are either static or can be discovered easily and are needed to generate the tests by ginkgo.

`updateTestFrameworkForTests()` files the rest, mostly from the cloud provider env. var. and adds fields necessary to actually run the tests.
