### PR TITLE
UPSTREAM: <carry>: OCPBUGS-39360: Fix ClusterIsIPv6() detection for dual-stack v6-primary clusters

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/provider.go
+++ b/openshift-hack/cmd/k8s-tests-ext/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/openshift-hack/e2e"
@@ -21,6 +22,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/external"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	testfixtures "k8s.io/kubernetes/test/fixtures"
+	utilnet "k8s.io/utils/net"
 
 	// this appears to inexplicably auto-register global flags.
 	_ "k8s.io/kubernetes/test/e2e/storage/drivers"
@@ -91,12 +93,6 @@ func updateTestFrameworkForTests(provider string) error {
 		ConfigFile:  config.ConfigFile,
 	}
 
-	// these constants are taken from kube e2e and used by tests
-	testContext.IPFamily = "ipv4"
-	if config.HasIPv6 && !config.HasIPv4 {
-		testContext.IPFamily = "ipv6"
-	}
-
 	// load and set the host variable for kubectl
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: testContext.KubeConfig}, &clientcmd.ConfigOverrides{})
 	cfg, err := clientConfig.ClientConfig()
@@ -104,6 +100,23 @@ func updateTestFrameworkForTests(provider string) error {
 		return err
 	}
 	testContext.Host = cfg.Host
+
+	// Detect the cluster's primary IP family by checking the kubernetes.default service ClusterIP.
+	// This is the same approach used in upstream test/e2e/e2e.go's getDefaultClusterIPFamily().
+	// For dual-stack clusters, the primary IP family is determined by the ClusterIP of the kubernetes service.
+	testContext.IPFamily = "ipv4" // default
+	c, err := kclientset.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+	ctx := context.Background()
+	svc, err := c.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes.default service: %v", err)
+	}
+	if utilnet.IsIPv6String(svc.Spec.ClusterIP) {
+		testContext.IPFamily = "ipv6"
+	}
 
 	// Ensure that Kube tests run privileged (like they do upstream)
 	testContext.CreateTestingNS = func(ctx context.Context, baseName string, c kclientset.Interface, labels map[string]string) (*corev1.Namespace, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cluster IP family (IPv4 or IPv6) is now automatically detected from the cluster configuration with improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->