### PR TITLE
OCPBUGS-61222: Do not remove PVC ClaimRef to fix flaky VAC test

### DIFF
--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -328,7 +328,7 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 		originPv := pv.DeepCopy()
 		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
 		_, err = f.ClientSet.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
-		ginkgo.DeferCleanup(recoverPvReclaimPolicyAndRemoveClaimRef, f.ClientSet, originPv)
+		ginkgo.DeferCleanup(recoverPvReclaimPolicy, f.ClientSet, originPv)
 		framework.ExpectNoError(err, "Failed to update PV %q reclaim policy", pvName)
 
 		// The vac_protection_controller make sure there is a VolumeAttributesClass that is not used by any PVC/PV
@@ -369,7 +369,7 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		ginkgo.By(fmt.Sprintf("Deleting PV %q to make the vac unused for the PV", newVAC.Name))
 		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
-		recoverPvReclaimPolicyAndRemoveClaimRef(ctx, f.ClientSet, pv)
+		recoverPvReclaimPolicy(ctx, f.ClientSet, pv)
 
 		ginkgo.By(fmt.Sprintf("Waiting for PV %q to be deleted", pvName))
 		gomega.Eventually(func() bool {
@@ -432,8 +432,8 @@ func CleanupVAC(ctx context.Context, vac *storagev1beta1.VolumeAttributesClass, 
 	}, timeout, modifyPollInterval).Should(gomega.BeNil())
 }
 
-// recoverPvReclaimPolicyAndRemoveClaimRef recovers the test pv's reclaim policy to expected used for clean up test PV
-func recoverPvReclaimPolicyAndRemoveClaimRef(ctx context.Context, c clientset.Interface, expectedPv *v1.PersistentVolume) {
+// recoverPvReclaimPolicy recovers the test pv's reclaim policy to expected used for clean up test PV
+func recoverPvReclaimPolicy(ctx context.Context, c clientset.Interface, expectedPv *v1.PersistentVolume) {
 	setPvReclaimPolicyErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, expectedPv.Name, metav1.GetOptions{})
 		if err != nil {
@@ -443,11 +443,10 @@ func recoverPvReclaimPolicyAndRemoveClaimRef(ctx context.Context, c clientset.In
 			}
 			return err
 		}
-		if pv.Spec.PersistentVolumeReclaimPolicy == expectedPv.Spec.PersistentVolumeReclaimPolicy && pv.Spec.ClaimRef == nil {
+		if pv.Spec.PersistentVolumeReclaimPolicy == expectedPv.Spec.PersistentVolumeReclaimPolicy {
 			framework.Logf("PV %q reclaim policy is already recovered to %q", expectedPv.Name, expectedPv.Spec.PersistentVolumeReclaimPolicy)
 			return nil
 		}
-		pv.Spec.ClaimRef = nil
 		pv.Spec.PersistentVolumeReclaimPolicy = expectedPv.Spec.PersistentVolumeReclaimPolicy
 		_, err = c.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Fix an issue in the test where a PersistentVolume (PV) was marked for deletion, but the test subsequently set its status back to Available, preventing the PV from being deleted.

#### Does this PR introduce a user-facing change?
```release-note
None
```
