### PR TITLE
OCPBUGS-87017: fix flake race in VAP e2e case

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -289,7 +289,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 	*/
 	framework.It("should type check a CRD", func(ctx context.Context) {
 		crd := crontabExampleCRD()
-		crd.Spec.Group = "stable." + f.UniqueName
+		crd.Spec.Group = "stable." + f.UniqueName + ".example.com"
 		crd.Name = crd.Spec.Names.Plural + "." + crd.Spec.Group
 		var policy *admissionregistrationv1.ValidatingAdmissionPolicy
 		ginkgo.By("creating the CRD", func() {


### PR DESCRIPTION
## Description

Fixes intermittent (~4-5%) failures in:

```
[sig-api-machinery] Discovery should validate PreferredVersion for each APIGroup [Conformance]
```

The `should type check a CRD` test was creating a CRD with group `stable.<unique-name>`. The conformance test for discovery sees this group before its `PreferredVersion` is populated, causing a race condition. Adding the `.example.com` suffix uses a known example domain that avoids the race.

## Upstream

- kubernetes/kubernetes#133509 ("fix flake race in VAP e2e case")
- Commit: `f0e52c1c47647311383c2421df39bb8eb5ea66a6`
- Already present in release-4.22 via v1.35.5 merge.

## Jira

https://issues.redhat.com/browse/OCPBUGS-87017

/cherry-pick release-4.20

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-87017`