### PR TITLE
[release-4.12] OCPBUGS-77661: Skip E2e: attach on previously attached volumes should work

### DIFF
--- a/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
+++ b/openshift-hack/e2e/annotate/generated/zz_generated.annotations.go
@@ -13681,7 +13681,7 @@ var Annotations = map[string]string{
 
 	"[sig-storage] PersistentVolumes:vsphere [Feature:vsphere] should test that deleting the PV before the pod does not cause pod deletion to fail on vsphere volume detach": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[sig-storage] Pod Disks [Feature:StorageProvider] [Serial] attach on previously attached volumes should work": " [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[sig-storage] Pod Disks [Feature:StorageProvider] [Serial] attach on previously attached volumes should work": " [Disabled:Broken] [Suite:k8s]",
 
 	"[sig-storage] Pod Disks [Feature:StorageProvider] detach in a disrupted environment [Slow] [Disruptive] when node's API object is deleted": " [Serial] [Suite:k8s]",
 

--- a/openshift-hack/e2e/annotate/rules.go
+++ b/openshift-hack/e2e/annotate/rules.go
@@ -108,6 +108,9 @@ var (
 			`Netpol \[LinuxOnly\] NetworkPolicy between server and client using UDP should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector`,
 
 			`Topology Hints should distribute endpoints evenly`,
+
+			// https://issues.redhat.com/browse/OCPBUGS-72531
+			`\[sig-storage\] Pod Disks \[Feature:StorageProvider\] \[Serial\] attach on previously attached volumes should work`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
Similar to https://github.com/openshift/kubernetes/pull/2606

https://issues.redhat.com/browse/OCPBUGS-77661
This test was never used and has been deprecated in versions 4.18 and later.
Continuation of https://github.com/openshift/kubernetes/pull/2566

CI will fail on this PR too, tests need to be vendored to origin.
Cherry-picking from last PR was not possible due to merge conflicts.

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Skip e2e: attach on previously attached volumes should work
This test was never used and has been deprecated in versions 4.18 and later.

#### Which issue(s) this PR is related to:
N/A

#### Notes for reviewer
https://github.com/openshift/kubernetes/pull/2619 must be merged first to fix unit tests and verify checks.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```