### PR TITLE
WIP: Fix missing k8s image

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -88,10 +88,23 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`name.contains('[Serial]')`)},
 	})
 
-	for k, v := range image.GetOriginalImageConfigs() {
+	originals := image.GetOriginalImageConfigs()
+	for k, v := range originals {
 		image := convertToImage(v)
 		image.Index = int(k)
-		kubeTestsExtension.RegisterImage(image)
+		kubeTestsExtension.RegisterImage("original", image)
+	}
+
+	mirror := "quay.io/openshift/community-e2e-images"
+	if v := os.Getenv("TEST_IMAGE_MIRROR"); len(v) > 0 {
+		mirror = v
+	}
+	mapped := image.GetMappedImageConfigs(originals, mirror)
+
+	for k, v := range mapped {
+		image := convertToImage(v)
+		image.Index = int(k)
+		kubeTestsExtension.RegisterImage("mapped", image)
 	}
 
 	//FIXME(stbenjam): what other suites does k8s-test contribute to?

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlistimages"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
@@ -19,5 +20,6 @@ func DefaultExtensionCommands(registry *extension.Registry) []*cobra.Command {
 		cmdinfo.NewInfoCommand(registry),
 		cmdupdate.NewUpdateCommand(registry),
 		cmdimages.NewImagesCommand(registry),
+		cmdlistimages.NewListImagesCommand(registry),
 	}
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlistimages/cmdlistimages.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlistimages/cmdlistimages.go
@@ -1,0 +1,36 @@
+package cmdlistimages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewListImagesCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "list-images",
+		Short:        "List test images",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			extension := registry.Get(componentFlags.Component)
+			if extension == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+			images, err := json.Marshal(extension.TestImages)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", images)
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
@@ -22,6 +22,10 @@ func NewExtension(product, kind, name string) *Extension {
 			Kind:    kind,
 			Name:    name,
 		},
+		TestImages: map[string][]Image{
+			"original": nil,
+			"mapped":   nil,
+		},
 	}
 }
 
@@ -124,8 +128,8 @@ func (e *Extension) AddSuite(suite Suite) *Extension {
 	return e
 }
 
-func (e *Extension) RegisterImage(image Image) *Extension {
-	e.Images = append(e.Images, image)
+func (e *Extension) RegisterImage(key string, image Image) *Extension {
+	e.TestImages[key] = append(e.TestImages[key], image)
 	return e
 }
 

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -20,6 +20,8 @@ type Extension struct {
 
 	Images []Image `json:"images"`
 
+	TestImages map[string][]Image `json:"test_images"`
+
 	// Private data
 	specs         extensiontests.ExtensionTestSpecs
 	obsoleteTests sets.Set[string]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -508,6 +508,7 @@ github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlistimages
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate
 github.com/openshift-eng/openshift-tests-extension/pkg/dbtime


### PR DESCRIPTION
Example:

```
kubernetes on  fix-missing-k8s-image ❯ ./_output/bin/k8s-tests-ext list-images | jq
{
  "mapped": [
    {
      "index": 4,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-4-registry-k8s-io-e2e-test-images-apparmor-loader-1-4-m-K7F-syWFeA4t03"
    },
    {
      "index": 33,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-33-registry-k8s-io-sig-storage-volume-data-source-validator-v1-0-0-pJwTeQGTDmAV8753"
    },
    {
      "index": 10,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-10-registry-k8s-io-e2e-test-images-httpd-2-4-38-4-lYFH2l3oSS5xEICa"
    },
    {
      "index": 18,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-18-registry-k8s-io-e2e-test-images-nginx-1-14-4-20h7A1tgJp0m0c1_"
    },
    {
      "index": 21,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-21-registry-k8s-io-e2e-test-images-node-perf-npb-is-1-2-_tnI2Z3XnYHZzTZJ"
    },
    {
      "index": 24,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-24-registry-k8s-io-e2e-test-images-nonroot-1-4-u_r1WOwfmHWUVyUc"
    },
    {
      "index": 28,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-28-registry-k8s-io-e2e-test-images-regression-issue-74839-1-2-pZ_RxNuqvcwEiCKE"
    },
    {
      "index": 30,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-30-registry-k8s-io-e2e-test-images-volume-nfs-1-4-u7V8iW5QIcWM2i6h"
    },
    {
      "index": 32,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-32-registry-k8s-io-sig-storage-hello-populator-v1-0-1-Ei7libli17J5IWn-"
    },
    {
      "index": 25,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-25-registry-k8s-io-pause-3-10-b3MYAwZ_MelO9baY"
    },
    {
      "index": 26,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-26-registry-k8s-io-e2e-test-images-perl-5-26-Y8J-9BkLP356-AtD"
    },
    {
      "index": 27,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-27-registry-k8s-io-e2e-test-images-redis-5-0-5-3-vp1PVXVOrYaQL5QQ"
    },
    {
      "index": 12,
      "registry": "invalid.registry.k8s.io/invalid",
      "name": "alpine",
      "version": "3.1"
    },
    {
      "index": 19,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-19-registry-k8s-io-e2e-test-images-nginx-1-15-4-PSG4JEhRvqJc3rgT"
    },
    {
      "index": 39,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-39-registry-k8s-io-sig-storage-csi-provisioner-v5-1-0-9nVNb-KrN4Qb7WGv"
    },
    {
      "index": 42,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-42-registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver-v1-4-0-mUHHjVVuv0UQiTyf"
    },
    {
      "index": 1,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-1-registry-k8s-io-e2e-test-images-agnhost-2-53-S5hiptYgC5MyFXZH"
    },
    {
      "index": 8,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-8-registry-k8s-io-build-image-distroless-iptables-v0-7-6-q9JnbCuPRt2Q6Cyz"
    },
    {
      "index": 22,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-22-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep-1-3-EDGj7EOLGmRjJ92y"
    },
    {
      "index": 31,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-31-registry-k8s-io-e2e-test-images-volume-iscsi-2-6-3sOdD3WkuEQhhISN"
    },
    {
      "index": 9,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-9-registry-k8s-io-etcd-3-5-21-0-ul4Gh_2cA4Q27LA8"
    },
    {
      "index": 16,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-16-registry-k8s-io-e2e-test-images-nautilus-1-7-7f05f70QXiLXg0hX"
    },
    {
      "index": 38,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-38-registry-k8s-io-sig-storage-csi-attacher-v4-8-0-S1cGDJYg9N-xpVnU"
    },
    {
      "index": 35,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-35-registry-k8s-io-sig-storage-csi-external-health-monitor-controller-v0-12-1--7VXdNUMsJt30kdU"
    },
    {
      "index": 17,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-17-registry-k8s-io-sig-storage-nfs-provisioner-v4-0-8-W5pbwDbNliDm1x4k"
    },
    {
      "index": 2,
      "registry": "gcr.io/k8s-authenticated-test",
      "name": "agnhost",
      "version": "2.6"
    },
    {
      "index": 5,
      "registry": "gcr.io/authenticated-image-pulling",
      "name": "alpine",
      "version": "3.7"
    },
    {
      "index": 34,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-34-registry-k8s-io-sig-storage-hostpathplugin-v1-16-1-E8rDn5RMceBiqrUX"
    },
    {
      "index": 41,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-41-registry-k8s-io-sig-storage-csi-snapshotter-v8-3-0-LSRhS3Dw_X9lUrAu"
    },
    {
      "index": 36,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-36-registry-k8s-io-sig-storage-csi-node-driver-registrar-v2-13-0-Yz3cC3wjWoQESAfV"
    },
    {
      "index": 14,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-14-registry-k8s-io-e2e-test-images-jessie-dnsutils-1-7-bJ-yvCS2MUBlnXm1"
    },
    {
      "index": 15,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-15-registry-k8s-io-e2e-test-images-kitten-1-7-mZ7FrR_qsNkeZKj2"
    },
    {
      "index": 29,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-29-registry-k8s-io-e2e-test-images-resource-consumer-1-13-LT0C2W4wMzShSeGS"
    },
    {
      "index": 20,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-20-registry-k8s-io-e2e-test-images-node-perf-npb-ep-1-2-gVhsojuRuw0AAfMC"
    },
    {
      "index": 6,
      "registry": "gcr.io/authenticated-image-pulling",
      "name": "windows-nanoserver",
      "version": "v1"
    },
    {
      "index": 23,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-23-registry-k8s-io-e2e-test-images-nonewprivs-1-3-lsPs1J8LjWvEYqre"
    },
    {
      "index": 7,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-7-registry-k8s-io-e2e-test-images-busybox-1-36-1-1-n3BezCOfxp98l84K"
    },
    {
      "index": 40,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-40-registry-k8s-io-sig-storage-csi-resizer-v1-13-1-YKcEWbi0FydNavn_"
    },
    {
      "index": 3,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-3-registry-k8s-io-e2e-test-images-sample-apiserver-1-29-2-jfc3qrk0SlKStkiL"
    },
    {
      "index": 37,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-37-registry-k8s-io-sig-storage-livenessprobe-v2-15-0-4bLc1k1ifxb_KkX9"
    },
    {
      "index": 13,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-13-registry-k8s-io-e2e-test-images-ipc-utils-1-3-1gFPvJGe7Ngg9foG"
    },
    {
      "index": 11,
      "registry": "quay.io",
      "name": "openshift/community-e2e-images",
      "version": "e2e-11-registry-k8s-io-e2e-test-images-httpd-2-4-39-4-Hgo23C6O-Y8DPv5N"
    }
  ],
  "original": [
    {
      "index": 27,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "redis",
      "version": "5.0.5-3"
    },
    {
      "index": 31,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "volume/iscsi",
      "version": "2.6"
    },
    {
      "index": 35,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-external-health-monitor-controller",
      "version": "v0.12.1"
    },
    {
      "index": 36,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-node-driver-registrar",
      "version": "v2.13.0"
    },
    {
      "index": 14,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "jessie-dnsutils",
      "version": "1.7"
    },
    {
      "index": 4,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "apparmor-loader",
      "version": "1.4"
    },
    {
      "index": 15,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "kitten",
      "version": "1.7"
    },
    {
      "index": 17,
      "registry": "registry.k8s.io/sig-storage",
      "name": "nfs-provisioner",
      "version": "v4.0.8"
    },
    {
      "index": 33,
      "registry": "registry.k8s.io/sig-storage",
      "name": "volume-data-source-validator",
      "version": "v1.0.0"
    },
    {
      "index": 12,
      "registry": "invalid.registry.k8s.io/invalid",
      "name": "alpine",
      "version": "3.1"
    },
    {
      "index": 19,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "nginx",
      "version": "1.15-4"
    },
    {
      "index": 29,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "resource-consumer",
      "version": "1.13"
    },
    {
      "index": 37,
      "registry": "registry.k8s.io/sig-storage",
      "name": "livenessprobe",
      "version": "v2.15.0"
    },
    {
      "index": 39,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-provisioner",
      "version": "v5.1.0"
    },
    {
      "index": 42,
      "registry": "registry.k8s.io/cloud-provider-gcp",
      "name": "gcp-compute-persistent-disk-csi-driver",
      "version": "v1.4.0"
    },
    {
      "index": 13,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "ipc-utils",
      "version": "1.3"
    },
    {
      "index": 1,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "agnhost",
      "version": "2.53"
    },
    {
      "index": 10,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "httpd",
      "version": "2.4.38-4"
    },
    {
      "index": 20,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "node-perf/npb-ep",
      "version": "1.2"
    },
    {
      "index": 28,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "regression-issue-74839",
      "version": "1.2"
    },
    {
      "index": 30,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "volume/nfs",
      "version": "1.4"
    },
    {
      "index": 2,
      "registry": "gcr.io/k8s-authenticated-test",
      "name": "agnhost",
      "version": "2.6"
    },
    {
      "index": 8,
      "registry": "registry.k8s.io/build-image",
      "name": "distroless-iptables",
      "version": "v0.7.6"
    },
    {
      "index": 9,
      "registry": "registry.k8s.io",
      "name": "etcd",
      "version": "3.5.21-0"
    },
    {
      "index": 18,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "nginx",
      "version": "1.14-4"
    },
    {
      "index": 21,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "node-perf/npb-is",
      "version": "1.2"
    },
    {
      "index": 22,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "node-perf/tf-wide-deep",
      "version": "1.3"
    },
    {
      "index": 32,
      "registry": "registry.k8s.io/sig-storage",
      "name": "hello-populator",
      "version": "v1.0.1"
    },
    {
      "index": 40,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-resizer",
      "version": "v1.13.1"
    },
    {
      "index": 6,
      "registry": "gcr.io/authenticated-image-pulling",
      "name": "windows-nanoserver",
      "version": "v1"
    },
    {
      "index": 16,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "nautilus",
      "version": "1.7"
    },
    {
      "index": 23,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "nonewprivs",
      "version": "1.3"
    },
    {
      "index": 38,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-attacher",
      "version": "v4.8.0"
    },
    {
      "index": 25,
      "registry": "registry.k8s.io",
      "name": "pause",
      "version": "3.10"
    },
    {
      "index": 26,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "perl",
      "version": "5.26"
    },
    {
      "index": 11,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "httpd",
      "version": "2.4.39-4"
    },
    {
      "index": 5,
      "registry": "gcr.io/authenticated-image-pulling",
      "name": "alpine",
      "version": "3.7"
    },
    {
      "index": 7,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "busybox",
      "version": "1.36.1-1"
    },
    {
      "index": 24,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "nonroot",
      "version": "1.4"
    },
    {
      "index": 34,
      "registry": "registry.k8s.io/sig-storage",
      "name": "hostpathplugin",
      "version": "v1.16.1"
    },
    {
      "index": 41,
      "registry": "registry.k8s.io/sig-storage",
      "name": "csi-snapshotter",
      "version": "v8.3.0"
    },
    {
      "index": 3,
      "registry": "registry.k8s.io/e2e-test-images",
      "name": "sample-apiserver",
      "version": "1.29.2"
    }
  ]
}
```