### PR TITLE
OCPBUGS-60047: disable slow and flaky tests rather than labeling them

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -187,6 +187,21 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (immediate binding)] topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies",
 			"[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (immediate binding)] topology should provision a volume and schedule a pod with AllowedTopologies",
 		},
+		// tests too slow to be part of conformance
+		"Slow": {
+			"[sig-scalability]",                            // disable from the default set for now
+			"should create and stop a working application", // Inordinately slow tests
+
+			"[Feature:PerformanceDNS]", // very slow
+
+			"validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", // 5m, really?
+		},
+		// tests that are known flaky
+		"Flaky": {
+			"Job should run a job to completion when tasks sometimes fail and are not locally restarted", // seems flaky, also may require too many resources
+			// TODO(node): test works when run alone, but not in the suite in CI
+			"[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods",
+		},
 	}
 
 	var disabledSpecs et.ExtensionTestSpecs

--- a/openshift-hack/cmd/k8s-tests-ext/labels.go
+++ b/openshift-hack/cmd/k8s-tests-ext/labels.go
@@ -6,21 +6,6 @@ import (
 
 func addLabelsToSpecs(specs et.ExtensionTestSpecs) {
 	var namesByLabel = map[string][]string{
-		// tests too slow to be part of conformance
-		"[Slow]": {
-			"[sig-scalability]",                            // disable from the default set for now
-			"should create and stop a working application", // Inordinately slow tests
-
-			"[Feature:PerformanceDNS]", // very slow
-
-			"validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", // 5m, really?
-		},
-		// tests that are known flaky
-		"[Flaky]": {
-			"Job should run a job to completion when tasks sometimes fail and are not locally restarted", // seems flaky, also may require too many resources
-			// TODO(node): test works when run alone, but not in the suite in CI
-			"[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods",
-		},
 		// tests that must be run without competition
 		"[Serial]": {
 			"[Disruptive]",


### PR DESCRIPTION
I had originally simply labeled these tests due to a misunderstanding of the annotation rules. These should have been always skipped (disabled) as shown in https://github.com/openshift/kubernetes/blob/4e77d9d318cafbba66d3d905d95d28211d4617db/openshift-hack/e2e/annotate/rules.go#L33-L34