### PR TITLE
[release-4.13] OCPBUGS-77660: Skip E2e: attach on previously attached volumes should work

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -13639,7 +13639,7 @@ var Annotations = map[string]string{
 
 	"[sig-storage] PersistentVolumes:vsphere [Feature:vsphere] should test that deleting the PV before the pod does not cause pod deletion to fail on vsphere volume detach": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[sig-storage] Pod Disks [Feature:StorageProvider] [Serial] attach on previously attached volumes should work": " [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[sig-storage] Pod Disks [Feature:StorageProvider] [Serial] attach on previously attached volumes should work": " [Disabled:Broken] [Suite:k8s]",
 
 	"[sig-storage] Pod Disks [Feature:StorageProvider] detach in a disrupted environment [Slow] [Disruptive] when node's API object is deleted": " [Serial] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -112,6 +112,8 @@ var (
 			`Netpol \[LinuxOnly\] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector`,
 
 			`Topology Hints should distribute endpoints evenly`,
+			// https://issues.redhat.com/browse/OCPBUGS-72531
+			`\[sig-storage\] Pod Disks \[Feature:StorageProvider\] \[Serial\] attach on previously attached volumes should work`,
 		},
 		// tests that need to be temporarily disabled while the rebase is in progress
 		"[Disabled:RebaseInProgress]": {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-77660
This test was never used and has been deprecated in versions 4.18 and later.
Continuation of https://github.com/openshift/kubernetes/pull/2566

Backporting on request of @davegord. CI will fail on this PR too, tests need to be vendored to origin. 
Cherry-picking from last PR was not possible due to merge conflicts.

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Skip e2e: attach on previously attached volumes should work
This test was never used and has been deprecated in versions 4.18 and later.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
https://github.com/openshift/kubernetes/pull/2618 must be merged first to fix unit tests and verify checks.
cc @davegord @jsafrane 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```