### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Register OpenShift cloud providers in k8s-tests-ext

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/provider.go
+++ b/openshift-hack/cmd/k8s-tests-ext/provider.go
@@ -32,6 +32,29 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
 )
 
+func init() {
+	// Register OpenShift-specific cloud providers that are not part of upstream
+	// Kubernetes. Without these registrations, k8s-tests-ext crashes with
+	// "Unknown provider" when openshift-tests passes a provider like "ibmcloud".
+	// These providers don't need any special setup for running upstream kube
+	// tests, so a NullProvider is sufficient.
+	for _, name := range []string{
+		"baremetal",
+		"ovirt",
+		"kubevirt",
+		"alibabacloud",
+		"nutanix",
+		"ibmcloud",
+		"external",
+	} {
+		func(n string) {
+			framework.RegisterProvider(n, func() (framework.ProviderInterface, error) {
+				return framework.NullProvider{}, nil
+			})
+		}(name)
+	}
+}
+
 // Initialize a good enough test context for generating e2e tests,
 // so they can be listed and filtered.
 func initializeCommonTestFramework() error {


### PR DESCRIPTION
## Summary

- Register all OpenShift-specific cloud providers (baremetal, ovirt, kubevirt, alibabacloud, nutanix, ibmcloud, external) as NullProviders in k8s-tests-ext
- Fixes mass test failures (3296 blocking failures) on IBM Cloud e2e jobs caused by `Unknown provider "ibmcloud"` crash in every test process

## Root Cause

After openshift/origin#30786 ("[STOR-2893](https://redhat.atlassian.net/browse/STOR-2893): add storage BYOK feature tests", merged March 23) correctly added `ibmcloud` to the provider switch in `openshift-tests`, the provider name is now properly passed through to `k8s-tests-ext` via `TEST_PROVIDER`. Previously, `ibmcloud` wasn't in the switch, so `openshift-tests` fell back to `skeleton` which is always registered.

However, `k8s-tests-ext` only registers upstream Kubernetes providers (aws, azure, gce, kubemark, openstack, vsphere) via the `_ "k8s.io/kubernetes/test/e2e"` import chain. When `framework.AfterReadingAllFlags()` calls `SetupProviderConfig("ibmcloud")`, it fails with "Unknown provider" and `Exit(1)`, crashing every test process with 0s duration and epoch-zero timestamps.

## Fix

Register all OpenShift-specific providers as `NullProvider` in `k8s-tests-ext`'s `init()`. These providers don't need special setup for upstream kube e2e tests — the `NullProvider` is sufficient (same base type used by the `skeleton` and `local` providers).

This also prevents the same issue from occurring in the future if other OpenShift platforms (baremetal, nutanix, etc.) are similarly added to origin's provider switch.

## Evidence

- **Failing job** (March 27): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_installer/10268/pull-ci-openshift-installer-main-e2e-ibmcloud-ovn/2037396943243579392
  - 3296 blocking failures, all with `(0s) 0001-01-01T00:00:00` timestamps
  - Every test process logs: `E0327 test_context.go:584] Unknown provider "ibmcloud". The following providers are known: aws azure gce kubemark local openstack skeleton vsphere`
- **Passing job** (March 17, before origin#30786): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_installer/10268/pull-ci-openshift-installer-main-e2e-ibmcloud-ovn/2034026036072550400
  - Provider was `skeleton` (visible in skip messages: `not skeleton`)

## Test plan

- [x] Verify `k8s-tests-ext` compiles successfully
- [ ] Run IBM Cloud e2e job and confirm tests no longer crash with "Unknown provider"

🤖 Generated with [Claude Code](https://claude.com/claude-code)