### PR TITLE
[WIP - DO NOT MERGE] : fix `oc get apirequestcounts` returns non deprecated APIs after 4.17 to 4.18 + upgrade

### DIFF
--- a/openshift-kube-apiserver/filters/apirequestcount_filter.go
+++ b/openshift-kube-apiserver/filters/apirequestcount_filter.go
@@ -24,7 +24,9 @@ func WithAPIRequestCountLogging(handler http.Handler, requestLogger apirequestco
 			Version:  info.APIVersion,
 			Resource: info.Resource,
 		}
-		if minor, ok := apirequestcount.DeprecatedAPIRemovedRelease[gvr]; !ok || minor <= currentMinor {
+		// If the minor value is zero (i.e. 0), it means no minor version was found.
+		// Therefore the API is not deprecated.
+		if minor := apirequestcount.DeprecatedAPIRemovedRelease[gvr]; minor == 0 || minor <= currentMinor {
 			return
 		}
 		timestamp, ok := request.ReceivedTimestampFrom(req.Context())


### PR DESCRIPTION
**THIS IS A WIP PR **

**NOTE** : I removed the template as it corresponded to Kubernetes itself - please let me know if I need to add it back to fill out. :) 

## WHAT 
+ fix `oc get apirequestcounts` returns non deprecated APIs after 4.17 to 4.18 + upgrade

## WHY
+ 4.17 to 4.18 + upgrades result in `oc get apirequestcounts` returning non deprecated APIs. This is unexpected behaviour. 
+ Expected behaviour for `oc get apirequestcounts` should be to only return deprecated APIs. 

## HOW 
+ Redundant ok check for API's `minor` version removed. 
+ Version check through uint behavior (uint default value is 0) added. 