### PR TITLE
STOR-2481: UPSTREAM: <carry>: Skip SELinux test with Feature:SELinuxMountReadWriteteOncePodOnly

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // addEnvironmentSelectors adds the environmentSelector field to appropriate specs to facilitate including or excluding
@@ -28,9 +29,10 @@ func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
 
 	// SELinux tests marked with [Feature:SELinuxMountReadWriteOncePodOnly] require SELinuxMount
 	// feature gate **disabled**.
-	// TODO(jsafrane): once SELinuxMount graduates to GA, remove the tests upstream + remove this check.
+	// REBASE NOTE: this will intentionally fail to compile when the feature gate is removed upstream.
+	// Just remove this check + notify the OCP storage team.
 	specs.Select(et.NameContains("[Feature:SELinuxMountReadWriteOncePodOnly]")).
-		Exclude(et.FeatureGateEnabled("SELinuxMount"))
+		Exclude(et.FeatureGateEnabled(string(features.SELinuxMount)))
 }
 
 // filterByPlatform is a helper function to do, simple, "NameContains" filtering on tests by platform

--- a/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
+++ b/openshift-hack/cmd/k8s-tests-ext/environment_selectors.go
@@ -25,6 +25,12 @@ func addEnvironmentSelectors(specs et.ExtensionTestSpecs) {
 	specs.SelectAny([]et.SelectFunction{ // Since these must use "NameContainsAll" they cannot be included in filterByNetwork
 		et.NameContainsAll("NetworkPolicy", "named port"),
 	}).Exclude(et.NetworkEquals("OVNKubernetes")).AddLabel("[Skipped:Network/OVNKubernetes]")
+
+	// SELinux tests marked with [Feature:SELinuxMountReadWriteOncePodOnly] require SELinuxMount
+	// feature gate **disabled**.
+	// TODO(jsafrane): once SELinuxMount graduates to GA, remove the tests upstream + remove this check.
+	specs.Select(et.NameContains("[Feature:SELinuxMountReadWriteOncePodOnly]")).
+		Exclude(et.FeatureGateEnabled("SELinuxMount"))
 }
 
 // filterByPlatform is a helper function to do, simple, "NameContains" filtering on tests by platform


### PR DESCRIPTION
Tests with `[Feature:SELinuxMountReadWriteOncePodOnly]` must be skipped if `SELinuxMount` feature gate is set to true. See
https://github.com/kubernetes/kubernetes/blob/1ce98e3c093e6c2eea794737de894394683c9ffb/test/e2e/storage/csimock/csi_selinux_mount.go#L50 for details how the SELinux tests use FeatureGate: / Feature: to test various combinations of the gates.

This is replacement of https://github.com/openshift/kubernetes/pull/2380. Now the code will fail to compile when upstream removes `SELinuxMount` FG. A person doing such a rebase should see a helpful comment + remove the check.