### PR TITLE
OCPBUGS-61465: Add a new field Mapped into openshift-test extension Image struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/opencontainers/cgroups v0.0.3
 	github.com/opencontainers/runc v1.2.5
 	github.com/opencontainers/selinux v1.11.1
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250916161632-d81c09058835
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20251104171704-4de6984a8e50
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7
 	github.com/openshift/apiserver-library-go v0.0.0-20251015164739-79d04067059d
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250916161632-d81c09058835 h1:rkqIIfdYYkasXbF2XKVgh/3f1mhjSQK9By8WtVMgYo8=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250916161632-d81c09058835/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20251104171704-4de6984a8e50 h1:IDbKc3X/GwWtwDraBK+l0H0nUNcE3vU8BCba7HTo7/0=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20251104171704-4de6984a8e50/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 h1:Ot2fbEEPmF3WlPQkyEW/bUCV38GMugH/UmZvxpWceNc=
 github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7/go.mod h1:d5uzF0YN2nQQFA0jIEWzzOZ+edmo6wzlGLvx5Fhz4uY=
 github.com/openshift/apiserver-library-go v0.0.0-20251015164739-79d04067059d h1:Mfya3RxHWvidOrKyHj3bmFn5x2B89DLZIvDAhwm+C2s=

--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -88,9 +88,16 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`name.contains('[Serial]')`)},
 	})
 
-	for k, v := range image.GetOriginalImageConfigs() {
-		image := convertToImage(v)
-		image.Index = int(k)
+	mirror := "quay.io/openshift/community-e2e-images"
+	if v := os.Getenv("TEST_IMAGE_MIRROR"); len(v) > 0 {
+		mirror = v
+	}
+	originals := image.GetOriginalImageConfigs()
+	mapped := image.GetMappedImageConfigs(originals, mirror)
+	for k, v := range originals {
+		image := convertToImage(v, int(k))
+		mappedImage := convertToImage(mapped[k], int(k))
+		image.Mapped = &mappedImage
 		kubeTestsExtension.RegisterImage(image)
 	}
 
@@ -158,10 +165,10 @@ func main() {
 	}
 }
 
-// convertToImages converts an image.Config to an extension.Image, which
+// convertToImage converts an image.Config to an extension.Image, which
 // can easily be serialized to JSON. Since image.Config has unexported fields,
 // reflection is used to read its values.
-func convertToImage(obj interface{}) e.Image {
+func convertToImage(obj interface{}, index int) e.Image {
 	image := e.Image{}
 	val := reflect.ValueOf(obj)
 	typ := reflect.TypeOf(obj)
@@ -177,6 +184,7 @@ func convertToImage(obj interface{}) e.Image {
 			image.Version = fieldValue.String()
 		}
 	}
+	image.Index = index
 	return image
 }
 

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -88,4 +88,7 @@ type Image struct {
 	Registry string `json:"registry"`
 	Name     string `json:"name"`
 	Version  string `json:"version"`
+	// Mapped is the image reference that this image is mirrored to by the image mirror tool.
+	// This field should be populated if the mirrored image reference is predetermined by the test extensions.
+	Mapped *Image `json:"mapped,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -496,7 +496,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250916161632-d81c09058835
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20251104171704-4de6984a8e50
 ## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages


### PR DESCRIPTION
The current GetMappedImageConfigs returns the map with only mapped image config. The new func GetImageConfigsWithMappedImage will return original image information along with mapped one.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
