### PR TITLE
Add mountOptions on volumeMounts

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2187,6 +2187,10 @@ type VolumeMount struct {
 	// SubPathExpr and SubPath are mutually exclusive.
 	// +optional
 	SubPathExpr string
+	// mountOptions is a list of mount options (noexec, nodev, nosuid) to apply
+	// when mounting this volume into the container.
+	// +optional
+	MountOptions []string
 }
 
 // MountPropagationMode describes mount propagation.

--- a/pkg/apis/core/v1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1/zz_generated.conversion.go
@@ -9069,6 +9069,7 @@ func autoConvert_v1_VolumeMount_To_core_VolumeMount(in *corev1.VolumeMount, out 
 	out.SubPath = in.SubPath
 	out.MountPropagation = (*core.MountPropagationMode)(unsafe.Pointer(in.MountPropagation))
 	out.SubPathExpr = in.SubPathExpr
+	out.MountOptions = *(*[]string)(unsafe.Pointer(&in.MountOptions))
 	return nil
 }
 
@@ -9085,6 +9086,7 @@ func autoConvert_core_VolumeMount_To_v1_VolumeMount(in *core.VolumeMount, out *c
 	out.SubPath = in.SubPath
 	out.MountPropagation = (*corev1.MountPropagationMode)(unsafe.Pointer(in.MountPropagation))
 	out.SubPathExpr = in.SubPathExpr
+	out.MountOptions = *(*[]string)(unsafe.Pointer(&in.MountOptions))
 	return nil
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3146,6 +3146,19 @@ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]strin
 			allErrs = append(allErrs, validateMountPropagation(mnt.MountPropagation, container, fldPath.Child("mountPropagation"))...)
 		}
 		allErrs = append(allErrs, validateMountRecursiveReadOnly(mnt, fldPath.Child("recursiveReadOnly"))...)
+
+		if len(mnt.MountOptions) > 0 {
+			if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeMountOptions) {
+				allErrs = append(allErrs, field.Forbidden(idxPath.Child("mountOptions"), "mount options require the VolumeMountOptions feature gate to be enabled"))
+			} else {
+				allowedOptions := sets.New("noexec", "nodev", "nosuid")
+				for j, opt := range mnt.MountOptions {
+					if !allowedOptions.Has(opt) {
+						allErrs = append(allErrs, field.NotSupported(idxPath.Child("mountOptions").Index(j), opt, sets.List(allowedOptions)))
+					}
+				}
+			}
+		}
 	}
 	return allErrs
 }

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -6498,6 +6498,11 @@ func (in *VolumeMount) DeepCopyInto(out *VolumeMount) {
 		*out = new(MountPropagationMode)
 		**out = **in
 	}
+	if in.MountOptions != nil {
+		in, out := &in.MountOptions, &out.MountOptions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1081,6 +1081,13 @@ const (
 	// co-ordinate better with cluster-autoscaler for storage limits.
 	VolumeLimitScaling featuregate.Feature = "VolumeLimitScaling"
 
+	// owner: @nispriha
+	// kep: https://kep.k8s.io/5855
+	//
+	// Enables mount options (noexec, nodev, nosuid) on volumeMounts, passed
+	// through CRI to the container runtime.
+	VolumeMountOptions featuregate.Feature = "VolumeMountOptions"
+
 	// owner: @ksubrmnn
 	//
 	// Allows kube-proxy to create DSR loadbalancers for Windows
@@ -1907,6 +1914,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	VolumeMountOptions: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	WinDSR: {
 		{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
@@ -2479,6 +2490,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	VolumeAttributesClass: {},
 
 	VolumeLimitScaling: {},
+
+	VolumeMountOptions: {},
 
 	WinDSR: {},
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34283,6 +34283,26 @@ func schema_k8sio_api_core_v1_VolumeMount(ref common.ReferenceCallback) common.O
 							Format:      "",
 						},
 					},
+					"mountOptions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "mountOptions is a list of mount options (noexec, nodev, nosuid) to apply when mounting this volume into the container. These options are passed through CRI to the container runtime and enforced at the OS level. Only VFS-level bind mount flags are permitted; filesystem-specific options are not allowed. This is an alpha field and requires the VolumeMountOptions feature gate.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"name", "mountPath"},
 			},

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -495,6 +495,9 @@ type Mount struct {
 	// ImageSubPath is set if an image volume sub path should get mounted. This
 	// field is only required if the above Image is set.
 	ImageSubPath string
+	// MountOptions specifies additional mount options (noexec, nodev, nosuid)
+	// to pass through CRI to the container runtime.
+	MountOptions []string
 }
 
 // ImageVolumes is a map of image specs by volume name.

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -409,6 +409,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			RecursiveReadOnly: rro,
 			SELinuxRelabel:    relabelVolume,
 			Propagation:       propagation,
+			MountOptions:      mount.MountOptions,
 		})
 	}
 	if mountEtcHostsFile {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -492,6 +492,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 			RecursiveReadOnly: v.RecursiveReadOnly,
 			Image:             v.Image,
 			ImageSubPath:      v.ImageSubPath,
+			MountOptions:      v.MountOptions,
 		}
 
 		volumeMounts = append(volumeMounts, mount)
@@ -759,6 +760,7 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 			Propagation:       mount.Propagation,
 			Image:             mount.Image,
 			ImageSubPath:      mount.ImageSubPath,
+			MountOptions:      mount.MountOptions,
 		})
 	}
 	return cStatus

--- a/staging/src/k8s.io/api/core/v1/generated.pb.go
+++ b/staging/src/k8s.io/api/core/v1/generated.pb.go
@@ -14084,6 +14084,15 @@ func (m *VolumeMount) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.MountOptions) > 0 {
+		for iNdEx := len(m.MountOptions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.MountOptions[iNdEx])
+			copy(dAtA[i:], m.MountOptions[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.MountOptions[iNdEx])))
+			i--
+			dAtA[i] = 0x42
+		}
+	}
 	if m.RecursiveReadOnly != nil {
 		i -= len(*m.RecursiveReadOnly)
 		copy(dAtA[i:], *m.RecursiveReadOnly)
@@ -20023,6 +20032,12 @@ func (m *VolumeMount) Size() (n int) {
 		l = len(*m.RecursiveReadOnly)
 		n += 1 + l + sovGenerated(uint64(l))
 	}
+	if len(m.MountOptions) > 0 {
+		for _, s := range m.MountOptions {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -24105,6 +24120,7 @@ func (this *VolumeMount) String() string {
 		`MountPropagation:` + valueToStringGenerated(this.MountPropagation) + `,`,
 		`SubPathExpr:` + fmt.Sprintf("%v", this.SubPathExpr) + `,`,
 		`RecursiveReadOnly:` + valueToStringGenerated(this.RecursiveReadOnly) + `,`,
+		`MountOptions:` + fmt.Sprintf("%v", this.MountOptions) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -67955,6 +67971,38 @@ func (m *VolumeMount) Unmarshal(dAtA []byte) error {
 			}
 			s := RecursiveReadOnlyMode(dAtA[iNdEx:postIndex])
 			m.RecursiveReadOnly = &s
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MountOptions", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MountOptions = append(m.MountOptions, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -6866,6 +6866,17 @@ message VolumeMount {
   // SubPathExpr and SubPath are mutually exclusive.
   // +optional
   optional string subPathExpr = 6;
+
+  // mountOptions is a list of mount options (noexec, nodev, nosuid) to apply
+  // when mounting this volume into the container. These options are passed
+  // through CRI to the container runtime and enforced at the OS level.
+  // Only VFS-level bind mount flags are permitted; filesystem-specific
+  // options are not allowed.
+  // This is an alpha field and requires the VolumeMountOptions feature gate.
+  // +featureGate=VolumeMountOptions
+  // +optional
+  // +listType=atomic
+  repeated string mountOptions = 8;
 }
 
 // VolumeMountStatus shows status of volume mounts.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2413,6 +2413,16 @@ type VolumeMount struct {
 	// SubPathExpr and SubPath are mutually exclusive.
 	// +optional
 	SubPathExpr string `json:"subPathExpr,omitempty" protobuf:"bytes,6,opt,name=subPathExpr"`
+	// mountOptions is a list of mount options (noexec, nodev, nosuid) to apply
+	// when mounting this volume into the container. These options are passed
+	// through CRI to the container runtime and enforced at the OS level.
+	// Only VFS-level bind mount flags are permitted; filesystem-specific
+	// options are not allowed.
+	// This is an alpha field and requires the VolumeMountOptions feature gate.
+	// +featureGate=VolumeMountOptions
+	// +optional
+	// +listType=atomic
+	MountOptions []string `json:"mountOptions,omitempty" protobuf:"bytes,8,rep,name=mountOptions"`
 }
 
 // MountPropagationMode describes mount propagation.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -2770,6 +2770,7 @@ var map_VolumeMount = map[string]string{
 	"subPath":           "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
 	"mountPropagation":  "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).",
 	"subPathExpr":       "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+	"mountOptions":      "mountOptions is a list of mount options (noexec, nodev, nosuid) to apply when mounting this volume into the container. These options are passed through CRI to the container runtime and enforced at the OS level. Only VFS-level bind mount flags are permitted; filesystem-specific options are not allowed. This is an alpha field and requires the VolumeMountOptions feature gate.",
 }
 
 func (VolumeMount) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
@@ -6508,6 +6508,11 @@ func (in *VolumeMount) DeepCopyInto(out *VolumeMount) {
 		*out = new(MountPropagationMode)
 		**out = **in
 	}
+	if in.MountOptions != nil {
+		in, out := &in.MountOptions, &out.MountOptions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.DaemonSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.DaemonSet.json
@@ -615,7 +615,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -929,7 +932,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1243,7 +1249,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.DaemonSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.DaemonSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.Deployment.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.Deployment.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.Deployment.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.Deployment.yaml
@@ -426,7 +426,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -655,7 +657,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -885,7 +889,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.ReplicaSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.ReplicaSet.json
@@ -617,7 +617,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -931,7 +934,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1245,7 +1251,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.ReplicaSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.ReplicaSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.StatefulSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.StatefulSet.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1.StatefulSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1.StatefulSet.yaml
@@ -426,7 +426,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -655,7 +657,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -885,7 +889,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.Deployment.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.Deployment.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.Deployment.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.Deployment.yaml
@@ -428,7 +428,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -657,7 +659,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -887,7 +891,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.StatefulSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.StatefulSet.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.StatefulSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta1.StatefulSet.yaml
@@ -426,7 +426,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -655,7 +657,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -885,7 +889,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.DaemonSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.DaemonSet.json
@@ -615,7 +615,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -929,7 +932,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1243,7 +1249,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.DaemonSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.DaemonSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.Deployment.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.Deployment.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.Deployment.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.Deployment.yaml
@@ -426,7 +426,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -655,7 +657,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -885,7 +889,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.ReplicaSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.ReplicaSet.json
@@ -617,7 +617,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -931,7 +934,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1245,7 +1251,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.ReplicaSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.ReplicaSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.StatefulSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.StatefulSet.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.StatefulSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/apps.v1beta2.StatefulSet.yaml
@@ -426,7 +426,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -655,7 +657,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -885,7 +889,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1.CronJob.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1.CronJob.json
@@ -699,7 +699,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [
@@ -1013,7 +1016,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [
@@ -1327,7 +1333,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1.CronJob.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1.CronJob.yaml
@@ -478,7 +478,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true
@@ -707,7 +709,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true
@@ -937,7 +941,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1.Job.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1.Job.json
@@ -650,7 +650,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -964,7 +967,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1278,7 +1284,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1.Job.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1.Job.yaml
@@ -442,7 +442,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -671,7 +673,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -901,7 +905,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1beta1.CronJob.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1beta1.CronJob.json
@@ -699,7 +699,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [
@@ -1013,7 +1016,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [
@@ -1327,7 +1333,10 @@
                     "mountPath": "mountPathValue",
                     "subPath": "subPathValue",
                     "mountPropagation": "mountPropagationValue",
-                    "subPathExpr": "subPathExprValue"
+                    "subPathExpr": "subPathExprValue",
+                    "mountOptions": [
+                      "mountOptionsValue"
+                    ]
                   }
                 ],
                 "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/batch.v1beta1.CronJob.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/batch.v1beta1.CronJob.yaml
@@ -478,7 +478,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true
@@ -707,7 +709,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true
@@ -937,7 +941,9 @@ spec:
             - devicePath: devicePathValue
               name: nameValue
             volumeMounts:
-            - mountPath: mountPathValue
+            - mountOptions:
+              - mountOptionsValue
+              mountPath: mountPathValue
               mountPropagation: mountPropagationValue
               name: nameValue
               readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.Pod.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.Pod.json
@@ -557,7 +557,10 @@
             "mountPath": "mountPathValue",
             "subPath": "subPathValue",
             "mountPropagation": "mountPropagationValue",
-            "subPathExpr": "subPathExprValue"
+            "subPathExpr": "subPathExprValue",
+            "mountOptions": [
+              "mountOptionsValue"
+            ]
           }
         ],
         "volumeDevices": [
@@ -871,7 +874,10 @@
             "mountPath": "mountPathValue",
             "subPath": "subPathValue",
             "mountPropagation": "mountPropagationValue",
-            "subPathExpr": "subPathExprValue"
+            "subPathExpr": "subPathExprValue",
+            "mountOptions": [
+              "mountOptionsValue"
+            ]
           }
         ],
         "volumeDevices": [
@@ -1185,7 +1191,10 @@
             "mountPath": "mountPathValue",
             "subPath": "subPathValue",
             "mountPropagation": "mountPropagationValue",
-            "subPathExpr": "subPathExprValue"
+            "subPathExpr": "subPathExprValue",
+            "mountOptions": [
+              "mountOptionsValue"
+            ]
           }
         ],
         "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.Pod.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.Pod.yaml
@@ -374,7 +374,9 @@ spec:
     - devicePath: devicePathValue
       name: nameValue
     volumeMounts:
-    - mountPath: mountPathValue
+    - mountOptions:
+      - mountOptionsValue
+      mountPath: mountPathValue
       mountPropagation: mountPropagationValue
       name: nameValue
       readOnly: true
@@ -603,7 +605,9 @@ spec:
     - devicePath: devicePathValue
       name: nameValue
     volumeMounts:
-    - mountPath: mountPathValue
+    - mountOptions:
+      - mountOptionsValue
+      mountPath: mountPathValue
       mountPropagation: mountPropagationValue
       name: nameValue
       readOnly: true
@@ -833,7 +837,9 @@ spec:
     - devicePath: devicePathValue
       name: nameValue
     volumeMounts:
-    - mountPath: mountPathValue
+    - mountOptions:
+      - mountOptionsValue
+      mountPath: mountPathValue
       mountPropagation: mountPropagationValue
       name: nameValue
       readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.PodTemplate.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.PodTemplate.json
@@ -600,7 +600,10 @@
               "mountPath": "mountPathValue",
               "subPath": "subPathValue",
               "mountPropagation": "mountPropagationValue",
-              "subPathExpr": "subPathExprValue"
+              "subPathExpr": "subPathExprValue",
+              "mountOptions": [
+                "mountOptionsValue"
+              ]
             }
           ],
           "volumeDevices": [
@@ -914,7 +917,10 @@
               "mountPath": "mountPathValue",
               "subPath": "subPathValue",
               "mountPropagation": "mountPropagationValue",
-              "subPathExpr": "subPathExprValue"
+              "subPathExpr": "subPathExprValue",
+              "mountOptions": [
+                "mountOptionsValue"
+              ]
             }
           ],
           "volumeDevices": [
@@ -1228,7 +1234,10 @@
               "mountPath": "mountPathValue",
               "subPath": "subPathValue",
               "mountPropagation": "mountPropagationValue",
-              "subPathExpr": "subPathExprValue"
+              "subPathExpr": "subPathExprValue",
+              "mountOptions": [
+                "mountOptionsValue"
+              ]
             }
           ],
           "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.PodTemplate.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.PodTemplate.yaml
@@ -407,7 +407,9 @@ template:
       - devicePath: devicePathValue
         name: nameValue
       volumeMounts:
-      - mountPath: mountPathValue
+      - mountOptions:
+        - mountOptionsValue
+        mountPath: mountPathValue
         mountPropagation: mountPropagationValue
         name: nameValue
         readOnly: true
@@ -636,7 +638,9 @@ template:
       - devicePath: devicePathValue
         name: nameValue
       volumeMounts:
-      - mountPath: mountPathValue
+      - mountOptions:
+        - mountOptionsValue
+        mountPath: mountPathValue
         mountPropagation: mountPropagationValue
         name: nameValue
         readOnly: true
@@ -866,7 +870,9 @@ template:
       - devicePath: devicePathValue
         name: nameValue
       volumeMounts:
-      - mountPath: mountPathValue
+      - mountOptions:
+        - mountOptionsValue
+        mountPath: mountPathValue
         mountPropagation: mountPropagationValue
         name: nameValue
         readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.ReplicationController.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.ReplicationController.json
@@ -606,7 +606,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -920,7 +923,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1234,7 +1240,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/core.v1.ReplicationController.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/core.v1.ReplicationController.yaml
@@ -412,7 +412,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -641,7 +643,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -871,7 +875,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.DaemonSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.DaemonSet.json
@@ -615,7 +615,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -929,7 +932,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1243,7 +1249,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.DaemonSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.DaemonSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.Deployment.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.Deployment.json
@@ -616,7 +616,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -930,7 +933,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1244,7 +1250,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.Deployment.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.Deployment.yaml
@@ -428,7 +428,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -657,7 +659,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -887,7 +891,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.ReplicaSet.json
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.ReplicaSet.json
@@ -617,7 +617,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -931,7 +934,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [
@@ -1245,7 +1251,10 @@
                 "mountPath": "mountPathValue",
                 "subPath": "subPathValue",
                 "mountPropagation": "mountPropagationValue",
-                "subPathExpr": "subPathExprValue"
+                "subPathExpr": "subPathExprValue",
+                "mountOptions": [
+                  "mountOptionsValue"
+                ]
               }
             ],
             "volumeDevices": [

--- a/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.ReplicaSet.yaml
+++ b/staging/src/k8s.io/api/testdata/HEAD/extensions.v1beta1.ReplicaSet.yaml
@@ -418,7 +418,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -647,7 +649,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true
@@ -877,7 +881,9 @@ spec:
         - devicePath: devicePathValue
           name: nameValue
         volumeMounts:
-        - mountPath: mountPathValue
+        - mountOptions:
+          - mountOptionsValue
+          mountPath: mountPathValue
           mountPropagation: mountPropagationValue
           name: nameValue
           readOnly: true

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemount.go
@@ -67,6 +67,13 @@ type VolumeMountApplyConfiguration struct {
 	// Defaults to "" (volume's root).
 	// SubPathExpr and SubPath are mutually exclusive.
 	SubPathExpr *string `json:"subPathExpr,omitempty"`
+	// mountOptions is a list of mount options (noexec, nodev, nosuid) to apply
+	// when mounting this volume into the container. These options are passed
+	// through CRI to the container runtime and enforced at the OS level.
+	// Only VFS-level bind mount flags are permitted; filesystem-specific
+	// options are not allowed.
+	// This is an alpha field and requires the VolumeMountOptions feature gate.
+	MountOptions []string `json:"mountOptions,omitempty"`
 }
 
 // VolumeMountApplyConfiguration constructs a declarative configuration of the VolumeMount type for use with
@@ -128,5 +135,15 @@ func (b *VolumeMountApplyConfiguration) WithMountPropagation(value corev1.MountP
 // If called multiple times, the SubPathExpr field is set to the value of the last call.
 func (b *VolumeMountApplyConfiguration) WithSubPathExpr(value string) *VolumeMountApplyConfiguration {
 	b.SubPathExpr = &value
+	return b
+}
+
+// WithMountOptions adds the given value to the MountOptions field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the MountOptions field.
+func (b *VolumeMountApplyConfiguration) WithMountOptions(values ...string) *VolumeMountApplyConfiguration {
+	for i := range values {
+		b.MountOptions = append(b.MountOptions, values[i])
+	}
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -8912,6 +8912,12 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.api.core.v1.VolumeMount
   map:
     fields:
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
     - name: mountPath
       type:
         scalar: string

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -1129,6 +1129,9 @@ type Mount struct {
 	// return an error.
 	// Introduced in the Image Volume Source KEP beta graduation: https://kep.k8s.io/4639
 	ImageSubPath  string `protobuf:"bytes,10,opt,name=image_sub_path,json=imageSubPath,proto3" json:"image_sub_path,omitempty"`
+	// MountOptions specifies additional mount options (e.g., noexec, nodev,
+	// nosuid) for bind mounts.
+	MountOptions  []string `protobuf:"bytes,11,rep,name=mount_options,json=mountOptions,proto3" json:"mount_options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1231,6 +1234,13 @@ func (x *Mount) GetImageSubPath() string {
 		return x.ImageSubPath
 	}
 	return ""
+}
+
+func (x *Mount) GetMountOptions() []string {
+	if x != nil {
+		return x.MountOptions
+	}
+	return nil
 }
 
 // IDMapping describes host to container ID mappings for a pod sandbox.

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -267,6 +267,10 @@ message Mount {
     // return an error.
     // Introduced in the Image Volume Source KEP beta graduation: https://kep.k8s.io/4639
     string image_sub_path = 10;
+    // MountOptions specifies additional mount options (e.g., noexec, nodev,
+    // nosuid) that the runtime MUST apply when mounting this volume into the
+    // container. These are passed as OCI mount options.
+    repeated string mount_options = 11;
 }
 
 // IDMapping describes host to container ID mappings for a pod sandbox.

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1997,6 +1997,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.35"
+- name: VolumeMountOptions
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.37"
 - name: WatchCacheInitializationPostStartHook
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for specifying mount options on volume mounts (e.g., `noexec`, `nodev`, `nosuid`), controlled by the `VolumeMountOptions` feature gate (alpha, available in v1.37).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->