### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Filter featuregates by FeatureGate label instead of using OffByDefault label

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -11,16 +11,12 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 		"Alpha": { // alpha features that are not gated
 			"[Feature:StorageVersionAPI]",
 			"[Feature:ClusterTrustBundle]",
-			"[Feature:SELinuxMount]",
-			"[FeatureGate:SELinuxMount]",
 			"[Feature:DynamicResourceAllocation]",
-			"[Feature:VolumeAttributesClass]", // disabled Beta
 			"[sig-cli] Kubectl client Kubectl prune with applyset should apply and prune objects", // Alpha feature since k8s 1.27
 			// 4.19
 			"[Feature:PodLevelResources]",
 			"[Feature:PodLogsQuerySplitStreams]",
 			// 4.20
-			"[Feature:OffByDefault]",
 			"[Feature:CBOR]",
 		},
 		// tests for features that are not implemented in openshift

--- a/openshift-hack/test-kubernetes-e2e.sh
+++ b/openshift-hack/test-kubernetes-e2e.sh
@@ -31,7 +31,7 @@ NETWORK_SKIPS="\[Skipped:Network/OVNKubernetes\]|\[Feature:Networking-IPv6\]|\[F
 TEST_SUITE="${TEST_SUITE:-parallel}"
 COMMON_SKIPS="\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Disabled:.+\]|\[Skipped:${PLATFORM}\]|${NETWORK_SKIPS}"
 # Skip tests for features that require a TechPreview cluster. TODO: Remove when the feature is enabled by default.
-COMMON_SKIPS="\[OCPFeatureGate:VolumeGroupSnapshot\]|${COMMON_SKIPS}"
+COMMON_SKIPS="\[OCPFeatureGate:VolumeGroupSnapshot\]|\[Feature:OffByDefault\]|${COMMON_SKIPS}"
 
 case "${TEST_SUITE}" in
 serial)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind failing-test

#### What this PR does / why we need it:
Filter FeatureGate tests by their label `FeatureGate:` and disable filtering by `OffByDefault` label for openshift tests.
Filtering for k8s jobs now includes the `OffByDefault` label, which will be ignored on our jobs.

This enables only specified FeatureGates and helps with failing CI on TechPreview tests run on standard clusters.

#### Does this PR introduce a user-facing change?
```release-note
Filter FeatureGate tests with label "FeatureGate" to run only on TechPreview Clusters
```