### PR TITLE
OCPBUGS-43994: UPSTREAM: <carry>: kube-apiserver: Only log each HTTP request once

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -131,16 +131,15 @@ func withLogging(handler http.Handler, stackTracePred StacktracePred, shouldLogR
 		req = req.WithContext(context.WithValue(ctx, respLoggerContextKey, rl))
 
 		var logFunc func()
-		logFunc = rl.Log
+		if klog.V(3).Enabled() || (rl.isTerminating && klog.V(1).Enabled()) {
+			logFunc = rl.Log
+		}
 		defer func() {
 			if logFunc != nil {
 				logFunc()
 			}
 		}()
 
-		if klog.V(3).Enabled() || (rl.isTerminating && klog.V(1).Enabled()) {
-			defer rl.Log()
-		}
 		w = responsewriter.WrapForHTTP1Or2(rl)
 		handler.ServeHTTP(w, req)
 
@@ -149,7 +148,7 @@ func withLogging(handler http.Handler, stackTracePred StacktracePred, shouldLogR
 		// WithRoutine handler in the handler chain (i.e. above handler.ServeHTTP()
 		// would return request is completely responsed), we want the logging to
 		// happen in that goroutine too, so we append it to the task.
-		if routine.AppendTask(ctx, &routine.Task{Func: rl.Log}) {
+		if logFunc != nil && routine.AppendTask(ctx, &routine.Task{Func: logFunc}) {
 			logFunc = nil
 		}
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kube-apiserver now logs each HTTP request twice since there is an extra logging call when finishing the request. This duplicity is now removed.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A