### PR TITLE
OCPBUGS-46422: Disable ServiceCIDR tests

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -36,6 +36,7 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			"[Feature:KubeProxyDaemonSetMigration]",    // upgrades are run separately
 			"[Feature:BoundServiceAccountTokenVolume]", // upgrades are run separately
 			"[Feature:StatefulUpgrade]",                // upgrades are run separately
+			"Service CIDRs",                            // requires extra support from some components
 		},
 		// tests that rely on special configuration that we do not yet support
 		"SpecialConfig": {


### PR DESCRIPTION
The ServiceCIDR feature, enabled by default in 1.33, does not work in OpenShift. (It requires support from any component that cares if the cluster service CIDRs change.) We're blocking use of it via a VAP (https://github.com/openshift/cluster-network-operator/pull/2605) but will need to also skip the tests for it.

It seems like the test skip stuff has changed since the last time I used it and I'm not sure if this fix is correct...