### PR TITLE
Revert "UPSTREAM: revert<carry>: Mark admissionregistration.k8s.io/v1beta1 as deprecated.""

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
+++ b/openshift-kube-apiserver/filters/apirequestcount/deprecated.go
@@ -9,6 +9,12 @@ import (
 var DeprecatedAPIRemovedRelease = map[schema.GroupVersionResource]uint{
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}:                 32,
 	{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}: 32,
+
+	// 4.17 shipped with admissionregistration.k8s.io/v1beta1 served under the default featureset.
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}:   33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}:     33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicies"}:       33,
+	{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicybindings"}: 33,
 }
 
 // removedRelease of a specified resource.version.group.


### PR DESCRIPTION
Reverts openshift/kubernetes#2422 now that https://github.com/openshift/machine-config-operator/pull/5256 is in 4.17.39