### PR TITLE
OCPBUGS-60610: Fix race condition in conntrack regression test by keying pending map with IP+port

### DIFF
--- a/test/images/regression-issue-74839/main.go
+++ b/test/images/regression-issue-74839/main.go
@@ -100,17 +100,18 @@ func probe(ip string) {
 
 		log.Printf("tcp packet: %+v, flag: %v, data: %v, addr: %v", pkt, pkt.FlagString(), data, addr)
 
+		connectionKey := fmt.Sprintf("%s_%d", addr.String(), pkt.SrcPort)
 		if pkt.Flags&SYN != 0 {
-			pending[addr.String()] = pkt.Seq + 1
+			pending[connectionKey] = pkt.Seq + 1
 			continue
 		}
 		if pkt.Flags&RST != 0 {
 			log.Println("ERROR: RST received")
 		}
 		if pkt.Flags&ACK != 0 {
-			if seq, ok := pending[addr.String()]; ok {
+			if seq, ok := pending[connectionKey]; ok {
 				log.Println("connection established")
-				delete(pending, addr.String())
+				delete(pending, connectionKey)
 
 				badPkt := &tcpPacket{
 					SrcPort:    pkt.DestPort,


### PR DESCRIPTION
The pending map in the regression test was keyed by only the client IP, this can cause a race condition where ACK packets from an old connection would trigger packet injection if there was a new SYN from another port.

Specifically:
1. SYN from port A adds client IP to pending map
2. ACK from port A triggers packet injection and removes IP from pending map
3. SYN from port B re-adds the same client IP to pending map
4. Server closes connection with A and the clients ACK triggers another packet injection
5. Client on port A sends A RST since the connection is already closed

This resulted in out-of-window packets being injected to the wrong connection, causing the client to send spurious RST packets that made the test unreliable.
NOTE: This only affects environments with `nf_conntrack_tcp_be_liberal` configured.

The fix keys the pending map by both IP address and source port (IP_port format), ensuring ACK packets only affect their corresponding connection.

