### PR TITLE
OCPBUGS-57477: UPSTREAM: 133392: test: add retry to getMetricsFromNode

### DIFF
--- a/test/e2e/framework/metrics/kubelet_metrics.go
+++ b/test/e2e/framework/metrics/kubelet_metrics.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	proxyTimeout = 2 * time.Minute
 	// dockerOperationsLatencyKey is the key for the operation latency metrics.
 	// Taken from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
 	dockerOperationsLatencyKey = "docker_operations_duration_seconds"


### PR DESCRIPTION
test: add retry to getMetricsFromNode and deflake 'should grab all metrics from kubelet /metrics/resource endpoint

Upstream 1.34 PR: https://github.com/kubernetes/kubernetes/pull/133392