### PR TITLE
STOR-2963: Save SELinuxWarningController upgradeability to a ConfigMap

### DIFF
--- a/pkg/controller/volume/selinuxwarning/cache/openshift_patch.go
+++ b/pkg/controller/volume/selinuxwarning/cache/openshift_patch.go
@@ -1,0 +1,18 @@
+package cache
+
+type ConflictCounter interface {
+	GetConflictCount() int
+}
+
+var _ ConflictCounter = &volumeCache{}
+
+func (c *volumeCache) GetConflictCount() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	conflictCount := 0
+	for _, conflicts := range c.conflicts {
+		conflictCount += len(conflicts)
+	}
+	return conflictCount
+}

--- a/pkg/controller/volume/selinuxwarning/openshift_upgrade_controller.go
+++ b/pkg/controller/volume/selinuxwarning/openshift_upgrade_controller.go
@@ -1,0 +1,102 @@
+package selinuxwarning
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	applyconfigurationscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller/volume/selinuxwarning/cache"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+const (
+	checkInterval      = 30 * time.Second
+	configMapNamespace = "openshift-config"
+	configMapName      = "selinux-conflicts"
+	fieldManager       = "selinux-conflicts-reporter"
+)
+
+type SELinuxConflictsReporterController struct {
+	kubeClient        clientset.Interface
+	conflictCounter   cache.ConflictCounter
+	previousConflicts metav1.ConditionStatus
+}
+
+func NewSELinuxConflictsReporterController(kubeClient clientset.Interface, volumeCache cache.VolumeCache) *SELinuxConflictsReporterController {
+	return &SELinuxConflictsReporterController{
+		kubeClient: kubeClient,
+		// Ugly retype to avoid more carry patches in Kubernetes code.
+		// We added ConflictCounter in cache/openshift_patch.go,
+		// therefore we know that VolumeCache implements it.
+		conflictCounter:   volumeCache.(cache.ConflictCounter),
+		previousConflicts: metav1.ConditionUnknown,
+	}
+}
+
+func (c *SELinuxConflictsReporterController) Run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountGAReadiness) {
+		logger.V(2).Info("SELinuxMountGAReadiness feature gate is disabled, not starting OpenShift SELinux conflicts reporter")
+		return
+	}
+	logger.V(2).Info("Starting OpenShift SELinux conflicts reporter")
+	timer := time.NewTimer(checkInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			c.reportSELinuxConflicts(ctx)
+			timer.Reset(checkInterval)
+		}
+	}
+}
+
+func (c *SELinuxConflictsReporterController) reportSELinuxConflicts(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Checking for SELinux conflicts")
+
+	currentConflicts := c.getConflicts(logger)
+	if currentConflicts == c.previousConflicts {
+		logger.V(4).Info("SELinux conflict status did not change since last check")
+		return
+	}
+	logger.V(4).Info("SELinux conflict status changed, updating the config map")
+	if err := c.applySELinuxConflictsConfigMap(ctx, currentConflicts); err != nil {
+		logger.Error(err, "Error saving conflicts config map")
+		// To keep it simple: no exponential backoff try again in the next iteration.
+		return
+	}
+	logger.V(2).Info("SELinux conflict updated", "Conflicts", currentConflicts)
+	c.previousConflicts = currentConflicts
+}
+
+func (c *SELinuxConflictsReporterController) getConflicts(logger klog.Logger) metav1.ConditionStatus {
+	conflictsCount := c.conflictCounter.GetConflictCount()
+	if conflictsCount > 0 {
+		logger.V(4).Info("Found SELinux-conflicting pods", "conflictsCount", conflictsCount)
+		return metav1.ConditionTrue
+	}
+	logger.V(4).Info("Found no SELinux-conflicting pods")
+	return metav1.ConditionFalse
+}
+
+func (c *SELinuxConflictsReporterController) applySELinuxConflictsConfigMap(ctx context.Context, conflictsPresent metav1.ConditionStatus) error {
+	cm := applyconfigurationscorev1.ConfigMap(configMapName, configMapNamespace).
+		WithData(map[string]string{
+			"conflictsPresent": string(conflictsPresent),
+		}).WithAnnotations(map[string]string{
+		"Description": "This config map is used to report presence of SELinux conflicts from kube-controller-manager to storage Upgradeable condition in OpenShift 5.0",
+	})
+	_, err := c.kubeClient.CoreV1().ConfigMaps(configMapNamespace).Apply(ctx, cm, metav1.ApplyOptions{FieldManager: fieldManager, Force: true})
+	if err != nil {
+		return fmt.Errorf("error applying config map %s: %w", configMapName, err)
+	}
+	return nil
+}

--- a/pkg/controller/volume/selinuxwarning/openshift_upgrade_controller_test.go
+++ b/pkg/controller/volume/selinuxwarning/openshift_upgrade_controller_test.go
@@ -1,0 +1,336 @@
+package selinuxwarning
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
+	volumecache "k8s.io/kubernetes/pkg/controller/volume/selinuxwarning/cache"
+)
+
+var _ volumecache.ConflictCounter = &fakeVolumeCache{}
+
+func (f *fakeVolumeCache) GetConflictCount() int {
+	count := 0
+	for _, conflicts := range f.conflictsToSend {
+		count += len(conflicts)
+	}
+	return count
+}
+
+func TestReportSELinuxConflicts(t *testing.T) {
+	cmTrue := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: map[string]string{
+			"conflictsPresent": "True",
+		},
+	}
+	cmFalse := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: map[string]string{
+			"conflictsPresent": "False",
+		},
+	}
+	tests := []struct {
+		name            string
+		conflicts       map[cache.ObjectName][]volumecache.Conflict
+		initialConflict metav1.ConditionStatus
+		// If set, the ConfigMap already exists before the test runs.
+		existingConfigMap *v1.ConfigMap
+
+		expectConfigMapData map[string]string
+		// If true, no ConfigMap write is expected (status didn't change).
+		expectNoWrite bool
+	}{
+		{
+			name:            "no conflicts, create the config map",
+			initialConflict: metav1.ConditionUnknown,
+			conflicts:       nil,
+			expectConfigMapData: map[string]string{
+				"conflictsPresent": "False",
+			},
+		},
+		{
+			name:            "conflicts present, create the config map",
+			initialConflict: metav1.ConditionUnknown,
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{
+				{Namespace: "ns1", Name: "pod1"}: {
+					{
+						PropertyName:       "SELinuxLabel",
+						EventReason:        "SELinuxLabelConflict",
+						Pod:                cache.ObjectName{Namespace: "ns1", Name: "pod1"},
+						PropertyValue:      ":::s0:c1,c2",
+						OtherPod:           cache.ObjectName{Namespace: "ns1", Name: "pod2"},
+						OtherPropertyValue: ":::s0:c98,c99",
+					},
+				},
+			},
+			expectConfigMapData: map[string]string{
+				"conflictsPresent": "True",
+			},
+		},
+		{
+			name:              "no conflicts, status was already False",
+			conflicts:         nil,
+			initialConflict:   metav1.ConditionFalse,
+			existingConfigMap: cmFalse,
+			expectNoWrite:     true,
+		},
+		{
+			name: "conflicts present, status was already True",
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{
+				{Namespace: "ns1", Name: "pod1"}: {
+					{
+						PropertyName: "SELinuxLabel",
+						EventReason:  "SELinuxLabelConflict",
+					},
+				},
+			},
+			initialConflict:   metav1.ConditionTrue,
+			existingConfigMap: cmTrue,
+			expectNoWrite:     true,
+		},
+		{
+			name:              "no conflicts, status changes from True to False",
+			conflicts:         nil,
+			initialConflict:   metav1.ConditionTrue,
+			existingConfigMap: cmTrue,
+			expectConfigMapData: map[string]string{
+				"conflictsPresent": "False",
+			},
+		},
+		{
+			name: "conflicts appear, status changes from False to True",
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{
+				{Namespace: "ns1", Name: "pod1"}: {
+					{
+						PropertyName: "SELinuxLabel",
+						EventReason:  "SELinuxLabelConflict",
+					},
+				},
+			},
+			initialConflict:   metav1.ConditionFalse,
+			existingConfigMap: cmFalse,
+			expectConfigMapData: map[string]string{
+				"conflictsPresent": "True",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			var fakeClient *fake.Clientset
+			if tt.existingConfigMap != nil {
+				fakeClient = fake.NewClientset(tt.existingConfigMap)
+			} else {
+				fakeClient = fake.NewClientset()
+			}
+
+			labelCache := &fakeVolumeCache{
+				conflictsToSend: tt.conflicts,
+			}
+
+			c := &SELinuxConflictsReporterController{
+				kubeClient:        fakeClient,
+				conflictCounter:   labelCache,
+				previousConflicts: tt.initialConflict,
+			}
+
+			c.reportSELinuxConflicts(ctx)
+
+			if tt.expectNoWrite {
+				cm, err := fakeClient.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+				if tt.existingConfigMap != nil {
+					// The ConfigMap should still exist unchanged.
+					if err != nil {
+						t.Fatalf("expected ConfigMap to exist, got error: %v", err)
+					}
+					if cm.Data["conflictsPresent"] != tt.existingConfigMap.Data["conflictsPresent"] {
+						t.Errorf("ConfigMap data changed unexpectedly: got %v, want %v", cm.Data, tt.existingConfigMap.Data)
+					}
+				} else {
+					if err == nil || !apierrors.IsNotFound(err) {
+						t.Fatalf("expected ConfigMap to not exist, got error: %v", err)
+					}
+				}
+				return
+			}
+
+			cm, err := fakeClient.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get ConfigMap: %v", err)
+			}
+			for key, expectedValue := range tt.expectConfigMapData {
+				if cm.Data[key] != expectedValue {
+					t.Errorf("ConfigMap data[%q] = %q, want %q", key, cm.Data[key], expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestApplySELinuxConflictsConfigMap(t *testing.T) {
+	cmTrue := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: map[string]string{
+			"conflictsPresent": "True",
+		},
+	}
+	cmFalse := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: map[string]string{
+			"conflictsPresent": "False",
+		},
+	}
+	tests := []struct {
+		name              string
+		existingConfigMap *v1.ConfigMap
+		conflictsPresent  metav1.ConditionStatus
+		expectData        map[string]string
+	}{
+		{
+			name:             "creates ConfigMap when it does not exist",
+			conflictsPresent: metav1.ConditionTrue,
+			expectData: map[string]string{
+				"conflictsPresent": "True",
+			},
+		},
+		{
+			name:              "patches ConfigMap when it already exists",
+			existingConfigMap: cmFalse,
+			conflictsPresent:  metav1.ConditionTrue,
+			expectData: map[string]string{
+				"conflictsPresent": string(metav1.ConditionTrue),
+			},
+		},
+		{
+			name:              "patches ConfigMap from True to False",
+			existingConfigMap: cmTrue,
+			conflictsPresent:  metav1.ConditionFalse,
+			expectData: map[string]string{
+				"conflictsPresent": "False",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var fakeClient *fake.Clientset
+			if tt.existingConfigMap != nil {
+				fakeClient = fake.NewClientset(tt.existingConfigMap)
+			} else {
+				fakeClient = fake.NewClientset()
+			}
+
+			c := &SELinuxConflictsReporterController{
+				kubeClient: fakeClient,
+				// the rest of the struct is not used in this test
+			}
+
+			err := c.applySELinuxConflictsConfigMap(ctx, tt.conflictsPresent)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			cm, err := fakeClient.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get ConfigMap: %v", err)
+			}
+			for key, expectedValue := range tt.expectData {
+				if cm.Data[key] != expectedValue {
+					t.Errorf("ConfigMap data[%q] = %q, want %q", key, cm.Data[key], expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestGetConflicts(t *testing.T) {
+	tests := []struct {
+		name      string
+		conflicts map[cache.ObjectName][]volumecache.Conflict
+		expected  metav1.ConditionStatus
+	}{
+		{
+			name:      "no conflicts returns False",
+			conflicts: nil,
+			expected:  metav1.ConditionFalse,
+		},
+		{
+			name:      "empty conflicts returns False",
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{},
+			expected:  metav1.ConditionFalse,
+		},
+		{
+			name: "one conflict returns True",
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{
+				{Namespace: "ns1", Name: "pod1"}: {
+					{
+						PropertyName:       "SELinuxLabel",
+						EventReason:        "SELinuxLabelConflict",
+						Pod:                cache.ObjectName{Namespace: "ns1", Name: "pod1"},
+						PropertyValue:      ":::s0:c1,c2",
+						OtherPod:           cache.ObjectName{Namespace: "ns1", Name: "pod2"},
+						OtherPropertyValue: ":::s0:c98,c99",
+					},
+				},
+			},
+			expected: metav1.ConditionTrue,
+		},
+		{
+			name: "multiple conflicts returns True",
+			conflicts: map[cache.ObjectName][]volumecache.Conflict{
+				{Namespace: "ns1", Name: "pod1"}: {
+					{PropertyName: "SELinuxLabel"},
+				},
+				{Namespace: "ns1", Name: "pod2"}: {
+					{PropertyName: "SELinuxLabel"},
+					{PropertyName: "SELinuxChangePolicy"},
+				},
+			},
+			expected: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			logger := ktesting.NewLogger(t, ktesting.NewConfig())
+			_ = ctx
+
+			labelCache := &fakeVolumeCache{
+				conflictsToSend: tt.conflicts,
+			}
+
+			c := &SELinuxConflictsReporterController{
+				conflictCounter: labelCache,
+			}
+
+			got := c.getConflicts(logger)
+			if got != tt.expected {
+				t.Errorf("getConflicts() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -381,6 +381,13 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 			wait.UntilWithContext(ctx, c.runWorker, time.Second)
 		})
 	}
+
+	seLinuxConflictsReporterController := NewSELinuxConflictsReporterController(c.kubeClient, c.labelCache)
+	wg.Go(func() {
+		defer utilruntime.HandleCrash()
+		seLinuxConflictsReporterController.Run(ctx)
+	})
+
 	<-ctx.Done()
 }
 

--- a/pkg/features/openshift_features.go
+++ b/pkg/features/openshift_features.go
@@ -9,6 +9,7 @@ var (
 	RouteExternalCertificate        featuregate.Feature = "RouteExternalCertificate"
 	MinimumKubeletVersion           featuregate.Feature = "MinimumKubeletVersion"
 	StoragePerformantSecurityPolicy featuregate.Feature = "StoragePerformantSecurityPolicy"
+	SELinuxMountGAReadiness         featuregate.Feature = "SELinuxMountGAReadiness"
 )
 
 // registerOpenshiftFeatures injects openshift-specific feature gates
@@ -25,8 +26,13 @@ func registerOpenshiftFeatures() {
 	defaultVersionedKubernetesFeatureGates[StoragePerformantSecurityPolicy] = featuregate.VersionedSpecs{
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 	}
+	// Introduced in 5.0
+	defaultVersionedKubernetesFeatureGates[SELinuxMountGAReadiness] = featuregate.VersionedSpecs{
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	}
 
 	defaultKubernetesFeatureGateDependencies[RouteExternalCertificate] = []featuregate.Feature{}
 	defaultKubernetesFeatureGateDependencies[MinimumKubeletVersion] = []featuregate.Feature{}
 	defaultKubernetesFeatureGateDependencies[StoragePerformantSecurityPolicy] = []featuregate.Feature{}
+	defaultKubernetesFeatureGateDependencies[SELinuxMountGAReadiness] = []featuregate.Feature{}
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -564,6 +564,10 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(storageGroup).Resources("csidrivers").RuleOrDie(),
+				// RBAC cannot restrict `create` by resourceName, so adding a generic rule to allow creation of any ConfigMap
+				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
+				// ... and allow patching only of the selinux-conflicts ConfigMap
+				rbacv1helpers.NewRule("patch").Groups(legacyGroup).Resources("configmaps").Names("selinux-conflicts").RuleOrDie(),
 			},
 		})
 	}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1406,6 +1406,20 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resourceNames:
+    - selinux-conflicts
+    resources:
+    - configmaps
+    verbs:
+    - patch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
KCM's SELinuxWarningController knows how many Pods could get broken by upgrade to Kubernetes 1.37 / a version where `SELinuxMount` feature gate is enabled.

Add a carry patch to KCM to store the information into a ConfigMap `openshift-config/selinux-conflicts`.
cluster-storage-operator can read it from there and mark itself `Upgradeable: false`.

See https://github.com/openshift/enhancements/pull/2010 for details.

* The first commit is a clean upstream cherry-pick of few PRs that are / will be available in 1.36.something.
* The second patch is the actual `<carry>`. Written in a way that minimizes a possibility of a conflict with future  Kubernetes patches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SELinux conflict monitoring and reporting now available in volume controller, reporting status every 30 seconds.
  * New `SELinuxMountGAReadiness` feature gate added.

* **Chores**
  * Updated RBAC permissions to support SELinux conflict reporting.

* **Tests**
  * Added comprehensive test coverage for SELinux conflict reporting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->