### PR TITLE
[release-4.22] OCPBUGS-93787: backport kubernetes/conformance umbrella suite

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -70,6 +70,14 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]')) && labels.exists(l, l == "Conformance")`)},
 	})
 
+	// kubernetes/conformance is used by OPCT to run the minimal true upstream
+	// Kubernetes conformance tests, not the broader view OCP takes of what
+	// "conformance" means.
+	kubeTestsExtension.AddSuite(e.Suite{
+		Name:       "kubernetes/conformance",
+		Qualifiers: []string{withExcludedTestsFilter(`labels.exists(l, l == "Conformance")`)},
+	})
+
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
 		Parents: []string{


### PR DESCRIPTION
## Summary

Backport the kubernetes/conformance suite with Conformance label filter from master (combines PRs #2682 and #2694) to release-4.22.

Cherry-pick of:
- #2682 (add kubernetes/conformance umbrella suite)
- #2694 (fix kubernetes/conformance to filter on [Conformance] label)

Combined into a single clean change since #2694 simplified the approach from #2682. The final implementation adds the suite with its own Conformance qualifier, without needing AddGlobalSuite or parent references.

## What it does

Adds the `kubernetes/conformance` suite that selects only `[Conformance]`-labeled tests (~428 tests). This suite is used by OPCT for VCSP partner validations.

Without this fix, `openshift-tests run kubernetes/conformance` on 4.22 returns "suite not found".

## Testing

- Validated on master via /payload-job: 428 tests, 0 failures (2 independent CI runs)
- Validated locally on 5.0 cluster: 428 tests, 0 failures
- Root cause analysis confirmed the Conformance label filter prevents the 3806-test leak we saw on master before #2694

/cc @stbenjam