### PR TITLE
[WIP] OCPBUGS-64663 runAsUser/runAsGroup not behaving to the expected range values in user namespaces

### DIFF
--- a/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaulting_scc_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaulting_scc_test.go
@@ -82,7 +82,13 @@ func TestDefaultingHappens(t *testing.T) {
 	"readOnlyRootFilesystem": false,
 	"requiredDropCapabilities": null,
 	"runAsGroup": {
-		"type": "RunAsAny"
+		"ranges": [
+			{
+				"max": 65534,
+				"min": 1000
+			}
+		],
+		"type": "MustRunAs"
 	},
 	"runAsUser": {
 		"type": "RunAsAny"

--- a/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaulting_scc_test.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaulting_scc_test.go
@@ -81,6 +81,9 @@ func TestDefaultingHappens(t *testing.T) {
 	"priority": null,
 	"readOnlyRootFilesystem": false,
 	"requiredDropCapabilities": null,
+	"runAsGroup": {
+		"type": "RunAsAny"
+	},
 	"runAsUser": {
 		"type": "RunAsAny"
 	},

--- a/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaults.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaults.go
@@ -7,8 +7,9 @@ import (
 	sccutil "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util"
 )
 
-// Default SCCs for new fields.  FSGroup, SupplementalGroups, and RunAsGroup are
+// Default SCCs for new fields.  FSGroup and SupplementalGroups are
 // set to the RunAsAny strategy if they are unset on the scc.
+// RunAsGroup is set to the MustRunAs strategy with ranges [1000, 65534] if unset.
 func SetDefaults_SCC(scc *securityv1.SecurityContextConstraints) {
 	if len(scc.FSGroup.Type) == 0 {
 		scc.FSGroup.Type = securityv1.FSGroupStrategyRunAsAny
@@ -17,7 +18,13 @@ func SetDefaults_SCC(scc *securityv1.SecurityContextConstraints) {
 		scc.SupplementalGroups.Type = securityv1.SupplementalGroupsStrategyRunAsAny
 	}
 	if len(scc.RunAsGroup.Type) == 0 {
-		scc.RunAsGroup.Type = securityv1.RunAsGroupStrategyRunAsAny
+		scc.RunAsGroup.Type = securityv1.RunAsGroupStrategyMustRunAs
+		scc.RunAsGroup.Ranges = []securityv1.IDRange{
+			{
+				Min: 1000,
+				Max: 65534,
+			},
+		}
 	}
 
 	if scc.Users == nil {

--- a/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaults.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/defaults.go
@@ -7,7 +7,7 @@ import (
 	sccutil "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util"
 )
 
-// Default SCCs for new fields.  FSGroup and SupplementalGroups are
+// Default SCCs for new fields.  FSGroup, SupplementalGroups, and RunAsGroup are
 // set to the RunAsAny strategy if they are unset on the scc.
 func SetDefaults_SCC(scc *securityv1.SecurityContextConstraints) {
 	if len(scc.FSGroup.Type) == 0 {
@@ -15,6 +15,9 @@ func SetDefaults_SCC(scc *securityv1.SecurityContextConstraints) {
 	}
 	if len(scc.SupplementalGroups.Type) == 0 {
 		scc.SupplementalGroups.Type = securityv1.SupplementalGroupsStrategyRunAsAny
+	}
+	if len(scc.RunAsGroup.Type) == 0 {
+		scc.RunAsGroup.Type = securityv1.RunAsGroupStrategyRunAsAny
 	}
 
 	if scc.Users == nil {

--- a/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/validation/validation.go
+++ b/openshift-kube-apiserver/admission/customresourcevalidation/securitycontextconstraints/validation/validation.go
@@ -73,9 +73,10 @@ func ValidateSecurityContextConstraints(scc *securityv1.SecurityContextConstrain
 	// ensure the runAsGroup strategy has a valid type
 	if len(scc.RunAsGroup.Type) > 0 {
 		if scc.RunAsGroup.Type != securityv1.RunAsGroupStrategyMustRunAs &&
+			scc.RunAsGroup.Type != securityv1.RunAsGroupStrategyMustRunAsRange &&
 			scc.RunAsGroup.Type != securityv1.RunAsGroupStrategyRunAsAny {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("runAsGroup", "type"), scc.RunAsGroup.Type,
-				[]string{string(securityv1.RunAsGroupStrategyMustRunAs), string(securityv1.RunAsGroupStrategyRunAsAny)}))
+				[]string{string(securityv1.RunAsGroupStrategyMustRunAs), string(securityv1.RunAsGroupStrategyMustRunAsRange), string(securityv1.RunAsGroupStrategyRunAsAny)}))
 		}
 		allErrs = append(allErrs, validateIDRanges(scc.RunAsGroup.Ranges, field.NewPath("runAsGroup"))...)
 

--- a/vendor/github.com/openshift/api/security/v1/types.go
+++ b/vendor/github.com/openshift/api/security/v1/types.go
@@ -125,6 +125,10 @@ type SecurityContextConstraints struct {
 	// runAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
 	// +nullable
 	RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" protobuf:"bytes,14,opt,name=runAsUser"`
+	// runAsGroup is the strategy that will dictate what RunAsGroup is used in the SecurityContext.
+	// +nullable
+	// +optional
+	RunAsGroup RunAsGroupStrategyOptions `json:"runAsGroup,omitempty" protobuf:"bytes,27,opt,name=runAsGroup"`
 	// supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
 	// +nullable
 	SupplementalGroups SupplementalGroupsStrategyOptions `json:"supplementalGroups,omitempty" protobuf:"bytes,15,opt,name=supplementalGroups"`
@@ -268,6 +272,18 @@ type SupplementalGroupsStrategyOptions struct {
 	Ranges []IDRange `json:"ranges,omitempty" protobuf:"bytes,2,rep,name=ranges"`
 }
 
+// RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.
+type RunAsGroupStrategyOptions struct {
+	// type is the strategy that will dictate what RunAsGroup is used in the SecurityContext.
+	Type RunAsGroupStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=RunAsGroupStrategyType"`
+	// gid is the group id that containers must run as.  Required for the MustRunAs strategy if not using
+	// namespace/service account allocated gids.
+	GID *int64 `json:"gid,omitempty" protobuf:"varint,2,opt,name=gid"`
+	// ranges are the allowed ranges of gids that may be used.
+	// +listType=atomic
+	Ranges []IDRange `json:"ranges,omitempty" protobuf:"bytes,3,rep,name=ranges"`
+}
+
 // IDRange provides a min/max of an allowed range of IDs.
 // TODO: this could be reused for UIDs.
 type IDRange struct {
@@ -295,6 +311,10 @@ type SupplementalGroupsStrategyType string
 // FSGroupStrategyType denotes strategy types for generating FSGroup values for a
 // SecurityContext
 type FSGroupStrategyType string
+
+// RunAsGroupStrategyType denotes strategy types for generating RunAsGroup values for a
+// SecurityContext
+type RunAsGroupStrategyType string
 
 const (
 	// NamespaceLevelAllowHost allows a pod to set `hostUsers` field to either `true` or `false`
@@ -325,6 +345,11 @@ const (
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
 	// container may make requests for any gid.
 	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
+
+	// container must run as a particular gid.
+	RunAsGroupStrategyMustRunAs RunAsGroupStrategyType = "MustRunAs"
+	// container may make requests for any gid.
+	RunAsGroupStrategyRunAsAny RunAsGroupStrategyType = "RunAsAny"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/openshift/api/security/v1/types.go
+++ b/vendor/github.com/openshift/api/security/v1/types.go
@@ -348,6 +348,8 @@ const (
 
 	// container must run as a particular gid.
 	RunAsGroupStrategyMustRunAs RunAsGroupStrategyType = "MustRunAs"
+	// container must run with a gid in a range.
+	RunAsGroupStrategyMustRunAsRange RunAsGroupStrategyType = "MustRunAsRange"
 	// container may make requests for any gid.
 	RunAsGroupStrategyRunAsAny RunAsGroupStrategyType = "RunAsAny"
 )


### PR DESCRIPTION
Hi Team,

Can you PTAL for this PR. 

Without this PR: There is no proper message to user why the deployment is not in ready state. 
https://issues.redhat.com/browse/OCPBUGS-64663

Try to create deployment with value runAsGroup: 65536 

oc get deploy -n testropatil
NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
deployment-invalid-group-test-65536   0/1     1            0           57m

Check output message:
oc get deploy/deployment-invalid-group-test-65536 -n testropatil -o yaml
      hostUsers: false
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext:
        fsGroup: 1000
        runAsGroup: 65536
        runAsNonRoot: true
        runAsUser: 1000
        seccompProfile:
          type: RuntimeDefault
      terminationGracePeriodSeconds: 30
status:
  conditions:
  - lastTransitionTime: "2025-11-05T05:50:19Z"
    lastUpdateTime: "2025-11-05T05:50:19Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2025-11-05T05:50:19Z"
    lastUpdateTime: "2025-11-05T05:50:19Z"
    message: ReplicaSet "deployment-invalid-group-test-65536-75474b4bdf" is progressing.
    reason: ReplicaSetUpdated
    status: "True"
    type: Progressing
  observedGeneration: 1
  replicas: 1
  unavailableReplicas: 1
  updatedReplicas: 1
  
  With PR:
    When try to create deployment with invalid max value: 65536 it wont creates the deployment and gives below info/message
    oc create -f deployment-invalid-group-test-65536.yaml
    Will get message info as:
      The Deployment "deployment-invalid-group-test-65536" is invalid: spec.template.spec.securityContext.runAsGroup: Invalid value: 65536: must be between 0 and 65535 when user namespaces are enabled (hostUsers=false)
  

/hold