### PR TITLE
UPSTREAM: <carry>: support feature gate filtering from upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/runc v1.2.1
 	github.com/opencontainers/selinux v1.11.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c
 	github.com/openshift/api v0.0.0-20250129162653-107848b719c5
 	github.com/openshift/apiserver-library-go v0.0.0-20250127121756-dc9a973f14ce
 	github.com/openshift/client-go v0.0.0-20250125113824-8e1f0b8fa9a7

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45 h1:hXpbYtP3iTh8oy/RKwKkcMziwchY3fIk95ciczf7cOA=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c h1:R5dI2oOF2RtS1sKtLrhW9KMg0ydzF0XM2Q//ma55nWI=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20250129162653-107848b719c5 h1:PzJJmofv/P9R1JUxO8X6tAMxKACVS6Quxo/xBzMkSmI=
 github.com/openshift/api v0.0.0-20250129162653-107848b719c5/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/apiserver-library-go v0.0.0-20250502092109-8d341e94467d h1:M/oS6u+K6AYb2pkQJWsnwfts8R85sPJDbB0wgv7KKKo=

--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -18,7 +18,6 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			"[Feature:UserNamespacesPodSecurityStandards]",
 			"[Feature:UserNamespacesSupport]", // disabled Beta
 			"[Feature:DynamicResourceAllocation]",
-			"[Feature:VolumeAttributesClass]", // disabled Beta
 			"[sig-cli] Kubectl client Kubectl prune with applyset should apply and prune objects", // Alpha feature since k8s 1.27
 			// 4.19
 			"[Feature:PodLevelResources]",

--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -14,6 +14,7 @@ func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
 	filterByTopology(specs)
 	filterByNoOptionalCapabilities(specs)
 	filterByNetwork(specs)
+	filterByFeatureGate(specs)
 
 	// LoadBalancer tests in 1.31 require explicit platform-specific skips
 	// https://issues.redhat.com/browse/OCPBUGS-38840
@@ -245,5 +246,16 @@ func filterByNetwork(specs et.ExtensionTestSpecs) {
 		specs.SelectAny(selectFunctions).
 			Exclude(et.NetworkEquals(network)).
 			AddLabel(fmt.Sprintf("[Skipped:%s]", network))
+	}
+}
+
+// filterByFeatureGate is a helper to exclude tests that only work when a particular feature gate is enabled
+func filterByFeatureGate(specs et.ExtensionTestSpecs) {
+	techPreviewFeatureGates := []string{
+		"VolumeAttributesClass", // Kubernetes beta, disabled by default
+	}
+
+	for _, featureGate := range techPreviewFeatureGates {
+		specs.Select(et.NameContains("[FeatureGate:" + featureGate)).Include(et.FeatureGateEnabled(featureGate))
 	}
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runsuite.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runsuite.go
@@ -24,8 +24,9 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:          "run-suite NAME",
-		Short:        "Run a group of tests by suite",
+		Use: "run-suite NAME",
+		Short: "Run a group of tests by suite. This is more limited than origin, and intended for light local " +
+			"development use. Orchestration parameters, scheduling, isolation, etc are not obeyed, and Ginkgo tests are executed serially.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ext := registry.Get(opts.componentFlags.Component)

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
@@ -29,6 +29,22 @@ func ArchitectureEquals(arch string) string {
 	return fmt.Sprintf(`architecture=="%s"`, arch)
 }
 
+func APIGroupEnabled(apiGroup string) string {
+	return fmt.Sprintf(`apiGroups.exists(api, api=="%s")`, apiGroup)
+}
+
+func APIGroupDisabled(apiGroup string) string {
+	return fmt.Sprintf(`!apiGroups.exists(api, api=="%s")`, apiGroup)
+}
+
+func FeatureGateEnabled(featureGate string) string {
+	return fmt.Sprintf(`featureGates.exists(fg, fg=="%s")`, featureGate)
+}
+
+func FeatureGateDisabled(featureGate string) string {
+	return fmt.Sprintf(`!featureGates.exists(fg, fg=="%s")`, featureGate)
+}
+
 func ExternalConnectivityEquals(externalConnectivity string) string {
 	return fmt.Sprintf(`externalConnectivity=="%s"`, externalConnectivity)
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
@@ -31,6 +31,9 @@ type ExtensionTestSpec struct {
 	// Source is the origin of the test.
 	Source string `json:"source"`
 
+	// CodeLocations are the files where the spec originates from.
+	CodeLocations []string `json:"codeLocations,omitempty"`
+
 	// Lifecycle informs the executor whether the test is informing only, and should not cause the
 	// overall job run to fail, or if it's blocking where a failure of the test is fatal.
 	// Informing lifecycle tests can be used temporarily to gather information about a test's stability.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -1,11 +1,13 @@
 package extension
 
 import (
+	"time"
+
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 )
 
-const CurrentExtensionAPIVersion = "v1.0"
+const CurrentExtensionAPIVersion = "v1.1"
 
 // Extension represents an extension to openshift-tests.
 type Extension struct {
@@ -45,14 +47,40 @@ type Component struct {
 	Name string `json:"name"`
 }
 
-// Suite represents additional suites the extension wants to advertise.
+type ClusterStability string
+
+var (
+	// ClusterStabilityStable means that at no point during testing do we expect a component to take downtime and upgrades are not happening.
+	ClusterStabilityStable ClusterStability = "Stable"
+
+	// ClusterStabilityDisruptive means that the suite is expected to induce outages to the cluster.
+	ClusterStabilityDisruptive ClusterStability = "Disruptive"
+
+	// ClusterStabilityUpgrade was previously defined, but was removed by @deads2k. Please contact him if you find a use
+	// case for it and needs to be reintroduced.
+	// ClusterStabilityUpgrade    ClusterStability = "Upgrade"
+)
+
+// Suite represents additional suites the extension wants to advertise. Child suites when being executed in the context
+// of a parent will have their count, parallelism, stability, and timeout options superseded by the parent's suite.
 type Suite struct {
-	// The name of the suite.
-	Name string `json:"name"`
-	// Parent suites this suite is part of.
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	// Parents are the parent suites this suite is part of.
 	Parents []string `json:"parents,omitempty"`
 	// Qualifiers are CEL expressions that are OR'd together for test selection that are members of the suite.
 	Qualifiers []string `json:"qualifiers,omitempty"`
+
+	// Count is the default number of times to execute each test in this suite.
+	Count int `json:"count,omitempty"`
+	// Parallelism is the maximum parallelism of this suite.
+	Parallelism int `json:"parallelism,omitempty"`
+	// ClusterStability informs openshift-tests whether this entire test suite is expected to be disruptive or not
+	// to normal cluster operations.
+	ClusterStability ClusterStability `json:"clusterStability,omitempty"`
+	// TestTimeout is the default timeout for tests in this suite.
+	TestTimeout *time.Duration `json:"testTimeout,omitempty"`
 }
 
 type Image struct {

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/environment.go
@@ -7,15 +7,17 @@ import (
 )
 
 type EnvironmentalFlags struct {
-	Platform             string
-	Network              string
-	NetworkStack         string
-	Upgrade              string
-	Topology             string
+	APIGroups            []string
 	Architecture         string
 	ExternalConnectivity string
-	OptionalCapabilities []string
 	Facts                map[string]string
+	FeatureGates         []string
+	Network              string
+	NetworkStack         string
+	OptionalCapabilities []string
+	Platform             string
+	Topology             string
+	Upgrade              string
 	Version              string
 }
 
@@ -24,26 +26,10 @@ func NewEnvironmentalFlags() *EnvironmentalFlags {
 }
 
 func (f *EnvironmentalFlags) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&f.Platform,
-		"platform",
-		"",
-		"The hardware or cloud platform (\"aws\", \"gcp\", \"metal\", ...). Since: v1.0")
-	fs.StringVar(&f.Network,
-		"network",
-		"",
-		"The network of the target cluster (\"ovn\", \"sdn\"). Since: v1.0")
-	fs.StringVar(&f.NetworkStack,
-		"network-stack",
-		"",
-		"The network stack of the target cluster (\"ipv6\", \"ipv4\", \"dual\"). Since: v1.0")
-	fs.StringVar(&f.Upgrade,
-		"upgrade",
-		"",
-		"The upgrade that was performed prior to the test run (\"micro\", \"minor\"). Since: v1.0")
-	fs.StringVar(&f.Topology,
-		"topology",
-		"",
-		"The target cluster topology (\"ha\", \"microshift\", ...). Since: v1.0")
+	fs.StringArrayVar(&f.APIGroups,
+		"api-group",
+		f.APIGroups,
+		"The API groups supported by this cluster. Since: v1.1")
 	fs.StringVar(&f.Architecture,
 		"architecture",
 		"",
@@ -52,14 +38,38 @@ func (f *EnvironmentalFlags) BindFlags(fs *pflag.FlagSet) {
 		"external-connectivity",
 		"",
 		"The External Connectivity of the target cluster (\"Disconnected\", \"Direct\", \"Proxied\"). Since: v1.0")
-	fs.StringSliceVar(&f.OptionalCapabilities,
-		"optional-capability",
-		[]string{},
-		"An Optional Capability of the target cluster. Can be passed multiple times. Since: v1.0")
+	fs.StringArrayVar(&f.FeatureGates,
+		"feature-gate",
+		f.FeatureGates,
+		"The feature gates enabled on this cluster. Since: v1.1")
 	fs.StringToStringVar(&f.Facts,
 		"fact",
 		make(map[string]string),
 		"Facts advertised by cluster components. Since: v1.0")
+	fs.StringVar(&f.Network,
+		"network",
+		"",
+		"The network of the target cluster (\"ovn\", \"sdn\"). Since: v1.0")
+	fs.StringVar(&f.NetworkStack,
+		"network-stack",
+		"",
+		"The network stack of the target cluster (\"ipv6\", \"ipv4\", \"dual\"). Since: v1.0")
+	fs.StringSliceVar(&f.OptionalCapabilities,
+		"optional-capability",
+		[]string{},
+		"An Optional Capability of the target cluster. Can be passed multiple times. Since: v1.0")
+	fs.StringVar(&f.Platform,
+		"platform",
+		"",
+		"The hardware or cloud platform (\"aws\", \"gcp\", \"metal\", ...). Since: v1.0")
+	fs.StringVar(&f.Topology,
+		"topology",
+		"",
+		"The target cluster topology (\"ha\", \"microshift\", ...). Since: v1.0")
+	fs.StringVar(&f.Upgrade,
+		"upgrade",
+		"",
+		"The upgrade that was performed prior to the test run (\"micro\", \"minor\"). Since: v1.0")
 	fs.StringVar(&f.Version,
 		"version",
 		"",
@@ -89,14 +99,16 @@ func (f *EnvironmentalFlags) IsEmpty() bool {
 
 // EnvironmentFlagVersions holds the "Since" version metadata for each flag.
 var EnvironmentFlagVersions = map[string]string{
-	"platform":              "v1.0",
-	"network":               "v1.0",
-	"network-stack":         "v1.0",
-	"upgrade":               "v1.0",
-	"topology":              "v1.0",
+	"api-group":             "v1.1",
 	"architecture":          "v1.0",
 	"external-connectivity": "v1.0",
-	"optional-capability":   "v1.0",
 	"fact":                  "v1.0",
+	"feature-gate":          "v1.1",
+	"network":               "v1.0",
+	"network-stack":         "v1.0",
+	"optional-capability":   "v1.0",
+	"platform":              "v1.0",
+	"topology":              "v1.0",
+	"upgrade":               "v1.0",
 	"version":               "v1.0",
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
@@ -10,8 +10,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
-	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 	"github.com/pkg/errors"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 
 	ext "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 )
@@ -40,8 +41,12 @@ func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
 	return &suiteConfig, &reporterConfig, nil
 }
 
-func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, error) {
-	var tests []*ext.ExtensionTestSpec
+// BuildExtensionTestSpecsFromOpenShiftGinkgoSuite generates OTE specs for Gingko tests. While OTE isn't limited to
+// calling ginkgo tests, anything that implements the ExtensionTestSpec interface can be used, it's the most common
+// course of action.  The typical use case is to omit selectFns, but if provided, these will filter the returned list
+// of specs, applied in the order provided.
+func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunction) (ext.ExtensionTestSpecs, error) {
+	var specs ext.ExtensionTestSpecs
 	var enforceSerialExecutionForGinkgo sync.Mutex // in-process parallelization for ginkgo is impossible so far
 
 	if _, _, err := configureGinkgo(); err != nil {
@@ -54,10 +59,16 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, 
 	}
 
 	ginkgo.GetSuite().WalkTests(func(name string, spec types.TestSpec) {
+		var codeLocations []string
+		for _, cl := range spec.CodeLocations() {
+			codeLocations = append(codeLocations, cl.String())
+		}
+
 		testCase := &ext.ExtensionTestSpec{
-			Name:      spec.Text(),
-			Labels:    sets.New[string](spec.Labels()...),
-			Lifecycle: GetLifecycle(spec.Labels()),
+			Name:          spec.Text(),
+			Labels:        sets.New[string](spec.Labels()...),
+			CodeLocations: codeLocations,
+			Lifecycle:     GetLifecycle(spec.Labels()),
 			Run: func() *ext.ExtensionTestResult {
 				enforceSerialExecutionForGinkgo.Lock()
 				defer enforceSerialExecutionForGinkgo.Unlock()
@@ -103,10 +114,23 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, 
 				return result
 			},
 		}
-		tests = append(tests, testCase)
+		specs = append(specs, testCase)
 	})
 
-	return tests, nil
+	// Default select function is to exclude vendored specs.  When relying on Kubernetes test framework for its helpers,
+	// it also unfortunately ends up importing *all* Gingko specs.  This is unsafe: it would potentially override the
+	// kube specs already present in origin.  The best course of action is enforce this behavior on everyone.  If for
+	// some reason, you must include vendored specs, you can opt-in directly by supplying your own SelectFunctions or using
+	// AllTestsIncludedVendored().
+	if len(selectFns) == 0 {
+		selectFns = []ext.SelectFunction{ext.ModuleTestsOnly()}
+	}
+
+	for _, selectFn := range selectFns {
+		specs = specs.Select(selectFn)
+	}
+
+	return specs, nil
 }
 
 func Informing() ginkgo.Labels {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c
 ## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages


### PR DESCRIPTION
When considering upstream feature gates, not all are known or present in
openshift/api, so we have to be selective about which we filter on.

This uses data provided by OTE and an allow list to include/exclude
upstream tests.

$ k8s-tests-ext list tests --platform aws --feature-gate VolumeAttributesClass |\
  jq '.[].name' | grep VolumeAttributesClass | wc -l
30
$ k8s-tests-ext list tests --platform aws |\
  jq '.[].name' | grep VolumeAttributesClass | wc -l
       0