### PR TITLE
WIP: OKD-259: Validate OKD featureset to prevent it from being enabled on OCP clusters

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -39,6 +39,8 @@ PRINT_HELP ?=
 WHAT ?=
 TESTS ?=
 BRANCH ?=
+TAGS ?=
+GO_BUILD_FLAGS := $(if ${TAGS},-tags=${TAGS},)
 
 # We don't need make's built-in rules.
 MAKEFLAGS += --no-builtin-rules
@@ -59,6 +61,11 @@ unexport KUBE_GOFLAGS
 else
 $(error Both KUBE_GOFLAGS and GOFLAGS are set. Please use just GOFLAGS)
 endif
+endif
+
+# Add build tags to GOFLAGS
+ifneq ($(TAGS),)
+GOFLAGS := $(GOFLAGS) $(GO_BUILD_FLAGS)
 endif
 
 # This controls the verbosity of the build.  Higher numbers mean more output.

--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -1,7 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+ARG TAGS=""
 WORKDIR /go/src/k8s.io/kubernetes
 COPY . .
-RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination openshift-hack/cmd/k8s-tests-ext' && \
+RUN make TAGS="${TAGS}" WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler cmd/kubelet cmd/watch-termination openshift-hack/cmd/k8s-tests-ext' && \
     mkdir -p /tmp/build && \
     cp openshift-hack/images/hyperkube/hyperkube openshift-hack/images/hyperkube/kubensenter /tmp/build && \
     cp /go/src/k8s.io/kubernetes/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination,k8s-tests-ext} \

--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -8,7 +8,7 @@ RUN make WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd/kube-scheduler
     /tmp/build && \
     gzip /tmp/build/k8s-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/origin/scos-4.20:base-stream9
 RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all
 COPY --from=builder /tmp/build/* /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \

--- a/openshift-kube-apiserver/admission/customresourcevalidation/features/validate_features.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/features/validate_features.go
@@ -13,6 +13,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+	"k8s.io/kubernetes/openshift-kube-apiserver/version"
 )
 
 const PluginName = "config.openshift.io/ValidateFeatureGate"
@@ -52,8 +53,8 @@ type featureGateV1 struct {
 
 func validateOKDFeatureSet(spec configv1.FeatureGateSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if spec.FeatureSet == configv1.OKD {
-		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec.featureSet"), spec.FeatureSet, []string{"OKD"}))
+	if spec.FeatureSet == configv1.OKD && !version.IsSCOS() {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.featureSet"), "OKD featureset is not supported on OpenShift clusters"))
 	}
 
 	return allErrs

--- a/openshift-kube-apiserver/admission/customresourcevalidation/features/validate_features.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/features/validate_features.go
@@ -50,6 +50,15 @@ func toFeatureGateV1(uncastObj runtime.Object) (*configv1.FeatureGate, field.Err
 type featureGateV1 struct {
 }
 
+func validateOKDFeatureSet(spec configv1.FeatureGateSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if spec.FeatureSet == configv1.OKD {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec.featureSet"), spec.FeatureSet, []string{"OKD"}))
+	}
+
+	return allErrs
+}
+
 func (featureGateV1) ValidateCreate(_ context.Context, uncastObj runtime.Object) field.ErrorList {
 	obj, allErrs := toFeatureGateV1(uncastObj)
 	if len(allErrs) > 0 {
@@ -57,7 +66,7 @@ func (featureGateV1) ValidateCreate(_ context.Context, uncastObj runtime.Object)
 	}
 
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
-
+	allErrs = append(allErrs, validateOKDFeatureSet(obj.Spec)...)
 	return allErrs
 }
 
@@ -72,6 +81,7 @@ func (featureGateV1) ValidateUpdate(_ context.Context, uncastObj runtime.Object,
 	}
 
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, validateOKDFeatureSet(obj.Spec)...)
 
 	return allErrs
 }

--- a/openshift-kube-apiserver/version/scos.go
+++ b/openshift-kube-apiserver/version/scos.go
@@ -1,0 +1,7 @@
+//go:build scos
+
+package version
+
+func init() {
+	SCOS = true
+}

--- a/openshift-kube-apiserver/version/version.go
+++ b/openshift-kube-apiserver/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+var (
+	// SCOS is a setting to enable CentOS Stream CoreOS-only modifications
+	SCOS = false
+)
+
+// IsSCOS returns true if CentOS Stream CoreOS-only modifications are enabled
+func IsSCOS() bool {
+	return SCOS
+}

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -53,8 +53,12 @@ var (
 	// your cluster may fail in an unrecoverable way.
 	CustomNoUpgrade FeatureSet = "CustomNoUpgrade"
 
+	// OKD turns on features for OKD. Turning this feature set ON is supported for OKD clusters, but NOT for OpenShift clusters
+	// this feature set on CANNOT BE UNDONE for OKD clusters and when enabled on OpenShift clusters it PREVENTS UPGRADES.
+	OKD FeatureSet = "OKD"
+
 	// AllFixedFeatureSets are the featuresets that have known featuregates.  Custom doesn't for instance.  LatencySensitive is dead
-	AllFixedFeatureSets = []FeatureSet{Default, TechPreviewNoUpgrade, DevPreviewNoUpgrade}
+	AllFixedFeatureSets = []FeatureSet{Default, TechPreviewNoUpgrade, DevPreviewNoUpgrade, OKD}
 )
 
 type FeatureGateSpec struct {
@@ -67,10 +71,11 @@ type FeatureGateSelection struct {
 	// Turning on or off features may cause irreversible changes in your cluster which cannot be undone.
 	// +unionDiscriminator
 	// +optional
-	// +kubebuilder:validation:Enum=CustomNoUpgrade;DevPreviewNoUpgrade;TechPreviewNoUpgrade;""
+	// +kubebuilder:validation:Enum=CustomNoUpgrade;DevPreviewNoUpgrade;TechPreviewNoUpgrade;OKD;""
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'CustomNoUpgrade' ? self == 'CustomNoUpgrade' : true",message="CustomNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'TechPreviewNoUpgrade' ? self == 'TechPreviewNoUpgrade' : true",message="TechPreviewNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'DevPreviewNoUpgrade' ? self == 'DevPreviewNoUpgrade' : true",message="DevPreviewNoUpgrade may not be changed"
+	// +kubebuilder:validation:XValidation:rule="oldSelf == 'OKD' ? self == 'OKD' : true",message="OKD may not be changed"
 	FeatureSet FeatureSet `json:"featureSet,omitempty"`
 
 	// customNoUpgrade allows the enabling or disabling of any feature. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it: It allows the kubernetes repo to be built with a scos tag which will be used to validate if a cluster is a OCP or OKD cluster. This is to prevent users from enabling the OKD featureset if they happen to be on a OCP cluster 

#### Special notes for your reviewer: 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added: OKD featureset and OKD featureset validation 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/openshift/api/pull/2451
```
