### PR TITLE
OCPBUGS-84961: UPSTREAM: <carry>: fix kubernetes/conformance to filter on [Conformance] label

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -70,16 +70,17 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]')) && labels.exists(l, l == "Conformance")`)},
 	})
 
-	// AddGlobalSuite so the umbrella starts with zero qualifiers and inherits
-	// exclusively from its children via mergeParentQualifiers in origin.
-	kubeTestsExtension.AddGlobalSuite(e.Suite{
-		Name: "kubernetes/conformance",
+	// kubernetes/conformance is used by OCPT to run the minimal true upstream
+	// Kubernetes conformance tests, not the broader view OCP takes of what
+	// "conformance" means.
+	kubeTestsExtension.AddSuite(e.Suite{
+		Name:       "kubernetes/conformance",
+		Qualifiers: []string{withExcludedTestsFilter(`labels.exists(l, l == "Conformance")`)},
 	})
 
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
 		Parents: []string{
-			"kubernetes/conformance",
 			"openshift/conformance/parallel",
 		},
 		Qualifiers: []string{withExcludedTestsFilter(`(!name.contains('[Serial]') && !labels.exists(l, l == '[Serial]'))`)},
@@ -88,7 +89,6 @@ func main() {
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/serial",
 		Parents: []string{
-			"kubernetes/conformance",
 			"openshift/conformance/serial",
 		},
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]'))`)},


### PR DESCRIPTION
## Summary
- Change `kubernetes/conformance` from `AddGlobalSuite` (parent umbrella, no qualifiers) to `AddSuite` with a `[Conformance]` label filter, so it only matches the 428 true upstream Kubernetes conformance tests instead of OCP's broader conformance view
- Remove `kubernetes/conformance` from the Parents of `kubernetes/conformance/parallel` and `kubernetes/conformance/serial` so all suites are standalone
- This suite is used by OCPT to run the minimal true upstream Kubernetes conformance tests

## Test plan
- [x] Built `k8s-tests-ext` binary and verified `kubernetes/conformance` matches 428 tests (matching parallel/minimal 401 + serial/minimal 27)
- [ ] Verify OCPT can run `kubernetes/conformance` suite successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured conformance test suite registration to use explicit label qualifiers, improving how test qualifiers are inherited in serial conformance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->