### PR TITLE
OCPBUGS-78576: Update the csi-driver-host-path version to 1.17.1

### DIFF
--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -75,6 +75,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/drivers/proxy"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	"k8s.io/kubernetes/test/utils/image"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
@@ -451,12 +452,6 @@ func (d *Driver) SetUp(nodes *Nodes, driverResources map[string]resourceslice.Dr
 		}
 	}
 
-	manifests := []string{
-		// The code below matches the content of this manifest (ports,
-		// container names, etc.).
-		"test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml",
-	}
-
 	// Create service account and corresponding RBAC rules.
 	d.serviceAccountName = "dra-kubelet-plugin-" + d.Name + d.InstanceSuffix + "-service-account"
 	content := example.PluginPermissions
@@ -464,16 +459,52 @@ func (d *Driver) SetUp(nodes *Nodes, driverResources map[string]resourceslice.Dr
 	content = strings.ReplaceAll(content, "dra-kubelet-plugin", "dra-kubelet-plugin-"+d.Name+d.InstanceSuffix)
 	d.createFromYAML(ctx, []byte(content), d.f.Namespace.Name)
 
+	// Figure out which hostpathplugin to use: basically the latest one
+	// from the test/e2e/testing-manifests/storage-csi manifests. That is
+	// where SIG Storage maintains the versions of the hostpath image which
+	// are part of Kubernetes E2E testing. test/utils/image parses those files.
+	//
+	// We piggy-back on that instead of controlling the version ourselves
+	// because it reduces effort, at the risk of unexpected
+	// breakage. Another benefit is that -list-images and registry patching
+	// via test/utils/image + KUBE_TEST_REPO_LIST work.
+	hostPathImage := "registry.k8s.io/sig-storage/hostpathplugin"
+	hostPathVersion := ""
+	for _, config := range image.GetOriginalImageConfigs() {
+		parts := strings.SplitN(config.GetE2EImage(), ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		image, version := parts[0], parts[1]
+		if image != hostPathImage {
+			continue
+		}
+		// "Dumb" string comparison is good enough for e.g. v1.16.1 < v1.17.0.
+		// It seems unlikely that any major/patch will need more than one digit
+		// or that version grow beyond 99.
+		if hostPathVersion == "" || hostPathVersion < version {
+			hostPathVersion = version
+		}
+	}
+	origImageURL := hostPathImage + ":" + hostPathVersion
+	patchedImageURL, err := image.ReplaceRegistryInImageURL(origImageURL)
+	framework.ExpectNoError(err, "look up E2E image")
+
 	// Using a ReplicaSet instead of a DaemonSet has the advantage that we can control
 	// the lifecycle explicitly, in particular run two pods per node long enough to
 	// run checks.
+	manifests := []string{
+		// The code below matches the content of this manifest (ports,
+		// container names, etc.).
+		"test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml",
+	}
 	instanceKey := "app.kubernetes.io/instance"
 	rsName := ""
 	numNodes := int32(len(nodes.NodeNames))
 	pluginDataDirectoryPath := path.Join(framework.TestContext.KubeletRootDir, "plugins", d.Name)
 	registrarDirectoryPath := path.Join(framework.TestContext.KubeletRootDir, "plugins_registry")
 	instanceName := d.Name + d.InstanceSuffix
-	err := utils.CreateFromManifests(ctx, d.f, d.f.Namespace, func(item interface{}) error {
+	err = utils.CreateFromManifests(ctx, d.f, d.f.Namespace, func(item interface{}) error {
 		switch item := item.(type) {
 		case *appsv1.ReplicaSet:
 			item.Name += d.NameSuffix + d.InstanceSuffix
@@ -481,6 +512,7 @@ func (d *Driver) SetUp(nodes *Nodes, driverResources map[string]resourceslice.Dr
 			item.Spec.Replicas = &numNodes
 			item.Spec.Selector.MatchLabels[instanceKey] = instanceName
 			item.Spec.Template.Labels[instanceKey] = instanceName
+			item.Spec.Template.Spec.Containers[0].Image = patchedImageURL
 			item.Spec.Template.Spec.ServiceAccountName = d.serviceAccountName
 			item.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels[instanceKey] = instanceName
 			item.Spec.Template.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{

--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: pause
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin # Version and actual registry get patched in during deployment.
           command:
             - /bin/sh
             - -c

--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: pause
-          image: registry.k8s.io/sig-storage/hostpathplugin # Version and actual registry get patched in during deployment.
+          image: registry.k8s.io/sig-storage/hostpathplugin:to-be-replaced # Version and actual registry get patched in during deployment.
           command:
             - /bin/sh
             - -c

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -237,7 +237,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
           args:
             - "--drivername=mock.storage.k8s.io"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
           args:
             - -v=5
             - -nodeid=$(KUBE_NODE_NAME)


### PR DESCRIPTION
This is a replacement for https://github.com/openshift/kubernetes/pull/2629, with two upstream PRs:

#136913: Update the csi-driver-host-path version to 1.17.1 in the CSI driver manifests
#136337: Update DRA tests to read csi-driver-host-path from the CSI driver manifests instead of hardcoding its own version.