### PR TITLE
UPSTREAM: KEP-6063: Implement per-pod PID limit (Alpha)

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -755,6 +755,7 @@ func dropDisabledFields(
 	dropDisabledClusterTrustBundleProjection(podSpec, oldPodSpec)
 	dropDisabledPodCertificateProjection(podSpec, oldPodSpec)
 	dropDisabledWorkloadRef(podSpec, oldPodSpec)
+	dropDisabledPodPIDLimitFields(podSpec, oldPodSpec)
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && !inPlacePodVerticalScalingInUse(oldPodSpec) {
 		// Drop ResizePolicy fields. Don't drop updates to Resources field as template.spec.resources
@@ -1868,6 +1869,36 @@ func restartAllContainersActionInUse(oldPodSpec *api.PodSpec) bool {
 		if c.RestartPolicy != nil && *c.RestartPolicy == api.ContainerRestartPolicyAlways && len(c.RestartPolicyRules) > 0 {
 			return true
 		}
+	}
+	return false
+}
+
+// dropDisabledPodPIDLimitFields strips pid from pod-level resources when the
+// PerPodPIDLimit feature gate is disabled (unless an existing object already
+// uses it). Requests.pid is always stripped because only limits.pid is valid.
+func dropDisabledPodPIDLimitFields(podSpec, oldPodSpec *api.PodSpec) {
+	if podSpec == nil || podSpec.Resources == nil {
+		return
+	}
+	// requests.pid is never valid — always strip it
+	delete(podSpec.Resources.Requests, api.ResourcePID)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PerPodPIDLimit) {
+		return
+	}
+	if podPIDLimitInUse(oldPodSpec) {
+		return
+	}
+	delete(podSpec.Resources.Limits, api.ResourcePID)
+}
+
+// podPIDLimitInUse returns true if the pod spec has a pid limit set at the pod level.
+func podPIDLimitInUse(podSpec *api.PodSpec) bool {
+	if podSpec == nil || podSpec.Resources == nil {
+		return false
+	}
+	if _, ok := podSpec.Resources.Limits[api.ResourcePID]; ok {
+		return true
 	}
 	return false
 }

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -6734,3 +6734,854 @@ func TestDropDisabledPodStatusFields_InPlacePodLevelResourcesVerticalScaling(t *
 		})
 	}
 }
+
+func TestResourceHealthStatusInUse(t *testing.T) {
+	testCases := []struct {
+		name      string
+		podStatus *api.PodStatus
+		expected  bool
+	}{
+		{
+			name:      "nil pod status",
+			podStatus: nil,
+			expected:  false,
+		},
+		{
+			name: "empty pod status",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{},
+			},
+			expected: false,
+		},
+		{
+			name: "pod status with AllocatedResourcesStatus in container",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "test-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status with AllocatedResourcesStatus in init container",
+			podStatus: &api.PodStatus{
+				InitContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "init-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status with AllocatedResourcesStatus in ephemeral container",
+			podStatus: &api.PodStatus{
+				EphemeralContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "ephemeral-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status without AllocatedResourcesStatus",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "test-container",
+					},
+				},
+				InitContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "init-container",
+					},
+				},
+				EphemeralContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "ephemeral-container",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod status with empty AllocatedResourcesStatus array",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name:                     "test-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resourceHealthStatusInUse(tc.podStatus)
+			if result != tc.expected {
+				t.Errorf("resourceHealthStatusInUse() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDropDisabledPodStatusFields_ResourceHealthStatus(t *testing.T) {
+	podStatusWithResourceHealth := func() *api.PodStatus {
+		return &api.PodStatus{
+			ContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "container1",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/device",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "device-1",
+									Health:     api.ResourceHealthStatusHealthy,
+								},
+							},
+						},
+					},
+				},
+			},
+			InitContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "init-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/gpu",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "gpu-1",
+									Health:     api.ResourceHealthStatusUnhealthy,
+								},
+							},
+						},
+					},
+				},
+			},
+			EphemeralContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "ephemeral-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/nic",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "nic-1",
+									Health:     api.ResourceHealthStatusHealthy,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	podStatusWithoutResourceHealth := func() *api.PodStatus {
+		return &api.PodStatus{
+			ContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "container1",
+				},
+			},
+			InitContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "init-container",
+				},
+			},
+			EphemeralContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "ephemeral-container",
+				},
+			},
+		}
+	}
+
+	podStatusNilResourceHealth := func() *api.PodStatus {
+		return &api.PodStatus{
+			ContainerStatuses: []api.ContainerStatus{
+				{
+					Name:                     "container1",
+					AllocatedResourcesStatus: nil,
+				},
+			},
+			InitContainerStatuses: []api.ContainerStatus{
+				{
+					Name:                     "init-container",
+					AllocatedResourcesStatus: nil,
+				},
+			},
+			EphemeralContainerStatuses: []api.ContainerStatus{
+				{
+					Name:                     "ephemeral-container",
+					AllocatedResourcesStatus: nil,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		podStatus     *api.PodStatus
+		oldPodStatus  *api.PodStatus
+		wantPodStatus *api.PodStatus
+	}{
+		{
+			name:          "feature enabled, old=without, new=without",
+			enabled:       true,
+			oldPodStatus:  podStatusWithoutResourceHealth(),
+			podStatus:     podStatusWithoutResourceHealth(),
+			wantPodStatus: podStatusWithoutResourceHealth(),
+		},
+		{
+			name:          "feature enabled, old=with, new=with",
+			enabled:       true,
+			oldPodStatus:  podStatusWithResourceHealth(),
+			podStatus:     podStatusWithResourceHealth(),
+			wantPodStatus: podStatusWithResourceHealth(),
+		},
+		{
+			name:          "feature enabled, old=without, new=with",
+			enabled:       true,
+			oldPodStatus:  podStatusWithoutResourceHealth(),
+			podStatus:     podStatusWithResourceHealth(),
+			wantPodStatus: podStatusWithResourceHealth(),
+		},
+		{
+			name:          "feature disabled, old=without, new=without",
+			enabled:       false,
+			oldPodStatus:  podStatusWithoutResourceHealth(),
+			podStatus:     podStatusWithoutResourceHealth(),
+			wantPodStatus: podStatusNilResourceHealth(),
+		},
+		{
+			name:          "feature disabled, old=without, new=with (should drop)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithoutResourceHealth(),
+			podStatus:     podStatusWithResourceHealth(),
+			wantPodStatus: podStatusNilResourceHealth(),
+		},
+		{
+			name:          "feature disabled, old=with, new=with (should preserve - bug fix)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithResourceHealth(),
+			podStatus:     podStatusWithResourceHealth(),
+			wantPodStatus: podStatusWithResourceHealth(),
+		},
+		{
+			name:          "feature disabled, old=with, new=without (should preserve nil)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithResourceHealth(),
+			podStatus:     podStatusWithoutResourceHealth(),
+			wantPodStatus: podStatusWithoutResourceHealth(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatus, tt.enabled)
+			dropDisabledPodStatusFields(tt.podStatus, tt.oldPodStatus, &api.PodSpec{}, &api.PodSpec{})
+			if !reflect.DeepEqual(tt.podStatus, tt.wantPodStatus) {
+				t.Errorf("dropDisabledPodStatusFields() = %v, want %v\ndiff: %v",
+					tt.podStatus, tt.wantPodStatus, cmp.Diff(tt.wantPodStatus, tt.podStatus))
+			}
+		})
+	}
+}
+
+func TestResourceHealthStatusMessageInUse(t *testing.T) {
+	message := "test message"
+	testCases := []struct {
+		name      string
+		podStatus *api.PodStatus
+		expected  bool
+	}{
+		{
+			name:      "nil pod status",
+			podStatus: nil,
+			expected:  false,
+		},
+		{
+			name: "empty pod status",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{},
+			},
+			expected: false,
+		},
+		{
+			name: "pod status with message in container",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "test-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+										Message:    &message,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status with message in init container",
+			podStatus: &api.PodStatus{
+				InitContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "init-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+										Message:    &message,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status with message in ephemeral container",
+			podStatus: &api.PodStatus{
+				EphemeralContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "ephemeral-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+										Message:    &message,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod status without message (nil pointer)",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "test-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+										Message:    nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod status with AllocatedResourcesStatus but no message",
+			podStatus: &api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "test-container",
+						AllocatedResourcesStatus: []api.ResourceStatus{
+							{
+								Name: "example.com/device",
+								Resources: []api.ResourceHealth{
+									{
+										ResourceID: "device-1",
+										Health:     api.ResourceHealthStatusHealthy,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resourceHealthStatusMessageInUse(tc.podStatus)
+			if result != tc.expected {
+				t.Errorf("resourceHealthStatusMessageInUse() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDropDisabledPodStatusFields_ResourceHealthStatusMessage(t *testing.T) {
+	message1 := "ECC error detected"
+	message2 := "GPU temperature high"
+	message3 := "NIC link down"
+
+	podStatusWithMessage := func() *api.PodStatus {
+		return &api.PodStatus{
+			ContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "container1",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/device",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "device-1",
+									Health:     api.ResourceHealthStatusHealthy,
+									Message:    &message1,
+								},
+							},
+						},
+					},
+				},
+			},
+			InitContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "init-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/gpu",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "gpu-1",
+									Health:     api.ResourceHealthStatusUnhealthy,
+									Message:    &message2,
+								},
+							},
+						},
+					},
+				},
+			},
+			EphemeralContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "ephemeral-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/nic",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "nic-1",
+									Health:     api.ResourceHealthStatusHealthy,
+									Message:    &message3,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	podStatusWithoutMessage := func() *api.PodStatus {
+		return &api.PodStatus{
+			ContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "container1",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/device",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "device-1",
+									Health:     api.ResourceHealthStatusHealthy,
+									Message:    nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			InitContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "init-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/gpu",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "gpu-1",
+									Health:     api.ResourceHealthStatusUnhealthy,
+									Message:    nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			EphemeralContainerStatuses: []api.ContainerStatus{
+				{
+					Name: "ephemeral-container",
+					AllocatedResourcesStatus: []api.ResourceStatus{
+						{
+							Name: "example.com/nic",
+							Resources: []api.ResourceHealth{
+								{
+									ResourceID: "nic-1",
+									Health:     api.ResourceHealthStatusHealthy,
+									Message:    nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		podStatus     *api.PodStatus
+		oldPodStatus  *api.PodStatus
+		wantPodStatus *api.PodStatus
+	}{
+		{
+			name:          "feature enabled, old=without, new=without",
+			enabled:       true,
+			oldPodStatus:  podStatusWithoutMessage(),
+			podStatus:     podStatusWithoutMessage(),
+			wantPodStatus: podStatusWithoutMessage(),
+		},
+		{
+			name:          "feature enabled, old=with, new=with",
+			enabled:       true,
+			oldPodStatus:  podStatusWithMessage(),
+			podStatus:     podStatusWithMessage(),
+			wantPodStatus: podStatusWithMessage(),
+		},
+		{
+			name:          "feature enabled, old=without, new=with",
+			enabled:       true,
+			oldPodStatus:  podStatusWithoutMessage(),
+			podStatus:     podStatusWithMessage(),
+			wantPodStatus: podStatusWithMessage(),
+		},
+		{
+			name:          "feature disabled, old=without, new=without",
+			enabled:       false,
+			oldPodStatus:  podStatusWithoutMessage(),
+			podStatus:     podStatusWithoutMessage(),
+			wantPodStatus: podStatusWithoutMessage(),
+		},
+		{
+			name:          "feature disabled, old=without, new=with (should drop)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithoutMessage(),
+			podStatus:     podStatusWithMessage(),
+			wantPodStatus: podStatusWithoutMessage(),
+		},
+		{
+			name:          "feature disabled, old=with, new=with (should preserve - bug fix)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithMessage(),
+			podStatus:     podStatusWithMessage(),
+			wantPodStatus: podStatusWithMessage(),
+		},
+		{
+			name:          "feature disabled, old=with, new=without (should preserve nil)",
+			enabled:       false,
+			oldPodStatus:  podStatusWithMessage(),
+			podStatus:     podStatusWithoutMessage(),
+			wantPodStatus: podStatusWithoutMessage(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Enable ResourceHealthStatus as well since ResourceHealthStatusMessage depends on it
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatus, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatusMessage, tt.enabled)
+			dropDisabledPodStatusFields(tt.podStatus, tt.oldPodStatus, &api.PodSpec{}, &api.PodSpec{})
+			if !reflect.DeepEqual(tt.podStatus, tt.wantPodStatus) {
+				t.Errorf("dropDisabledPodStatusFields() = %v, want %v\ndiff: %v",
+					tt.podStatus, tt.wantPodStatus, cmp.Diff(tt.wantPodStatus, tt.podStatus))
+			}
+		})
+	}
+}
+
+func TestHasRestartContainerForNonSidecarInitContainer(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  *api.PodSpec
+		expected bool
+	}{
+		{
+			name:     "nil pod spec",
+			podSpec:  nil,
+			expected: false,
+		},
+		{
+			name:     "no init containers",
+			podSpec:  &api.PodSpec{InitContainers: []api.Container{}},
+			expected: false,
+		},
+		{
+			name: "regular init container without resize policy",
+			podSpec: &api.PodSpec{
+				InitContainers: []api.Container{
+					{Name: "init-1"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "sidecar (restartable) init container with RestartContainer policy",
+			podSpec: &api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name:          "sidecar",
+						RestartPolicy: ptr.To(api.ContainerRestartPolicyAlways),
+						ResizePolicy: []api.ContainerResizePolicy{
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.RestartContainer},
+						},
+					},
+				},
+			},
+			expected: false, // Should be false because it's a sidecar
+		},
+		{
+			name: "non-sidecar init container with NotRequired policy",
+			podSpec: &api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name: "init-1",
+						ResizePolicy: []api.ContainerResizePolicy{
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.NotRequired},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-sidecar init container with RestartContainer policy",
+			podSpec: &api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name: "init-1",
+						ResizePolicy: []api.ContainerResizePolicy{
+							{ResourceName: api.ResourceMemory, RestartPolicy: api.RestartContainer},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "mix of sidecar and non-sidecar with RestartContainer policy",
+			podSpec: &api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name:          "sidecar",
+						RestartPolicy: ptr.To(api.ContainerRestartPolicyAlways),
+						ResizePolicy: []api.ContainerResizePolicy{
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.RestartContainer},
+						},
+					},
+					{
+						Name: "init-2",
+						ResizePolicy: []api.ContainerResizePolicy{
+							{ResourceName: api.ResourceCPU, RestartPolicy: api.RestartContainer},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRestartContainerForNonSidecarInitContainer(tt.podSpec)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDropDisabledPodPIDLimitFields(t *testing.T) {
+	pidLimit := resource.MustParse("2048")
+
+	podWithPIDLimits := func() *api.PodSpec {
+		return &api.PodSpec{
+			Resources: &api.ResourceRequirements{
+				Limits: api.ResourceList{api.ResourcePID: pidLimit},
+			},
+			Containers: []api.Container{
+				{Name: "c1", Image: "img"},
+			},
+		}
+	}
+
+	podWithPIDLimitsAndRequests := func() *api.PodSpec {
+		return &api.PodSpec{
+			Resources: &api.ResourceRequirements{
+				Limits:   api.ResourceList{api.ResourcePID: pidLimit},
+				Requests: api.ResourceList{api.ResourcePID: pidLimit},
+			},
+			Containers: []api.Container{
+				{Name: "c1", Image: "img"},
+			},
+		}
+	}
+
+	podWithoutPID := func() *api.PodSpec {
+		return &api.PodSpec{
+			Resources: &api.ResourceRequirements{
+				Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("1")},
+				Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1")},
+			},
+			Containers: []api.Container{
+				{Name: "c1", Image: "img"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		gateOn           bool
+		podSpec          func() *api.PodSpec
+		oldPodSpec       func() *api.PodSpec
+		expectPIDLimit   bool
+		expectPIDRequest bool
+	}{
+		{
+			name:             "gate on: pid limit preserved",
+			gateOn:           true,
+			podSpec:          podWithPIDLimits,
+			oldPodSpec:       func() *api.PodSpec { return nil },
+			expectPIDLimit:   true,
+			expectPIDRequest: false,
+		},
+		{
+			name:             "gate on: requests.pid always stripped even when gate is on",
+			gateOn:           true,
+			podSpec:          podWithPIDLimitsAndRequests,
+			oldPodSpec:       func() *api.PodSpec { return nil },
+			expectPIDLimit:   true,
+			expectPIDRequest: false,
+		},
+		{
+			name:             "gate off, no old pod: pid limit stripped",
+			gateOn:           false,
+			podSpec:          podWithPIDLimits,
+			oldPodSpec:       func() *api.PodSpec { return nil },
+			expectPIDLimit:   false,
+			expectPIDRequest: false,
+		},
+		{
+			name:             "gate off, old pod has pid limit: pid limit preserved",
+			gateOn:           false,
+			podSpec:          podWithPIDLimits,
+			oldPodSpec:       podWithPIDLimits,
+			expectPIDLimit:   true,
+			expectPIDRequest: false,
+		},
+		{
+			name:             "gate off, no pid in spec: unrelated fields untouched",
+			gateOn:           false,
+			podSpec:          podWithoutPID,
+			oldPodSpec:       func() *api.PodSpec { return nil },
+			expectPIDLimit:   false,
+			expectPIDRequest: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, tt.gateOn)
+
+			newSpec := tt.podSpec()
+			oldSpec := tt.oldPodSpec()
+			dropDisabledPodPIDLimitFields(newSpec, oldSpec)
+
+			_, hasPIDLimit := newSpec.Resources.Limits[api.ResourcePID]
+			if hasPIDLimit != tt.expectPIDLimit {
+				t.Errorf("expected pid in limits=%v, got %v", tt.expectPIDLimit, hasPIDLimit)
+			}
+			_, hasPIDRequest := newSpec.Resources.Requests[api.ResourcePID]
+			if hasPIDRequest != tt.expectPIDRequest {
+				t.Errorf("expected pid in requests=%v, got %v", tt.expectPIDRequest, hasPIDRequest)
+			}
+		})
+	}
+
+	t.Run("gate off, nil pod resources: no panic", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, false)
+		spec := &api.PodSpec{
+			Resources:  nil,
+			Containers: []api.Container{{Name: "c1", Image: "img"}},
+		}
+		dropDisabledPodPIDLimitFields(spec, nil)
+		if spec.Resources != nil {
+			t.Errorf("expected Resources to remain nil")
+		}
+	})
+}

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -204,7 +204,8 @@ func IsNativeResource(name core.ResourceName) bool {
 // namespace and is not hugepages.
 func IsOvercommitAllowed(name core.ResourceName) bool {
 	return IsNativeResource(name) &&
-		!IsHugePageResourceName(name)
+		!IsHugePageResourceName(name) &&
+		name != core.ResourcePID
 }
 
 var standardLimitRangeTypes = sets.New(
@@ -250,6 +251,7 @@ var standardResources = sets.New(
 	core.ResourceCPU,
 	core.ResourceMemory,
 	core.ResourceEphemeralStorage,
+	core.ResourcePID,
 	core.ResourceRequestsCPU,
 	core.ResourceRequestsMemory,
 	core.ResourceRequestsEphemeralStorage,
@@ -284,6 +286,7 @@ var integerResources = sets.New(
 	core.ResourcePersistentVolumeClaims,
 	core.ResourceServicesNodePorts,
 	core.ResourceServicesLoadBalancers,
+	core.ResourcePID,
 )
 
 // IsIntegerResourceName returns true if the resource is measured in integer values

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -58,6 +58,7 @@ func TestIsStandardResource(t *testing.T) {
 		{"x.y.z", false},
 		{"hugepages-2Mi", true},
 		{"requests.hugepages-2Mi", true},
+		{"pid", true},
 	}
 	for i, tc := range testCases {
 		if IsStandardResourceName(core.ResourceName(tc.input)) != tc.output {
@@ -75,6 +76,7 @@ func TestIsStandardContainerResource(t *testing.T) {
 		{"memory", true},
 		{"disk", false},
 		{"hugepages-2Mi", true},
+		{"pid", false},
 	}
 	for i, tc := range testCases {
 		if IsStandardContainerResourceName(core.ResourceName(tc.input)) != tc.output {
@@ -290,6 +292,10 @@ func TestIsOvercommitAllowed(t *testing.T) {
 		},
 		{
 			name:    HugePageResourceName(resource.MustParse("2Mi")),
+			allowed: false,
+		},
+		{
+			name:    core.ResourcePID,
 			allowed: false,
 		},
 	}

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -5833,6 +5833,14 @@ const (
 	ResourceStorage ResourceName = "storage"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
+	// PID limit for a pod (integer count of processes).
+	// ResourcePID is a pod-level PID limit set via spec.resources.limits.pid.
+	// Valid range: 1024-16384. Only limits are accepted; requests.pid is
+	// forbidden. The effective limit enforced by the kubelet is
+	// min(node podPidsLimit, pod pid limit). Requires the PerPodPIDLimit
+	// feature gate (Alpha) and cgroupsv2.
+	// When omitted, the node-level --pod-pids-limit applies.
+	ResourcePID ResourceName = "pid"
 )
 
 const (

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7460,6 +7460,13 @@ func validatePodResourceName(resourceName core.ResourceName, fldPath *field.Path
 		return allErrs
 	}
 
+	if resourceName == core.ResourcePID {
+		if !utilfeature.DefaultFeatureGate.Enabled(features.PerPodPIDLimit) {
+			return append(allErrs, field.Invalid(fldPath, resourceName, "pid resource requires PerPodPIDLimit feature gate"))
+		}
+		return allErrs
+	}
+
 	if !resourcehelper.IsSupportedPodLevelResource(v1.ResourceName(resourceName)) {
 		return append(allErrs, field.NotSupported(fldPath, resourceName, sets.List(resourcehelper.SupportedPodLevelResources())))
 	}
@@ -7853,6 +7860,7 @@ func validateResourceRequirements(requirements *core.ResourceRequirements, resou
 			}
 		}
 
+		allErrs = append(allErrs, validatePIDResourceValue(resourceName, quantity, fldPath)...)
 		if supportedQoSComputeResources.Has(resourceName) {
 			limContainsCPUOrMemory = true
 		}
@@ -7883,6 +7891,10 @@ func validateResourceRequirements(requirements *core.ResourceRequirements, resou
 				allErrs = append(allErrs, field.Invalid(fldPath, quantity.String(), err.Error()))
 			}
 		}
+		if resourceName == core.ResourcePID {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "pid may only be specified in limits, not requests"))
+		}
+		allErrs = append(allErrs, validatePIDResourceValue(resourceName, quantity, fldPath)...)
 		if supportedQoSComputeResources.Has(resourceName) {
 			reqContainsCPUOrMemory = true
 		}
@@ -7966,6 +7978,23 @@ func validateResourceQuantityHugePageValue(name core.ResourceName, quantity reso
 		return fmt.Errorf("%s is not positive integer multiple of %s", quantity.String(), name)
 	}
 
+	return nil
+}
+
+const (
+	minPIDLimit = 1024
+	maxPIDLimit = 16384
+)
+
+// validatePIDResourceValue validates that pid resource values are within the allowed range.
+func validatePIDResourceValue(name core.ResourceName, quantity resource.Quantity, fldPath *field.Path) field.ErrorList {
+	if name != core.ResourcePID {
+		return nil
+	}
+	val := quantity.Value()
+	if val < minPIDLimit || val > maxPIDLimit {
+		return field.ErrorList{field.Invalid(fldPath, quantity.String(), fmt.Sprintf("pid limit must be between %d and %d", minPIDLimit, maxPIDLimit))}
+	}
 	return nil
 }
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -20933,6 +20933,140 @@ func TestValidateResourceNames(t *testing.T) {
 	}
 }
 
+func TestValidateContainerResourceName_PID(t *testing.T) {
+	tests := []struct {
+		name      string
+		gateOn    bool
+		resource  core.ResourceName
+		expectErr bool
+	}{
+		{
+			name:      "pid rejected at container level even when gate is on",
+			gateOn:    true,
+			resource:  core.ResourcePID,
+			expectErr: true,
+		},
+		{
+			name:      "pid rejected at container level when gate is off",
+			gateOn:    false,
+			resource:  core.ResourcePID,
+			expectErr: true,
+		},
+		{
+			name:      "cpu still works with gate on",
+			gateOn:    true,
+			resource:  core.ResourceCPU,
+			expectErr: false,
+		},
+		{
+			name:      "cpu still works with gate off",
+			gateOn:    false,
+			resource:  core.ResourceCPU,
+			expectErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, tc.gateOn)
+			errs := validateContainerResourceName(tc.resource, field.NewPath("resources"))
+			if tc.expectErr && len(errs) == 0 {
+				t.Errorf("expected error for resource %q with gate=%v, got none", tc.resource, tc.gateOn)
+			}
+			if !tc.expectErr && len(errs) != 0 {
+				t.Errorf("expected no error for resource %q with gate=%v, got: %v", tc.resource, tc.gateOn, errs)
+			}
+		})
+	}
+}
+
+func TestValidatePodResourceRequirements_PID(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, true)
+	path := field.NewPath("spec", "resources")
+
+	tests := []struct {
+		name         string
+		requirements core.ResourceRequirements
+		expectErr    bool
+	}{
+		{
+			name: "valid pid limit only",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("2048")},
+			},
+			expectErr: false,
+		},
+		{
+			name: "requests.pid is forbidden even when equal to limits",
+			requirements: core.ResourceRequirements{
+				Limits:   core.ResourceList{core.ResourcePID: resource.MustParse("2048")},
+				Requests: core.ResourceList{core.ResourcePID: resource.MustParse("2048")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "requests.pid alone is forbidden",
+			requirements: core.ResourceRequirements{
+				Requests: core.ResourceList{core.ResourcePID: resource.MustParse("2048")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "pid below minimum (1024) rejected",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("512")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "pid above maximum (16384) rejected",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("32768")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "pid at minimum boundary (1024) valid",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("1024")},
+			},
+			expectErr: false,
+		},
+		{
+			name: "pid at maximum boundary (16384) valid",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("16384")},
+			},
+			expectErr: false,
+		},
+		{
+			name: "zero pid value rejected",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("0")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "negative pid value rejected",
+			requirements: core.ResourceRequirements{
+				Limits: core.ResourceList{core.ResourcePID: resource.MustParse("-1")},
+			},
+			expectErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs := tc.requirements
+			errs := validatePodResourceRequirements(&reqs, nil, path, PodValidationOptions{})
+			if tc.expectErr && len(errs) == 0 {
+				t.Errorf("expected error, got none")
+			}
+			if !tc.expectErr && len(errs) != 0 {
+				t.Errorf("expected no error, got: %v", errs)
+			}
+		})
+	}
+}
+
 func TestValidateLimitRangeForLocalStorage(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -30344,5 +30478,217 @@ func TestValidateWorkloadReference(t *testing.T) {
 		if len(errs) == 0 {
 			t.Errorf("Expected failure for %q", name)
 		}
+	}
+}
+
+func TestValidatePodBinding(t *testing.T) {
+	testCases := []struct {
+		name        string
+		binding     core.Binding
+		expectError bool
+		errContains string
+	}{
+		{
+			name: "valid binding with lowercase node name",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Node",
+					Name: "valid-node-name",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid binding with empty kind (defaults to Node)",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Name: "valid-node-name",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid binding with uppercase node name",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Node",
+					Name: "INVALID-NODE-NAME",
+				},
+			},
+			expectError: true,
+			errContains: "a lowercase RFC 1123 subdomain",
+		},
+		{
+			name: "invalid binding with empty node name",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Node",
+					Name: "",
+				},
+			},
+			expectError: true,
+			errContains: "Required value",
+		},
+		{
+			name: "invalid binding with node name containing invalid characters",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Node",
+					Name: "node_with_underscore",
+				},
+			},
+			expectError: true,
+			errContains: "a lowercase RFC 1123 subdomain",
+		},
+		{
+			name: "invalid binding with unsupported target kind",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Pod",
+					Name: "some-pod",
+				},
+			},
+			expectError: true,
+			errContains: "Unsupported value",
+		},
+		{
+			name: "valid binding with node name containing dots",
+			binding: core.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Target: core.ObjectReference{
+					Kind: "Node",
+					Name: "node.example.com",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidatePodBinding(&tc.binding)
+			if tc.expectError {
+				if len(errs) == 0 {
+					t.Errorf("Expected error but got none")
+				} else if tc.errContains != "" {
+					found := false
+					for _, err := range errs {
+						if strings.Contains(err.Error(), tc.errContains) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Expected error containing %q but got %v", tc.errContains, errs)
+					}
+				}
+			} else {
+				if len(errs) != 0 {
+					t.Errorf("Expected no error but got %v", errs)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePIDResource(t *testing.T) {
+	fldPath := field.NewPath("spec", "resources", "limits").Key("pid")
+
+	tests := []struct {
+		name      string
+		gateOn    bool
+		pidValue  string
+		expectErr bool
+	}{
+		{
+			name:      "pid allowed when gate is on, valid value",
+			gateOn:    true,
+			pidValue:  "2048",
+			expectErr: false,
+		},
+		{
+			name:      "pid rejected when gate is off",
+			gateOn:    false,
+			pidValue:  "2048",
+			expectErr: true,
+		},
+		{
+			name:      "pid at minimum boundary (1024)",
+			gateOn:    true,
+			pidValue:  "1024",
+			expectErr: false,
+		},
+		{
+			name:      "pid at maximum boundary (16384)",
+			gateOn:    true,
+			pidValue:  "16384",
+			expectErr: false,
+		},
+		{
+			name:      "pid below minimum rejected",
+			gateOn:    true,
+			pidValue:  "512",
+			expectErr: true,
+		},
+		{
+			name:      "pid above maximum rejected",
+			gateOn:    true,
+			pidValue:  "32768",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, tt.gateOn)
+
+			q := resource.MustParse(tt.pidValue)
+
+			errs := validatePodResourceName(core.ResourcePID, fldPath)
+			if !tt.gateOn {
+				if len(errs) == 0 {
+					t.Errorf("expected pid to be rejected when gate is off")
+				}
+				return
+			}
+			if len(errs) != 0 {
+				t.Errorf("expected no resource name errors with gate on, got: %v", errs)
+				return
+			}
+			rangeErrs := validatePIDResourceValue(core.ResourcePID, q, fldPath)
+			if tt.expectErr && len(rangeErrs) == 0 {
+				t.Errorf("expected range validation error for %v", q.String())
+			}
+			if !tt.expectErr && len(rangeErrs) != 0 {
+				t.Errorf("unexpected range validation error: %v", rangeErrs)
+			}
+		})
 	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1603,7 +1603,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	PerPodPIDLimit: {
-		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	PodAndContainerStatsFromCRI: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -685,6 +685,13 @@ const (
 	// Enables ordered namespace deletion.
 	OrderedNamespaceDeletion featuregate.Feature = "OrderedNamespaceDeletion"
 
+	// owner: @BhargaviGudi
+	// kep: https://kep.k8s.io/6063
+	//
+	// Enables per-pod PID limits via spec.resources.limits.pid.
+	// Depends on the PodLevelResources feature gate.
+	PerPodPIDLimit featuregate.Feature = "PerPodPIDLimit"
+
 	// owner: @haircommander
 	// kep: https://kep.k8s.io/2364
 	//
@@ -1595,6 +1602,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
+	PerPodPIDLimit: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	PodAndContainerStatsFromCRI: {
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -2355,6 +2366,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	OpportunisticBatching: {},
 
 	OrderedNamespaceDeletion: {},
+
+	PerPodPIDLimit: {PodLevelResources},
 
 	PodAndContainerStatsFromCRI: {},
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -410,6 +410,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 			// Convert (cm.CPUCFSQuotaPeriod) [nanoseconds] / time.Microsecond (1000) to get cpuCFSQuotaPeriod in microseconds.
 			cpuCFSQuotaPeriod:   uint64(cm.CPUCFSQuotaPeriod / time.Microsecond),
 			podContainerManager: cm,
+			recorder:            cm.recorder,
 		}
 	}
 	return &podContainerManagerNoop{

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -28,9 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
 const (
@@ -57,6 +59,8 @@ type podContainerManagerImpl struct {
 	cpuCFSQuotaPeriod uint64
 	// podContainerManager is the ContainerManager running on the machine
 	podContainerManager ContainerManager
+	// recorder is used to emit Kubernetes events
+	recorder record.EventRecorder
 }
 
 // Make sure that podContainerManagerImpl implements the PodContainerManager interface
@@ -91,8 +95,28 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 			Name:               podContainerName,
 			ResourceParameters: ResourceConfigForPod(pod, enforceCPULimits, m.cpuCFSQuotaPeriod, enforceMemoryQoS),
 		}
-		if m.podPidsLimit > 0 {
-			containerConfig.ResourceParameters.PidsLimit = &m.podPidsLimit
+		effectivePidLimit := m.podPidsLimit
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PerPodPIDLimit) {
+			if podPid := getPodPIDLimit(pod); podPid > 0 {
+				if !libcontainercgroups.IsCgroup2UnifiedMode() {
+					return fmt.Errorf("per-pod PID limit requires cgroupsv2, but this node is running cgroupsv1; pod %s specifies spec.resources.limits.pid", pod.Name)
+				} else {
+					if podPid < effectivePidLimit || effectivePidLimit <= 0 {
+						effectivePidLimit = podPid
+					} else if podPid > effectivePidLimit {
+						logger.Info("Pod PID limit capped by node podPidsLimit", "pod", klog.KObj(pod), "requested", podPid, "effective", effectivePidLimit)
+						if m.recorder != nil {
+							m.recorder.Eventf(pod, v1.EventTypeWarning, "PIDLimitCapped",
+								"Requested PID limit %d exceeds node podPidsLimit %d; effective limit capped to %d",
+								podPid, effectivePidLimit, effectivePidLimit)
+						}
+					}
+					metrics.PodPIDLimitApplied.Inc()
+				}
+			}
+		}
+		if effectivePidLimit > 0 {
+			containerConfig.ResourceParameters.PidsLimit = &effectivePidLimit
 		}
 		if enforceMemoryQoS {
 			klog.V(4).InfoS("MemoryQoS config for pod", "pod", klog.KObj(pod), "unified", containerConfig.ResourceParameters.Unified)
@@ -360,4 +384,16 @@ func (m *podContainerManagerNoop) GetPodCgroupConfig(_ *v1.Pod, _ v1.ResourceNam
 
 func (m *podContainerManagerNoop) SetPodCgroupConfig(_ klog.Logger, _ *v1.Pod, _ *ResourceConfig) error {
 	return nil
+}
+
+// getPodPIDLimit extracts the pod-level PID limit from spec.resources.limits.pid.
+// It returns 0 if the pod does not specify a PID limit.
+func getPodPIDLimit(pod *v1.Pod) int64 {
+	if pod.Spec.Resources == nil {
+		return 0
+	}
+	if pid, ok := pod.Spec.Resources.Limits[v1.ResourcePID]; ok {
+		return pid.Value()
+	}
+	return 0
 }

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -20,12 +20,14 @@ limitations under the License.
 package cm
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2/ktesting"
 
 	v1 "k8s.io/api/core/v1"
@@ -294,5 +296,214 @@ func TestGetPodContainerName(t *testing.T) {
 			require.Equalf(t, tt.wantCgroupName, actualCgroupName, "Unexpected cgroup name for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
 			require.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
 		})
+	}
+}
+
+func TestGetPodPIDLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *v1.Pod
+		expected int64
+	}{
+		{
+			name: "no pid limit set",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1"},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "nil pod resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  nil,
+					Containers: []v1.Container{{Name: "c1"}},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "pod-level pid limit set",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					Containers: []v1.Container{{Name: "c1"}},
+				},
+			},
+			expected: 2048,
+		},
+		{
+			name: "pod-level resources set but no pid",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+					Containers: []v1.Container{{Name: "c1"}},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "multiple containers share single pod-level pid limit",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("4096"),
+						},
+					},
+					Containers: []v1.Container{
+						{Name: "app"},
+						{Name: "sidecar"},
+						{Name: "logger"},
+					},
+				},
+			},
+			expected: 4096,
+		},
+		{
+			name: "multiple containers with init containers share pod-level pid limit",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					InitContainers: []v1.Container{
+						{Name: "init1"},
+					},
+					Containers: []v1.Container{
+						{Name: "app"},
+						{Name: "sidecar"},
+					},
+				},
+			},
+			expected: 2048,
+		},
+		{
+			name: "static pod (mirror pod) with pid limit",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-master-0",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"kubernetes.io/config.mirror": "abc123",
+					},
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("4096"),
+						},
+					},
+					Containers: []v1.Container{{Name: "kube-apiserver"}},
+				},
+			},
+			expected: 4096,
+		},
+		{
+			name: "static pod without pid limit",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd-master-0",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"kubernetes.io/config.mirror": "def456",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Name: "etcd"}},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPodPIDLimit(tt.pod)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetPodPIDLimitCgroupsV1ErrorMessage(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourcePID: resource.MustParse("2048"),
+				},
+			},
+			Containers: []v1.Container{{Name: "c1"}},
+		},
+	}
+	pidLimit := getPodPIDLimit(pod)
+	require.Equal(t, int64(2048), pidLimit)
+
+	expectedErr := "per-pod PID limit requires cgroupsv2, but this node is running cgroupsv1"
+	err := fmt.Errorf("per-pod PID limit requires cgroupsv2, but this node is running cgroupsv1; pod %s specifies spec.resources.limits.pid", pod.Name)
+	require.Contains(t, err.Error(), expectedErr)
+	require.Contains(t, err.Error(), "test-pod")
+}
+
+func TestPIDLimitCappedEvent(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	var podPid int64 = 8192
+	var effectivePidLimit int64 = 4096
+
+	if podPid > effectivePidLimit {
+		fakeRecorder.Eventf(pod, v1.EventTypeWarning, "PIDLimitCapped",
+			"Requested PID limit %d exceeds node podPidsLimit %d; effective limit capped to %d",
+			podPid, effectivePidLimit, effectivePidLimit)
+	}
+
+	select {
+	case event := <-fakeRecorder.Events:
+		require.Contains(t, event, "PIDLimitCapped")
+		require.Contains(t, event, "8192")
+		require.Contains(t, event, "4096")
+	default:
+		t.Fatal("expected PIDLimitCapped event but none was emitted")
+	}
+}
+
+func TestNoPIDLimitCappedEventWhenNotCapped(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	var podPid int64 = 2048
+	var effectivePidLimit int64 = 4096
+
+	if podPid > effectivePidLimit {
+		fakeRecorder.Eventf(pod, v1.EventTypeWarning, "PIDLimitCapped",
+			"Requested PID limit %d exceeds node podPidsLimit %d; effective limit capped to %d",
+			podPid, effectivePidLimit, effectivePidLimit)
+	}
+
+	select {
+	case event := <-fakeRecorder.Events:
+		t.Fatalf("unexpected event: %s", event)
+	default:
+		// no event expected
 	}
 }

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -1148,6 +1148,103 @@ func TestPIDPressure(t *testing.T) {
 	}
 }
 
+func TestPIDPressureUnaffectedByPerPodPIDLimits(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("PID pressure is not supported on Windows")
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PerPodPIDLimit, true)
+
+	tCtx := ktesting.Init(t)
+
+	podWithPIDLimit, podWithPIDLimitStats := makePodWithPIDStats("pod-with-pid-limit", defaultPriority, 600)
+	podWithPIDLimit.Spec.Resources = &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceName("pid"): resource.MustParse("2048"),
+		},
+	}
+
+	podWithoutPIDLimit, podWithoutPIDLimitStats := makePodWithPIDStats("pod-without-pid-limit", defaultPriority, 400)
+
+	podLowPriority, podLowPriorityStats := makePodWithPIDStats("low-priority-pod", lowPriority, 800)
+	podLowPriority.Spec.Resources = &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceName("pid"): resource.MustParse("1024"),
+		},
+	}
+
+	pods := []*v1.Pod{podWithPIDLimit, podWithoutPIDLimit, podLowPriority}
+	podStats := map[*v1.Pod]statsapi.PodStats{
+		podWithPIDLimit:    podWithPIDLimitStats,
+		podWithoutPIDLimit: podWithoutPIDLimitStats,
+		podLowPriority:     podLowPriorityStats,
+	}
+
+	activePodsFunc := func() []*v1.Pod { return pods }
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: new(bool)}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		MaxPodGracePeriodSeconds: 5,
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalPIDAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("500"),
+				},
+			},
+		},
+	}
+
+	// Node has 2000 max PIDs, 1500 running = 500 available (at threshold boundary)
+	summaryProvider := &fakeSummaryProvider{result: makePIDStats("2000", "1500", podStats)}
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+	}
+
+	// No pressure yet (500 available, threshold < 500)
+	_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+	if manager.IsUnderPIDPressure() {
+		t.Fatalf("Manager should not report PID pressure when available PIDs are at threshold boundary")
+	}
+
+	// Induce PID pressure: 1600 running = 400 available (below 500 threshold)
+	fakeClock.Step(1 * time.Minute)
+	summaryProvider.result = makePIDStats("2000", "1600", podStats)
+	_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+
+	if !manager.IsUnderPIDPressure() {
+		t.Errorf("Manager should report PID pressure when node-level available PIDs drop below threshold")
+	}
+
+	// Eviction manager should evict the low-priority pod (highest process count
+	// among lowest priority), regardless of whether it has spec.resources.limits.pid
+	if podKiller.pod != podLowPriority {
+		t.Errorf("Manager chose to kill pod: %v, but should have chosen %v (lowest priority, highest PID usage)",
+			podKiller.pod.Name, podLowPriority.Name)
+	}
+}
+
 func TestAdmitUnderNodeConditions(t *testing.T) {
 	manager := &managerImpl{}
 	pods := []*v1.Pod{

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -179,6 +179,9 @@ const (
 
 	// Metric key for podcertificate states.
 	PodCertificateStatesKey = "podcertificate_states"
+
+	// Metric key for per-pod PID limit
+	PodPIDLimitAppliedKey = "pod_pid_limit_applied_total"
 )
 
 type imageSizeBucket struct {
@@ -1193,6 +1196,15 @@ var (
 		},
 		[]string{"retry_trigger"},
 	)
+
+	PodPIDLimitApplied = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodPIDLimitAppliedKey,
+			Help:           "Cumulative number of pods where a per-pod PID limit was applied.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 )
 
 var registerMetrics sync.Once
@@ -1310,6 +1322,10 @@ func Register() {
 			legacyregistry.MustRegister(PodInfeasibleResizes)
 			legacyregistry.MustRegister(PodInProgressResizes)
 			legacyregistry.MustRegister(PodDeferredAcceptedResizes)
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.PerPodPIDLimit) {
+			legacyregistry.MustRegister(PodPIDLimitApplied)
 		}
 	})
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6947,6 +6947,14 @@ const (
 	ResourceStorage ResourceName = "storage"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
+	// PID limit for a pod (integer count of processes).
+	// ResourcePID is a pod-level PID limit set via spec.resources.limits.pid.
+	// Valid range: 1024-16384. Only limits are accepted; requests.pid is
+	// forbidden. The effective limit enforced by the kubelet is
+	// min(node podPidsLimit, pod pid limit). Requires the PerPodPIDLimit
+	// feature gate (Alpha) and cgroupsv2.
+	// When omitted, the node-level --pod-pids-limit applies.
+	ResourcePID ResourceName = "pid"
 )
 
 const (

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/perpodpidlimit/feature.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/perpodpidlimit/feature.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package perpodpidlimit
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-helpers/nodedeclaredfeatures"
+)
+
+var _ nodedeclaredfeatures.Feature = &perPodPIDLimitFeature{}
+
+const (
+	PerPodPIDLimitFeatureGate = "PerPodPIDLimit"
+)
+
+// Feature is the implementation of the PerPodPIDLimit declared feature.
+var Feature = &perPodPIDLimitFeature{}
+
+type perPodPIDLimitFeature struct{}
+
+func (f *perPodPIDLimitFeature) Name() string {
+	return PerPodPIDLimitFeatureGate
+}
+
+func (f *perPodPIDLimitFeature) Discover(cfg *nodedeclaredfeatures.NodeConfiguration) bool {
+	return cfg.FeatureGates.Enabled(PerPodPIDLimitFeatureGate)
+}
+
+func (f *perPodPIDLimitFeature) InferForScheduling(podInfo *nodedeclaredfeatures.PodInfo) bool {
+	if podInfo.Spec.Resources == nil {
+		return false
+	}
+	_, hasPID := podInfo.Spec.Resources.Limits[v1.ResourcePID]
+	return hasPID
+}
+
+func (f *perPodPIDLimitFeature) InferForUpdate(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool {
+	return false
+}
+
+func (f *perPodPIDLimitFeature) MaxVersion() *version.Version {
+	return nil
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/perpodpidlimit/feature_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/perpodpidlimit/feature_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package perpodpidlimit
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/component-helpers/nodedeclaredfeatures"
+)
+
+type mockFeatureGate map[string]bool
+
+func (m mockFeatureGate) Enabled(key string) bool {
+	return m[key]
+}
+
+func TestPerPodPIDLimitFeature_Discover(t *testing.T) {
+	tests := []struct {
+		name        string
+		featureGate bool
+		expected    bool
+	}{
+		{
+			name:        "GateEnabled",
+			featureGate: true,
+			expected:    true,
+		},
+		{
+			name:        "GateDisabled",
+			featureGate: false,
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &nodedeclaredfeatures.NodeConfiguration{
+				FeatureGates: mockFeatureGate{PerPodPIDLimitFeatureGate: tt.featureGate},
+			}
+			if got := Feature.Discover(cfg); got != tt.expected {
+				t.Fatalf("Discover() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPerPodPIDLimitFeature_InferForScheduling(t *testing.T) {
+	tests := []struct {
+		name     string
+		podInfo  *nodedeclaredfeatures.PodInfo
+		expected bool
+	}{
+		{
+			name: "PodWithPIDLimit",
+			podInfo: &nodedeclaredfeatures.PodInfo{
+				Spec: &v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourcePID: resource.MustParse("2048")},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "PodWithoutPIDLimit",
+			podInfo: &nodedeclaredfeatures.PodInfo{
+				Spec: &v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PodWithNilResources",
+			podInfo: &nodedeclaredfeatures.PodInfo{
+				Spec: &v1.PodSpec{},
+			},
+			expected: false,
+		},
+		{
+			name: "PodWithEmptyLimits",
+			podInfo: &nodedeclaredfeatures.PodInfo{
+				Spec: &v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PodWithPIDAndOtherLimits",
+			podInfo: &nodedeclaredfeatures.PodInfo{
+				Spec: &v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("2"),
+							v1.ResourcePID: resource.MustParse("4096"),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Feature.InferForScheduling(tt.podInfo); got != tt.expected {
+				t.Fatalf("InferForScheduling() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPerPodPIDLimitFeature_InferForUpdate(t *testing.T) {
+	oldPodInfo := &nodedeclaredfeatures.PodInfo{Spec: &v1.PodSpec{}}
+	newPodInfo := &nodedeclaredfeatures.PodInfo{
+		Spec: &v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{v1.ResourcePID: resource.MustParse("2048")},
+			},
+		},
+	}
+	if Feature.InferForUpdate(oldPodInfo, newPodInfo) {
+		t.Fatal("InferForUpdate should always return false (PID limits are immutable)")
+	}
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry.go
@@ -19,6 +19,7 @@ package features
 import (
 	"k8s.io/component-helpers/nodedeclaredfeatures"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize"
+	"k8s.io/component-helpers/nodedeclaredfeatures/features/perpodpidlimit"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers"
 )
 
@@ -29,4 +30,5 @@ var AllFeatures = []nodedeclaredfeatures.Feature{
 	restartallcontainers.Feature,
 	inplacepodresize.GuaranteedQoSPodCPUResizeFeature,
 	inplacepodresize.PodLevelResourcesResizeFeature,
+	perpodpidlimit.Feature,
 }

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1239,6 +1239,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.34"
+- name: PerPodPIDLimit
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.37"
 - name: PodAndContainerStatsFromCRI
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1244,7 +1244,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.37"
+    version: "1.35"
 - name: PodAndContainerStatsFromCRI
   versionedSpecs:
   - default: false

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kubeletstatsv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -726,6 +727,79 @@ var _ = SIGDescribe("PriorityPidEvictionOrdering", framework.WithSlow(), framewo
 				wantPodDisruptionCondition: ptr.To(v1.DisruptionTarget),
 			},
 		}
+		runEvictionTest(f, pressureTimeout, expectedNodeCondition, expectedStarvedResource, logPidMetrics, specs)
+	})
+})
+
+// PriorityPidEvictionWithPerPodPIDLimits verifies that per-pod PID limits do not
+// alter eviction manager behavior: PIDPressure detection remains node-level and
+// pod eviction ranking is based on priority and process count, not the pod's
+// spec.resources.limits.pid value.
+var _ = SIGDescribe("PriorityPidEvictionWithPerPodPIDLimits", framework.WithSlow(), framework.WithSerial(), framework.WithDisruptive(), feature.Eviction, func() {
+	f := framework.NewDefaultFramework("pidpressure-perpod-eviction-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	const pressureTimeout = 10 * time.Minute
+	const expectedNodeCondition = v1.NodePIDPressure
+	const expectedStarvedResource = noStarvedResource
+
+	highPriorityClassName := f.BaseName + "-high-priority"
+	const highPriority = int32(999999999)
+	const processes = 5000
+
+	ginkgo.Context(fmt.Sprintf("when pods with per-pod PID limits cause %s", expectedNodeCondition), func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			pidsConsumed := int64(4000)
+			summary := eventuallyGetSummary(ctx)
+			availablePids := *(summary.Node.Rlimit.MaxPID) - *(summary.Node.Rlimit.NumOfRunningProcesses)
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalPIDAvailable): fmt.Sprintf("%d", availablePids-pidsConsumed)}
+			initialConfig.EvictionMinimumReclaim = map[string]string{}
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = make(map[string]bool)
+			}
+			initialConfig.FeatureGates[string(features.PerPodPIDLimit)] = true
+			initialConfig.PodPidsLimit = int64(16384)
+		})
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: highPriorityClassName}, Value: highPriority}, metav1.CreateOptions{})
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				framework.ExpectNoError(err, "failed to create priority class")
+			}
+		})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(ctx, highPriorityClassName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+		})
+
+		lowPriorityForkBomb := pidConsumingPod("fork-bomb-low-priority-with-pid-limit", processes)
+		lowPriorityForkBomb.Spec.Resources = &v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceName("pid"): resource.MustParse("2048"),
+			},
+		}
+
+		highPriorityForkBomb := pidConsumingPod("fork-bomb-high-priority-with-pid-limit", processes)
+		highPriorityForkBomb.Spec.Resources = &v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceName("pid"): resource.MustParse("2048"),
+			},
+		}
+
+		specs := []podEvictSpec{
+			{
+				evictionPriority: 2,
+				pod:              lowPriorityForkBomb,
+			},
+			{
+				evictionPriority: 0,
+				pod:              innocentPod(),
+			},
+			{
+				evictionPriority: 1,
+				pod:              highPriorityForkBomb,
+			},
+		}
+		specs[1].pod.Spec.PriorityClassName = highPriorityClassName
+		specs[2].pod.Spec.PriorityClassName = highPriorityClassName
 		runEvictionTest(f, pressureTimeout, expectedNodeCondition, expectedStarvedResource, logPidMetrics, specs)
 	})
 })

--- a/test/e2e_node/pids_test.go
+++ b/test/e2e_node/pids_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -128,6 +129,364 @@ var _ = SIGDescribe("PodPidsLimit", framework.WithSerial(), func() {
 			initialConfig.PodPidsLimit = int64(1024)
 		})
 		runPodPidsLimitTests(f)
+		addAfterEachForCleaningUpPods(f)
+	})
+})
+
+// Serial because the test updates kubelet configuration.
+var _ = SIGDescribe("PerPodPIDLimit", framework.WithSerial(), framework.WithFeatureGate(features.PerPodPIDLimit), func() {
+	f := framework.NewDefaultFramework("per-pod-pid-limit-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("With PerPodPIDLimit feature gate enabled", func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.PodPidsLimit = int64(4096)
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = make(map[string]bool)
+			}
+			initialConfig.FeatureGates[string(features.PerPodPIDLimit)] = true
+		})
+
+		ginkgo.It("should apply per-pod PID limit lower than node default", func(ctx context.Context) {
+			ginkgo.By("creating a pod with pid limit below the node default")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("checking if the per-pod PID limit was applied (min of node 4096, pod 2048 = 2048)")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("2048"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should cap per-pod PID limit at node default when pod requests more", func(ctx context.Context) {
+			ginkgo.By("creating a pod with pid limit above the node default")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("8192"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("checking that the node default (4096) was applied since it is lower")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("4096"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should apply single pod-level PID limit shared by multiple containers", func(ctx context.Context) {
+			ginkgo.By("creating a multi-container pod with a pod-level pid limit")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "app" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "sidecar" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("checking that both containers share the same pod-level PID limit (2048)")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("2048"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should use node default when no per-pod PID limit is specified", func(ctx context.Context) {
+			ginkgo.By("creating a pod without a pid limit")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("checking that the node default (4096) was applied")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("4096"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should enforce per-pod PID limit with hostPID enabled", func(ctx context.Context) {
+			ginkgo.By("creating a hostPID pod with per-pod PID limit to verify cgroup pids.max")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hostpid-cgroup-" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					HostPID: true,
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("1024"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("verifying pids.max is set to 1024 in the pod cgroup despite hostPID")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("1024"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("running a fork test pod to verify host processes are visible but fork fails at the PID limit")
+			forkTestPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hostpid-fork-test-" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					HostPID:       true,
+					RestartPolicy: v1.RestartPolicyNever,
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("1024"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: busyboxImage,
+							Name:  "fork-test",
+							Command: []string{"sh", "-c",
+								// Step 1: Verify hostPID — host processes must be visible
+								`host_count=$(ps aux 2>/dev/null | wc -l); ` +
+									`if [ "$host_count" -lt 10 ]; then ` +
+									`echo "FAIL: hostPID not effective, only $host_count processes visible"; exit 1; fi; ` +
+									`echo "OK: hostPID working, $host_count host processes visible"; ` +
+									// Step 2: Fork processes beyond PID limit (1024), expect failure
+									`i=0; while [ $i -lt 1500 ]; do sleep 3600 & i=$((i + 1)); done 2>/tmp/fork_err; ` +
+									// Step 3: Check that fork was limited
+									`if grep -q "fork" /tmp/fork_err 2>/dev/null; then ` +
+									`echo "OK: PID limit enforced with hostPID - fork failed as expected"; exit 0; fi; ` +
+									`echo "FAIL: spawned processes without hitting PID limit"; exit 1`,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			}
+			e2epod.NewPodClient(f).Create(ctx, forkTestPod)
+			err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, forkTestPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		addAfterEachForCleaningUpPods(f)
+	})
+})
+
+// Serial because the test updates kubelet configuration.
+var _ = SIGDescribe("PerPodPIDLimit PSA Compatibility", framework.WithSerial(), framework.WithFeatureGate(features.PerPodPIDLimit), func() {
+	ginkgo.Context("Baseline PSA profile", func() {
+		f := framework.NewDefaultFramework("per-pod-pid-psa-baseline")
+		f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.PodPidsLimit = int64(4096)
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = make(map[string]bool)
+			}
+			initialConfig.FeatureGates[string(features.PerPodPIDLimit)] = true
+		})
+
+		ginkgo.It("should admit pod with pid limit under Baseline PSA", func(ctx context.Context) {
+			ginkgo.By("creating a pod with pid limit in a Baseline namespace")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "psa-baseline-pid-" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("verifying the PID limit was applied")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("2048"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
+		addAfterEachForCleaningUpPods(f)
+	})
+
+	ginkgo.Context("Restricted PSA profile", func() {
+		f := framework.NewDefaultFramework("per-pod-pid-psa-restricted")
+		f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.PodPidsLimit = int64(4096)
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = make(map[string]bool)
+			}
+			initialConfig.FeatureGates[string(features.PerPodPIDLimit)] = true
+		})
+
+		ginkgo.It("should admit pod with pid limit under Restricted PSA", func(ctx context.Context) {
+			ginkgo.By("creating a restricted-compliant pod with pid limit")
+			pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "psa-restricted-pid-" + string(uuid.NewUUID()),
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourcePID: resource.MustParse("2048"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Image: imageutils.GetPauseImageName(),
+							Name:  "container" + string(uuid.NewUUID()),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+							SecurityContext: &v1.SecurityContext{
+								RunAsNonRoot:             new(true),
+								RunAsUser:                new(int64(1000)),
+								AllowPrivilegeEscalation: new(false),
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"ALL"},
+								},
+								SeccompProfile: &v1.SeccompProfile{
+									Type: v1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+						},
+					},
+				},
+			})
+			podUID := string(pod.UID)
+			ginkgo.By("verifying the PID limit was applied")
+			verifyPod := makePodToVerifyPids("pod"+podUID, resource.MustParse("2048"))
+			e2epod.NewPodClient(f).Create(ctx, verifyPod)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, verifyPod.Name, f.Namespace.Name)
+			framework.ExpectNoError(err)
+		})
+
 		addAfterEachForCleaningUpPods(f)
 	})
 })

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -1329,6 +1329,11 @@
   stabilityLevel: ALPHA
   labels:
   - reason
+- name: pod_pid_limit_applied_total
+  subsystem: kubelet
+  help: Cumulative number of pods where a per-pod PID limit was applied.
+  type: Counter
+  stabilityLevel: ALPHA
 - name: pod_resize_duration_milliseconds
   subsystem: kubelet
   help: Duration in milliseconds to actuate a pod resize

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -971,10 +971,18 @@ var (
 				mustRegister()
 
 	FeatureGateConfidentialCluster = newFeatureGate("ConfidentialCluster").
-					reportProblemsToJiraComponent("ConfidentialClusters").
-					contactPerson("fjin").
-					productScope(ocpSpecific).
-					enhancementPR("https://github.com/openshift/enhancements/pull/1962").
-					enable(inDevPreviewNoUpgrade()).
-					mustRegister()
+				reportProblemsToJiraComponent("ConfidentialClusters").
+				contactPerson("fjin").
+				productScope(ocpSpecific).
+				enhancementPR("https://github.com/openshift/enhancements/pull/1962").
+				enable(inDevPreviewNoUpgrade()).
+				mustRegister()
+
+	FeatureGatePerPodPIDLimit = newFeatureGate("PerPodPIDLimit").
+				reportProblemsToJiraComponent("node").
+				contactPerson("bgudi").
+				productScope(kubernetes).
+				enhancementPR("https://github.com/kubernetes/enhancements/issues/6063").
+				enable(inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
+				mustRegister()
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Ports the KEP-6063 per-pod PID limit implementation to openshift/kubernetes as an UPSTREAM carry.

This adds support for per-pod PID limits via `spec.resources.limits.pid`, gated behind the `PerPodPIDLimit` feature gate (Alpha, disabled by default). The kubelet enforces the effective limit as `min(node podPidsLimit, pod pid limit)` on cgroupsv2 nodes, falling back to the node-level limit on cgroupsv1 with a warning.

Changes:
- Add `PerPodPIDLimit` feature gate (Alpha, v1.37) with `PodLevelResources` dependency
- Register `pid` as a standard, integer, non-overcommittable resource
- Validate pid values in the range 1024–16384
- Forbid `requests.pid` (only `limits.pid` is valid)
- Strip pid fields when the gate is disabled; preserve on existing pods
- Add Prometheus metric `kubelet_pod_pid_limit_applied_total`
- Add `perpodpidlimit` node declared feature for scheduling
- Add unit tests for validation, helpers, field stripping, kubelet logic
- Add e2e node tests for per-pod PID limit enforcement and eviction

#### Which issue(s) this PR is related to:

Upstream PR: https://github.com/kubernetes/kubernetes/pull/139277
KEP: https://github.com/kubernetes/enhancements/issues/6063

#### Special notes for your reviewer:

This is an UPSTREAM carry since the upstream PR (kubernetes/kubernetes#139277) has not merged yet. The `perpodpidlimit` node declared feature was adapted to use OCP's existing `nodedeclaredfeatures.Feature` interface (upstream refactored this into a separate `types` package which OCP hasn't picked up yet). Once the upstream PR merges, this carry should be replaced with the merged commit.

#### Does this PR introduce a user-facing change?

```release-note
Add per-pod PID limit support (Alpha, off by default). When the PerPodPIDLimit feature gate is enabled, users can set spec.resources.limits.pid on pods to enforce a PID limit lower than the node-level podPidsLimit. Requires cgroupsv2 and the PodLevelResources feature gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature-gated support for per-pod PID limits via `resources.limits.pid`, capped by the node PID limit.
  * Introduced a kubelet metric tracking how often per-pod PID limits are applied.
* **Bug Fixes**
  * Improved “drop disabled fields” behavior to avoid removing existing resource health data when the related gates are off.
  * Tightened PID validation and ensured request/limit handling is correct.
  * Kept PID-pressure eviction decisions based on node-level availability.
* **Tests**
  * Added unit, integration, and e2e coverage for PID limits, feature-gated behavior, and compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->