### PR TITLE
TRT-2068: Skip specific LoadBalancer test for "none" platform

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -123,6 +123,12 @@ func filterByPlatform(specs et.ExtensionTestSpecs) {
 			// https://issues.redhat.com/browse/OCPBUGS-53249
 			"[sig-network] LoadBalancers [Feature:LoadBalancer] should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on",
 		},
+		// MicroShift identifies itself as "none"
+		"none": {
+			// LoadBalancer tests in 1.31 require explicit platform-specific skips
+			// https://issues.redhat.com/browse/OCPBUGS-53249
+			"[sig-network] LoadBalancers [Feature:LoadBalancer] should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on",
+		},
 	}
 
 	for platform, exclusions := range platformExclusions {


### PR DESCRIPTION
This was done in https://github.com/openshift/kubernetes/pull/2247, but only using the `external` platform. I am not entirely sure if that is still necessary, but it is safer to also add this for the `none` platform as that is what MicroShift reports itself as. This is the only test that is failing in the microshift job [run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-microshift-release-4.20-periodics-e2e-aws-ovn-ocp-conformance/1950472063017816064), after merging https://github.com/openshift/kubernetes/pull/2331