### PR TITLE
UPSTREAM: <carry>: integrate strict cpu reservation and workload partitioning

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -210,7 +210,8 @@ func (p *staticPolicy) validateState(logger logr.Logger, s state.State) error {
 	tmpDefaultCPUset := s.GetDefaultCPUSet()
 
 	allCPUs := p.topology.CPUDetails.CPUs()
-	if p.options.StrictCPUReservation {
+	strictCPUReservation := p.options.StrictCPUReservation || managed.IsEnabled()
+	if strictCPUReservation {
 		allCPUs = allCPUs.Difference(p.reservedCPUs)
 	}
 
@@ -233,7 +234,7 @@ func (p *staticPolicy) validateState(logger logr.Logger, s state.State) error {
 	// 1. Check if the reserved cpuset is not part of default cpuset because:
 	// - kube/system reserved have changed (increased) - may lead to some containers not being able to start
 	// - user tampered with file
-	if p.options.StrictCPUReservation {
+	if strictCPUReservation {
 		if !p.reservedCPUs.Intersection(tmpDefaultCPUset).IsEmpty() {
 			return fmt.Errorf("some of strictly reserved cpus: %q are present in defaultCpuSet: %q",
 				p.reservedCPUs.Intersection(tmpDefaultCPUset).String(), tmpDefaultCPUset.String())
@@ -241,7 +242,7 @@ func (p *staticPolicy) validateState(logger logr.Logger, s state.State) error {
 	} else {
 		// 2. This only applies when managed mode is disabled. Active workload partitioning feature
 		//    removes the reserved cpus from the default cpu mask on purpose.
-		if !managed.IsEnabled() && !p.reservedCPUs.Intersection(tmpDefaultCPUset).Equals(p.reservedCPUs) {
+		if !p.reservedCPUs.Intersection(tmpDefaultCPUset).Equals(p.reservedCPUs) {
 			return fmt.Errorf("not all reserved cpus: \"%s\" are present in defaultCpuSet: \"%s\"",
 				p.reservedCPUs.String(), tmpDefaultCPUset.String())
 		}
@@ -278,17 +279,9 @@ func (p *staticPolicy) validateState(logger logr.Logger, s state.State) error {
 		}
 	}
 	totalKnownCPUs = totalKnownCPUs.Union(tmpCPUSets...)
-	availableCPUs := p.topology.CPUDetails.CPUs()
-
-	// CPU (workload) partitioning removes reserved cpus
-	// from the default mask intentionally
-	if managed.IsEnabled() {
-		availableCPUs = availableCPUs.Difference(p.reservedCPUs)
-	}
-
-	if !totalKnownCPUs.Equals(availableCPUs) {
+	if !totalKnownCPUs.Equals(allCPUs) {
 		return fmt.Errorf("current set of available CPUs \"%s\" doesn't match with CPUs in state \"%s\"",
-			availableCPUs.String(), totalKnownCPUs.String())
+			allCPUs.String(), totalKnownCPUs.String())
 	}
 
 	return nil

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -1047,6 +1047,18 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 			expCSet:          cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
 		},
 		{
+			// context issue: https://issues.redhat.com/browse/OCPBUGS-77659
+			// start, record state before run any pods, restart empty
+			description:      "empty cpuset with StrictCPUReservationOption enabled, simulate restart from empty",
+			topo:             topoDualSocketHT,
+			numReservedCPUs:  2,
+			reserved:         cpuset.New(0, 1),
+			cpuPolicyOptions: map[string]string{StrictCPUReservationOption: "true"},
+			stAssignments:    state.ContainerCPUAssignments{},
+			stDefaultCPUSet:  cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expCSet:          cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
 			description:     "reserved cores 0 & 1 are not present in available cpuset",
 			topo:            topoDualSocketHT,
 			numReservedCPUs: 2,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Ensure interoperability between the workload partitioning feature and the strict-cpu-reservation cpumanager policy option

#### Which issue(s) this PR is related to:
https://issues.redhat.com/browse/OCPBUGS-77659

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Fix bug which cause kubelet fail to start if the strict-cpu-reservation is enabled with no pods to run
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved strict CPU reservation validation when recovering or restarting.
  - Ensured reserved CPUs are consistently excluded from the available CPU set.
  - Prevented invalid CPU allocation states when managed CPU mode is enabled.

- **Tests**
  - Added coverage confirming correct recovery with reserved CPUs already excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->