### PR TITLE
OCPBUGS-61379: Disable KubeProxyNFAcct test

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -33,6 +33,7 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			"[Feature:BoundServiceAccountTokenVolume]", // upgrades are run separately
 			"[Feature:StatefulUpgrade]",                // upgrades are run separately
 			"Service CIDRs",                            // requires extra support from some components
+			"[Feature:KubeProxyNFAcct]",                // RHEL does not include the relevant kernel module
 		},
 		// tests that rely on special configuration that we do not yet support
 		"SpecialConfig": {


### PR DESCRIPTION
This tests a feature of kube-proxy iptables mode that logs extra information to help people confirm that their configuration is compatible with nftables mode, but it depends on an iptables kernel module RHEL doesn't ship by default.

(This won't have any effect on master since the e2e test doesn't exist there yet, but it should fix a failure in the 1.34 rebase.)

/assign @jacobsee 