### PR TITLE
NOJIRA: Update rebase.sh to handle go versions major.minor.patch

### DIFF
--- a/openshift-hack/rebase.sh
+++ b/openshift-hack/rebase.sh
@@ -126,7 +126,7 @@ fi
 # openshift-hack/images/hyperkube/Dockerfile.rhel still has FROM pointing to old tag
 # we need to remove the prefix "v" from the $k8s_tag to stay compatible
 sed -i -E "s/(io.openshift.build.versions=\"kubernetes=)(1.[1-9]+.[1-9]+)/\1${k8s_tag:1}/" openshift-hack/images/hyperkube/Dockerfile.rhel
-go_mod_go_ver=$(grep -E 'go 1\.[1-9][0-9]?' go.mod | sed -E 's/go (1\.[1-9][0-9]?)/\1/')
+go_mod_go_ver=$(grep -E 'go 1\.[1-9][0-9]?' go.mod | sed -E 's/go (1\.[1-9][0-9]?)/\1/' | cut -d '.' -f 1,2) # Need to handle mod versions like 1.23 and 1.23.4; our release images only have major.minor
 tag="rhel-8-release-golang-${go_mod_go_ver}-openshift-${openshift_release#release-}"
 
 # update openshift go.mod dependencies


### PR DESCRIPTION
The go version in the go.mod file is usually now in the form `major.minor.patch` instead of just `major.minor`. Our openshift images are just `major.minor` which causes the rebase script to fail. This fix correctly strips the patch off of a go version, if it exists in the go mod, so that rebase pulls the right openshift image.