### PR TITLE
[release-4.21] OCPBUGS-94059: backport kubernetes/conformance umbrella suite

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go
@@ -69,6 +69,14 @@ func main() {
 		Qualifiers: []string{withExcludedTestsFilter(`(name.contains('[Serial]') || labels.exists(l, l == '[Serial]')) && labels.exists(l, l == "Conformance")`)},
 	})
 
+	// kubernetes/conformance is used by OPCT to run the minimal true upstream
+	// Kubernetes conformance tests, not the broader view OCP takes of what
+	// "conformance" means.
+	kubeTestsExtension.AddSuite(e.Suite{
+		Name:       "kubernetes/conformance",
+		Qualifiers: []string{withExcludedTestsFilter(`labels.exists(l, l == "Conformance")`)},
+	})
+
 	kubeTestsExtension.AddSuite(e.Suite{
 		Name: "kubernetes/conformance/parallel",
 		Parents: []string{


### PR DESCRIPTION
## Summary

Backport the kubernetes/conformance suite with Conformance label filter from master (combines PRs #2682 and #2694) to release-4.21.

Same change as the 4.22 backport PR #2705.

## What it does

Adds the `kubernetes/conformance` suite that selects only `[Conformance]`-labeled tests (~428 tests). This suite is used by OPCT for VCSP partner validations.

## Testing

- Validated on master via /payload-job: 428 tests, 0 failures
- Validated on 4.22 via /payload-job (PR #2705): 436 tests, 0 failures
- Same 8-line change, same approach

/cc @stbenjam