### PR TITLE
OCPBUGS-58313: apiserver library go bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/opencontainers/selinux v1.11.1
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
-	github.com/openshift/apiserver-library-go v0.0.0-20250710132015-f0d44ef6e53b
+	github.com/openshift/apiserver-library-go v0.0.0-20250911093722-c3074dc10090
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
 	github.com/openshift/library-go v0.0.0-20250710130336-73c7662bc565
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e
 github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20250710004639-926605d3338b h1:A8OY6adT2aZNp7tsGsilHuQ3RqhzrFx5dzGr/UwXfJg=
 github.com/openshift/api v0.0.0-20250710004639-926605d3338b/go.mod h1:SPLf21TYPipzCO67BURkCfK6dcIIxx0oNRVWaOyRcXM=
-github.com/openshift/apiserver-library-go v0.0.0-20250710132015-f0d44ef6e53b h1:rIfs2f1zo9GLyxk6tak2bHzX01VTz6Xheay2NECfZpg=
-github.com/openshift/apiserver-library-go v0.0.0-20250710132015-f0d44ef6e53b/go.mod h1:8aHgQmkn0RbvMth8icv+itFvH+vF94VHBTjIUuPmkCU=
+github.com/openshift/apiserver-library-go v0.0.0-20250911093722-c3074dc10090 h1:6phyJKvzerNFx6n8rwBn12HCWP/k88cNhb78awSYmAc=
+github.com/openshift/apiserver-library-go v0.0.0-20250911093722-c3074dc10090/go.mod h1:8aHgQmkn0RbvMth8icv+itFvH+vF94VHBTjIUuPmkCU=
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
@@ -18,11 +18,52 @@ package sysctl
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 )
+
+type sysctl struct {
+	// the name of sysctl
+	name string
+	// the minimum kernel version where the sysctl is available
+	kernel string
+}
+
+// Legacy safe sysctls that were always allowed in previous releases.
+// These must always be returned to avoid regressions: pods that depended on these
+// sysctls should continue to work as before, regardless of kernel version detection.
+var legacySafeSysctls = []string{
+	"kernel.shm_rmid_forced",
+	"net.ipv4.ip_local_port_range",
+	"net.ipv4.tcp_syncookies",
+	"net.ipv4.ping_group_range",
+	"net.ipv4.ip_unprivileged_port_start",
+	"net.ipv4.tcp_keepalive_time",
+	"net.ipv4.tcp_fin_timeout",
+	"net.ipv4.tcp_keepalive_intvl",
+	"net.ipv4.tcp_keepalive_probes",
+}
+
+// Newer sysctls that are safe only if the kernel version is new enough.
+// We gate these to avoid exposing unsupported sysctls on older kernels.
+var newerSysctls = []sysctl{
+	{
+		name:   "net.ipv4.ip_local_reserved_ports",
+		kernel: "3.16",
+	}, {
+		name:   "net.ipv4.tcp_rmem",
+		kernel: "4.15",
+	}, {
+		name:   "net.ipv4.tcp_wmem",
+		kernel: "4.15",
+	},
+}
 
 // SafeSysctlAllowlist returns the allowlist of safe sysctls and safe sysctl patterns (ending in *).
 //
@@ -30,17 +71,31 @@ import (
 // - it is namespaced in the container or the pod
 // - it is isolated, i.e. has no influence on any other pod on the same node.
 func SafeSysctlAllowlist() []string {
-	return []string{
-		"kernel.shm_rmid_forced",
-		"net.ipv4.ip_local_port_range",
-		"net.ipv4.tcp_syncookies",
-		"net.ipv4.ping_group_range",
-		"net.ipv4.ip_unprivileged_port_start",
-		"net.ipv4.tcp_keepalive_time",
-		"net.ipv4.tcp_fin_timeout",
-		"net.ipv4.tcp_keepalive_intvl",
-		"net.ipv4.tcp_keepalive_probes",
+	return getSafeSysctlAllowlist(utilkernel.GetVersion)
+}
+
+// getSafeSysctlAllowlist returns the list of safe sysctls that can be used.
+// To prevent regressions:
+//  1. Always return the legacy list (known safe sysctls from previous releases).
+//  2. Conditionally add newer sysctls only if the detected kernel version
+//     is at least as new as required.
+func getSafeSysctlAllowlist(getVersion func() (*version.Version, error)) []string {
+	safeSysctlAllowlist := slices.Clone(legacySafeSysctls)
+
+	kernelVersion, err := getVersion()
+	if err != nil {
+		klog.Error(err, "failed to get kernel version, falling back to legacy safe sysctl list")
+		return safeSysctlAllowlist
 	}
+
+	for _, sc := range newerSysctls {
+		if kernelVersion.AtLeast(version.MustParseGeneric(sc.kernel)) {
+			safeSysctlAllowlist = append(safeSysctlAllowlist, sc.name)
+		} else {
+			klog.Info("kernel version is too old, dropping the sysctl from safe sysctl list", "kernelVersion", kernelVersion, "sysctl", sc.name)
+		}
+	}
+	return safeSysctlAllowlist
 }
 
 // mustMatchPatterns implements the SysctlsStrategy interface

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -545,7 +545,7 @@ github.com/openshift/api/security
 github.com/openshift/api/security/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20250710132015-f0d44ef6e53b
+# github.com/openshift/apiserver-library-go v0.0.0-20250911093722-c3074dc10090
 ## explicit; go 1.24.0
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Bumps apiserver-library-go
- Adds missing safe sysctls to list of SafeSysctlAllowlist [As part of Kubernetes v1.32, several sysctls [1] have been added to the SafeSysctlAllowlist. However, that list has not yet been updated in OCP]

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # OCPBUGS-58313

#### Special notes for your reviewer:
Bumping the changes introduced in the PR: https://github.com/openshift/apiserver-library-go/pull/148

#### Does this PR introduce a user-facing change?
Yes
The list of safe sysctls available changes with this PR.
