### PR TITLE
OCPBUGS-86229: apiserver: cache etcd storage monitors to avoid recreating clients on each metrics scrape

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -240,32 +241,98 @@ func (s *EtcdOptions) ApplyWithStorageFactoryTo(factory serverstorage.StorageFac
 		return err
 	}
 
-	metrics.SetStorageMonitorGetter(monitorGetter(factory))
+	monitorCache, err := newMonitorCache(factory, c.DrainedNotify())
+	if err != nil {
+		return err
+	}
+	metrics.SetStorageMonitorGetter(monitorCache.get)
 
 	c.RESTOptionsGetter = s.CreateRESTOptionsGetter(factory, c.ResourceTransformers)
 	return nil
 }
 
-func monitorGetter(factory serverstorage.StorageFactory) func() (monitors []metrics.Monitor, err error) {
-	return func() (monitors []metrics.Monitor, err error) {
-		defer func() {
-			if err != nil {
-				for _, m := range monitors {
-					m.Close()
-				}
-			}
-		}()
+type monitorCache struct {
+	mu       sync.RWMutex
+	closed   bool
+	monitors []metrics.Monitor
+	factory  serverstorage.StorageFactory
+	stopCh   <-chan struct{}
+}
 
-		var m metrics.Monitor
-		for _, cfg := range factory.Configs() {
-			m, err = storagefactory.CreateMonitor(cfg)
-			if err != nil {
-				return nil, err
-			}
-			monitors = append(monitors, m)
-		}
-		return monitors, nil
+var createMonitor = storagefactory.CreateMonitor
+
+func newMonitorCache(factory serverstorage.StorageFactory, stopCh <-chan struct{}) (*monitorCache, error) {
+	if stopCh == nil {
+		return nil, fmt.Errorf("stopCh is required for monitor cache cleanup")
 	}
+	cache := &monitorCache{
+		factory: factory,
+		stopCh:  stopCh,
+	}
+	return cache, nil
+}
+
+func (c *monitorCache) get() ([]metrics.Monitor, error) {
+	// Fast path: check if already initialized with read lock
+	c.mu.RLock()
+	if c.closed {
+		c.mu.RUnlock()
+		return nil, fmt.Errorf("monitor cache is closed")
+	}
+	if c.monitors != nil {
+		result := c.monitors
+		c.mu.RUnlock()
+		return result, nil
+	}
+	c.mu.RUnlock()
+
+	// Slow path: initialize with write lock
+	return c.initialize()
+}
+
+func (c *monitorCache) initialize() ([]metrics.Monitor, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return nil, fmt.Errorf("monitor cache is closed")
+	}
+	if c.monitors != nil {
+		return c.monitors, nil
+	}
+
+	var monitors []metrics.Monitor
+	for _, cfg := range c.factory.Configs() {
+		m, err := createMonitor(cfg)
+		if err != nil {
+			for _, already := range monitors {
+				already.Close() //nolint:errcheck
+			}
+			return nil, err
+		}
+		monitors = append(monitors, m)
+	}
+	c.monitors = monitors
+
+	go func() {
+		<-c.stopCh
+		c.close()
+	}()
+
+	return c.monitors, nil
+}
+
+func (c *monitorCache) close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.closed = true
+	for _, m := range c.monitors {
+		m.Close() //nolint:errcheck
+	}
+	c.monitors = nil
 }
 
 func (s *EtcdOptions) CreateRESTOptionsGetter(factory serverstorage.StorageFactory, resourceTransformers storagevalue.ResourceTransformers) generic.RESTOptionsGetter {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -491,4 +495,164 @@ func TestRestOptionsStorageObjectCountTracker(t *testing.T) {
 	if restOptions.StorageConfig.StorageObjectCountTracker != serverConfig.StorageObjectCountTracker {
 		t.Errorf("There are different StorageObjectCountTracker in restOptions and serverConfig")
 	}
+}
+
+func TestMonitorCache(t *testing.T) {
+	setCreateMonitor := func(t *testing.T, fn func(storagebackend.Config) (metrics.Monitor, error)) {
+		t.Helper()
+		original := createMonitor
+		createMonitor = fn
+		t.Cleanup(func() {
+			createMonitor = original
+		})
+	}
+
+	newTestCache := func(t *testing.T) *monitorCache {
+		t.Helper()
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+		cache, err := newMonitorCache(&SimpleStorageFactory{}, stopCh)
+		if err != nil {
+			t.Fatalf("newMonitorCache() returned error: %v", err)
+		}
+		return cache
+	}
+
+	testCases := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "reuses cached monitors on subsequent get calls",
+			test: func(t *testing.T) {
+				cache := newTestCache(t)
+				monitor := &fakeMonitor{}
+				var createCalls atomic.Int32
+
+				setCreateMonitor(t, func(cfg storagebackend.Config) (metrics.Monitor, error) {
+					createCalls.Add(1)
+					return monitor, nil
+				})
+
+				first, err := cache.get()
+				if err != nil {
+					t.Fatalf("first get() returned error: %v", err)
+				}
+				second, err := cache.get()
+				if err != nil {
+					t.Fatalf("second get() returned error: %v", err)
+				}
+
+				if got := createCalls.Load(); got != 1 {
+					t.Fatalf("expected createMonitor to be called once, got %d", got)
+				}
+				if len(first) != 1 || len(second) != 1 {
+					t.Fatalf("expected exactly one monitor from each call, got %d and %d", len(first), len(second))
+				}
+				if first[0] != monitor || second[0] != monitor {
+					t.Fatal("expected both calls to return the cached monitor instance")
+				}
+			},
+		},
+		{
+			name: "returns error when get is called after cache is closed",
+			test: func(t *testing.T) {
+				cache := newTestCache(t)
+				monitor := &fakeMonitor{}
+
+				setCreateMonitor(t, func(cfg storagebackend.Config) (metrics.Monitor, error) {
+					return monitor, nil
+				})
+
+				if _, err := cache.get(); err != nil {
+					t.Fatalf("initial get() returned error: %v", err)
+				}
+
+				cache.close()
+
+				if got := monitor.closeCalls.Load(); got != 1 {
+					t.Fatalf("expected close to be called once, got %d", got)
+				}
+				if _, err := cache.get(); err == nil || err.Error() != "monitor cache is closed" {
+					t.Fatalf("expected closed-cache error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "concurrent get calls all return the first initialized monitors",
+			test: func(t *testing.T) {
+				cache := newTestCache(t)
+				monitor := &fakeMonitor{}
+				initStarted := make(chan struct{})
+				allowInit := make(chan struct{})
+				var createCalls atomic.Int32
+
+				setCreateMonitor(t, func(cfg storagebackend.Config) (metrics.Monitor, error) {
+					if createCalls.Add(1) == 1 {
+						close(initStarted)
+					}
+					<-allowInit
+					return monitor, nil
+				})
+
+				const numGoroutines = 10
+				start := make(chan struct{})
+				results := make(chan []metrics.Monitor, numGoroutines)
+				errs := make(chan error, numGoroutines)
+				var wg sync.WaitGroup
+				wg.Add(numGoroutines)
+
+				for range numGoroutines {
+					go func() {
+						defer wg.Done()
+						<-start
+						got, err := cache.get()
+						results <- got
+						errs <- err
+					}()
+				}
+
+				close(start)
+				<-initStarted
+				close(allowInit)
+				wg.Wait()
+
+				if got := createCalls.Load(); got != 1 {
+					t.Fatalf("expected createMonitor to be called once, got %d", got)
+				}
+				if len(cache.monitors) != 1 || cache.monitors[0] != monitor {
+					t.Fatal("expected the initialized monitor to be cached")
+				}
+
+				for range numGoroutines {
+					if err := <-errs; err != nil {
+						t.Fatalf("get() returned error: %v", err)
+					}
+					got := <-results
+					if len(got) != 1 || got[0] != monitor {
+						t.Fatal("expected all goroutines to receive the same cached monitor")
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.test(t)
+		})
+	}
+}
+
+type fakeMonitor struct {
+	closeCalls atomic.Int32
+}
+
+func (f *fakeMonitor) Monitor(ctx context.Context) (metrics.StorageMetrics, error) {
+	return metrics.StorageMetrics{}, nil
+}
+
+func (f *fakeMonitor) Close() error {
+	f.closeCalls.Add(1)
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -355,7 +355,6 @@ func (c *monitorCollector) CollectWithStability(ch chan<- compbasemetrics.Metric
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		metrics, err := m.Monitor(ctx)
 		cancel()
-		m.Close()
 		if err != nil {
 			klog.InfoS("Failed to get storage metrics", "storage_cluster_id", storageClusterID, "err", err)
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The apiserver was creating new etcd storage monitor clients on every Prometheus metrics scrape cycle and immediately closing them afterward. This caused repeated gRPC connection churn against etcd, as each scrape round-tripped through client creation and teardown.

There are multiple client cases linked to this, either complaining about warnings or about memory consumption, so we decided on RIT to cherry-pick this and not wait for 1.37 to be incorporated.

#### Which issue(s) this PR is related to:

n/a

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced etcd storage monitor management with thread-safe caching and improved lifecycle management to prevent resource leaks.

* **Tests**
  * Added comprehensive tests for monitor caching, concurrent access, and proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->