### PR TITLE
OCPBUGS-78504: unflake HPAConfigurableTolerance test

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -499,7 +499,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 	})
 })
 
-var _ = SIGDescribe(feature.HPAConfigurableTolerance, framework.WithFeatureGate(features.HPAConfigurableTolerance),
+var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAConfigurableTolerance),
 	"Horizontal pod autoscaling (configurable tolerance)", func() {
 		f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -499,7 +499,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 	})
 })
 
-var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAConfigurableTolerance),
+var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithFeatureGate(features.HPAConfigurableTolerance),
 	"Horizontal pod autoscaling (configurable tolerance)", func() {
 		f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -499,7 +499,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 	})
 })
 
-var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithFeatureGate(features.HPAConfigurableTolerance),
+var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), framework.WithFeatureGate(features.HPAConfigurableTolerance),
 	"Horizontal pod autoscaling (configurable tolerance)", func() {
 		f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -547,10 +547,10 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithFeatureGa
 		})
 
 		ginkgo.Describe("with small scale-up, large scale-down tolerances", func() {
-			ginkgo.It("should not scale", func(ctx context.Context) {
+			ginkgo.It("should scale up but should not scale down", func(ctx context.Context) {
 				ginkgo.By("setting up resource consumer and HPA")
 				initPods := 10
-				podCPURequest := 200
+				podCPURequest := 500
 				targetCPUUtilizationPercent := 60
 				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)
 				waitDeadline := maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -550,14 +550,17 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), f
 			ginkgo.It("should scale up but should not scale down", func(ctx context.Context) {
 				ginkgo.By("setting up resource consumer and HPA")
 				initPods := 10
-				podCPURequest := 500
+				podCPURequest := 200
 				targetCPUUtilizationPercent := 60
+				// Compute initial load for 10 pods.
 				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)
 				waitDeadline := maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
 
+				// Pass 0 as initCPUTotal so the regular ConsumeCPU goroutine stays idle.
+				// We drive load exclusively via ConsumeCPUPerPod to guarantee even distribution.
 				rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 					hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
-					initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+					0, 0, 0, int64(podCPURequest), 200,
 					f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 					nil)
 				ginkgo.DeferCleanup(rc.CleanUp)
@@ -573,8 +576,14 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), f
 				ginkgo.By("waiting for deployment to start initial pods")
 				rc.WaitForReplicas(ctx, initPods, waitDeadline)
 
+				// Set initial stable load using even per-pod distribution and wait for
+				// HPA to observe it before triggering scale-up. This ensures HPA has a
+				// baseline measurement before we push load above the scale-up tolerance.
+				rc.ConsumeCPUPerPod(initCPUUsageTotal)
+				rc.EnsureDesiredReplicasInRange(ctx, initPods, initPods, maxHPAReactionTime+maxResourceConsumerDelay, hpa.Name)
+
 				ginkgo.By("trying to trigger scale up to 11 replicas")
-				rc.ConsumeCPU(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))
 
 				ginkgo.By("waiting for replicas to scale up")
 				waitStart := time.Now()
@@ -583,12 +592,10 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), f
 				framework.Logf("time waited for scale up: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
 
-				// Increase resource usage to match 12 replicas. The difference is less
-				// than 10% (the default tolerance), but it should scale up anyway thanks
-				// to the small scale-up custom tolerance.
-
+				// Increase to 12 replicas. Difference is less than 10% default tolerance
+				// but should still scale up due to the small (2%) custom scale-up tolerance.
 				ginkgo.By("trying to trigger scale up to 12 replicas")
-				rc.ConsumeCPU(usageForReplicasWithRequest(12, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(12, podCPURequest, targetCPUUtilizationPercent))
 
 				ginkgo.By("waiting for replicas to scale up")
 				waitStart = time.Now()
@@ -597,12 +604,11 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), f
 				framework.Logf("time waited for scale up: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
 
-				// Decrease resource usage to match 10 replicas. Should not scale down
-				// because of the large scale-down custom tolerance.
-
+				// Drop load to 10-replica level. Should NOT scale down because the
+				// difference is within the large (30%) custom scale-down tolerance.
 				ginkgo.By("triggering scale down by lowering consumption")
 				waitStart = time.Now()
-				rc.ConsumeCPU(usageForReplicasWithRequest(10, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(10, podCPURequest, targetCPUUtilizationPercent))
 
 				rc.EnsureDesiredReplicasInRange(ctx, 12, 12, waitDeadline, hpa.Name)
 				timeWaited = time.Since(waitStart)
@@ -610,6 +616,7 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), f
 				ginkgo.By("verifying time waited for a scale down")
 				framework.Logf("time waited for scale down: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically(">", waitDeadline), "waited %s, wanted to wait more than %s", timeWaited, waitDeadline)
+
 			})
 		})
 	})

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -127,6 +127,8 @@ type ResourceConsumer struct {
 	requestSizeCustomMetric  int
 	sidecarStatus            SidecarStatusType
 	sidecarType              SidecarWorkloadType
+	cpuPerPod                chan int
+	stopCPUPerPod            chan int
 }
 
 // NewDynamicResourceConsumer is a wrapper to create a new dynamic ResourceConsumer
@@ -217,6 +219,8 @@ func newResourceConsumer(ctx context.Context, name, nsName string, kind schema.G
 		stopCPU:                  make(chan int),
 		stopMem:                  make(chan int),
 		stopCustomMetric:         make(chan int),
+		cpuPerPod:                make(chan int),
+		stopCPUPerPod:            make(chan int),
 		consumptionTimeInSeconds: consumptionTimeInSeconds,
 		sleepTime:                time.Duration(consumptionTimeInSeconds) * time.Second,
 		requestSizeInMillicores:  requestSizeInMillicores,
@@ -232,6 +236,7 @@ func newResourceConsumer(ctx context.Context, name, nsName string, kind schema.G
 	rc.ConsumeMem(initMemoryTotal)
 	go rc.makeConsumeCustomMetric(ctx)
 	rc.ConsumeCustomMetric(initCustomMetric)
+	go rc.makeConsumeCPUPerPodRequests(ctx)
 	return rc
 }
 
@@ -436,6 +441,117 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta i
 	framework.ExpectNoError(err)
 }
 
+/*
+ConsumeCPUPerPod sends CPU load directly to each consumer pod via the
+Kubernetes pod proxy API, bypassing kube-proxy's non-deterministic load
+balancing. millicoresTotal is divided evenly across all running pods,
+guaranteeing each pod receives an equal share regardless of cluster network config.
+*/
+func (rc *ResourceConsumer) ConsumeCPUPerPod(millicoresTotal int) {
+	framework.Logf("RC %s: consume %v millicores in total (evenly distributed per pod)", rc.name, millicoresTotal)
+	rc.cpuPerPod <- millicoresTotal
+}
+
+func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
+	defer ginkgo.GinkgoRecover()
+	rc.stopWaitGroup.Add(1)
+	defer rc.stopWaitGroup.Done()
+	tick := time.After(time.Duration(0))
+	millicoresTotal := 0
+	for {
+		select {
+		case millicoresTotal = <-rc.cpuPerPod:
+			if millicoresTotal != 0 {
+				framework.Logf("RC %s: setting per-pod CPU to %v millicores total", rc.name, millicoresTotal)
+			} else {
+				framework.Logf("RC %s: disabling per-pod CPU consumption", rc.name)
+			}
+		case <-tick:
+			if millicoresTotal != 0 {
+				framework.Logf("RC %s: sending per-pod CPU request: %d millicores total", rc.name, millicoresTotal)
+				rc.sendConsumeCPUPerPodRequest(ctx, millicoresTotal)
+			}
+			tick = time.After(rc.sleepTime)
+		case <-ctx.Done():
+			framework.Logf("RC %s: stopping per-pod CPU consumer: %v", rc.name, ctx.Err())
+			return
+		case <-rc.stopCPUPerPod:
+			framework.Logf("RC %s: stopping per-pod CPU consumer", rc.name)
+			return
+		}
+	}
+}
+
+// sendConsumeCPUPerPodRequest distributes CPU load evenly across all running
+// pods by sending requests directly via the Kubernetes pod proxy API. This
+// bypasses kube-proxy load balancing, guaranteeing each pod receives exactly
+// its share. Falls back to sendConsumeCPURequest if pod listing fails.
+func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, millicoresTotal int) {
+	pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("name=%s", rc.name),
+	})
+	if err != nil {
+		framework.Logf("ConsumeCPUPerPod: failed to list pods: %v, falling back to service proxy", err)
+		rc.sendConsumeCPURequest(ctx, millicoresTotal)
+		return
+	}
+
+	var readyPods []string
+	for i := range pods.Items {
+		if pods.Items[i].Status.Phase == v1.PodRunning {
+			readyPods = append(readyPods, pods.Items[i].Name)
+		}
+	}
+	if len(readyPods) == 0 {
+		framework.Logf("ConsumeCPUPerPod: no running pods, falling back to service proxy")
+		rc.sendConsumeCPURequest(ctx, millicoresTotal)
+		return
+	}
+
+	perPodMillicores := millicoresTotal / len(readyPods)
+	if perPodMillicores == 0 {
+		perPodMillicores = 1
+	}
+
+	framework.Logf("ConsumeCPUPerPod: distributing %d millicores across %d pods (%d per pod)",
+		millicoresTotal, len(readyPods), perPodMillicores)
+
+	var wg sync.WaitGroup
+	for _, podName := range readyPods {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			// Pod proxy URL: /api/v1/namespaces/{ns}/pods/{podname}:{port}/proxy/{path}
+			// Both service and pod proxy support the name:port format. Without an explicit
+			// port the API server defaults to port 80, but resource-consumer listens on
+			// targetPort (8080), so the port must be specified.
+			err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+				_, podErr := rc.clientSet.CoreV1().RESTClient().Post().
+					Resource("pods").
+					Namespace(rc.nsName).
+					Name(fmt.Sprintf("%s:%d", name, targetPort)).
+					SubResource("proxy").
+					Suffix("ConsumeCPU").
+					Param("millicores", strconv.Itoa(perPodMillicores)).
+					Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
+					DoRaw(ctx)
+				if podErr != nil {
+					framework.Logf("ConsumeCPUPerPod: error sending to pod %s: %v", name, podErr)
+					return podErr
+				}
+				return nil
+			}).WithTimeout(serviceInitializationTimeout).WithPolling(serviceInitializationInterval).Should(gomega.Succeed())
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				framework.Logf("ConsumeCPUPerPod: giving up on pod %s: %v", name, err)
+			}
+		}(podName)
+	}
+	wg.Wait()
+}
+
 // GetReplicas get the replicas
 func (rc *ResourceConsumer) GetReplicas(ctx context.Context) (int, error) {
 	switch rc.kind {
@@ -527,6 +643,7 @@ func (rc *ResourceConsumer) Pause() {
 	rc.stopCPU <- 0
 	rc.stopMem <- 0
 	rc.stopCustomMetric <- 0
+	rc.stopCPUPerPod <- 0
 	rc.stopWaitGroup.Wait()
 }
 
@@ -536,6 +653,7 @@ func (rc *ResourceConsumer) Resume(ctx context.Context) {
 	go rc.makeConsumeCPURequests(ctx)
 	go rc.makeConsumeMemRequests(ctx)
 	go rc.makeConsumeCustomMetric(ctx)
+	go rc.makeConsumeCPUPerPodRequests(ctx)
 }
 
 // CleanUp clean up the background goroutines responsible for consuming resources.
@@ -544,6 +662,7 @@ func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	close(rc.stopCPU)
 	close(rc.stopMem)
 	close(rc.stopCustomMetric)
+	close(rc.stopCPUPerPod)
 	rc.stopWaitGroup.Wait()
 	// Wait some time to ensure all child goroutines are finished.
 	time.Sleep(10 * time.Second)


### PR DESCRIPTION
This PR is a cherry-pick of 4 different PRs that were merged upstream in relation to unflaking the `HPAConfigurableTolerance` test.

These are:
1. `https://github.com/kubernetes/kubernetes/pull/137090`
2. `https://github.com/kubernetes/kubernetes/pull/137134`
3. `https://github.com/kubernetes/kubernetes/pull/137168`
4. `https://github.com/kubernetes/kubernetes/pull/137612`

Supersedes: https://github.com/openshift/kubernetes/pull/2628