### PR TITLE
STOR-2481: UPSTREAM: <carry>: Skip SELinux test with Feature:SELinuxMountReadWriteteOncePodOnly

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -25,6 +25,12 @@ func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
 	specs.SelectAny([]et.SelectFunction{ // Since these must use "NameContainsAll" they cannot be included in filterByNetwork
 		et.NameContainsAll("NetworkPolicy", "named port"),
 	}).Exclude(et.NetworkEquals("OVNKubernetes")).AddLabel("[Skipped:Network/OVNKubernetes]")
+
+	// SELinux tests marked with [Feature:SELinuxMountReadWriteOncePodOnly] require SELinuxMount
+	// feature gate **disabled**.
+	// TODO(jsafrane): once SELinuxMount graduates to GA, remove the tests upstream + remove this check.
+	specs.Select(et.NameContains("[Feature:SELinuxMountReadWriteOncePodOnly]")).
+		Exclude(et.FeatureGateEnabled("SELinuxMount"))
 }
 
 // filterByPlatform is a helper function to do, simple, "NameContains" filtering on tests by platform


### PR DESCRIPTION
Tests with [Feature:SELinuxMountReadWriteOncePodOnly] must be skipped if SELinuxMount feature gate is set to true. See
https://github.com/kubernetes/kubernetes/blob/1ce98e3c093e6c2eea794737de894394683c9ffb/test/e2e/storage/csimock/csi_selinux_mount.go#L50 for details how the SELinux tests use FeatureGate: / Feature: to test various combinations of the gates.
