### PR TITLE
OCPBUGS-84961: add kubernetes/conformance umbrella suite

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -70,9 +70,16 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]')) && labels.exists(l, l == "Conformance")`)},
 	})
 
+	// AddGlobalSuite so the umbrella starts with zero qualifiers and inherits
+	// exclusively from its children via mergeParentQualifiers in origin.
+	kubeTestsExtension.AddGlobalSuite(e.Suite{
+		Name: "kubernetes/conformance",
+	})
+
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
 		Parents: []string{
+			"kubernetes/conformance",
 			"openshift/conformance/parallel",
 		},
 		Qualifiers: []string{withExcludedTestsFilter(`(!name.contains('[Serial]') && !labels.exists(l, l == '[Serial]'))`)},
@@ -81,6 +88,7 @@ func main() {
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/serial",
 		Parents: []string{
+			"kubernetes/conformance",
 			"openshift/conformance/serial",
 		},
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]'))`)},


### PR DESCRIPTION
## Summary

Restores the `kubernetes/conformance` suite, which was previously removed. This is an umbrella suite that aggregates `kubernetes/conformance/parallel` and `kubernetes/conformance/serial`.

Uses `AddGlobalSuite` so the umbrella inherits qualifiers exclusively from its children via `mergeParentQualifiers` (openshift/origin#31261), rather than picking up a default `source == "openshift:payload:hyperkube"` qualifier that would match all hyperkube tests.

## Companion PR

openshift/origin#31261

## Test plan

- [ ] `openshift-tests run kubernetes/conformance --dry-run` lists the expected tests
- [ ] Test count matches `kubernetes/conformance/parallel` + `kubernetes/conformance/serial`
- [ ] Excluded tests (`[Disabled:]`, `[Disruptive]`, `[Slow]`) are not included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conformance test suite registration to ensure proper test hierarchy and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->