### PR TITLE
UPSTREAM: <carry>: Rate-limit concurrent DRBG inits at request entry …

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/handler.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	rt "runtime"
@@ -183,7 +184,25 @@ func serviceErrorHandler(s runtime.NegotiatedSerializer, serviceErr restful.Serv
 	)
 }
 
+// drbgPrewarmSem limits the number of goroutines concurrently triggering
+// per-thread DRBG initialization via crypto/rand. In FIPS/CGo mode, the first
+// crypto/rand call on a new OS thread initializes OpenSSL's per-thread DRBG,
+// causing Go to create a new OS thread for the CGo call. Without rate-limiting,
+// a reconnect storm (e.g., kubelet watches after apiserver restart) can
+// simultaneously trigger thousands of DRBG inits, exhausting the OS thread limit.
+// The semaphore caps concurrent inits to 64, staggering thread creation over time.
+var drbgPrewarmSem = make(chan struct{}, 64)
+
 // ServeHTTP makes it an http.Handler
 func (a *APIServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Pre-warm the per-thread DRBG under a rate limiter before entering the handler
+	// chain. This covers all crypto/rand callers in the request path, not just
+	// individual call sites. A nil or zero-length read does not trigger DRBG init in
+	// OpenSSL, so we read one byte.
+	var prewarmBuf [1]byte
+	drbgPrewarmSem <- struct{}{}
+	rand.Read(prewarmBuf[:]) //nolint:errcheck
+	<-drbgPrewarmSem
+
 	a.FullHandlerChain.ServeHTTP(w, r)
 }


### PR DESCRIPTION
  
    In FIPS/CGo mode, the first crypto/rand call on a new OS thread triggers
    per-thread DRBG initialization via OpenSSL. Go creates a new OS thread for
    each concurrent CGo call, so a kubelet watch reconnect storm after apiserver
    restart can simultaneously trigger thousands of DRBG inits, exhausting the
    10k OS thread limit.
    
    Add a 64-slot semaphore at APIServerHandler.ServeHTTP that gates each request's
    initial crypto/rand read. This caps concurrent DRBG inits to 64, staggering
    thread creation over time rather than allowing an instantaneous burst.
    
    Note: a nil or zero-length read does not trigger DRBG init in OpenSSL; at
    least one byte must be read to force initialization.
    
    This approach covers all crypto/rand callers in the request path rather than
    individual call sites, and is complementary to the WithAuditInit fix (042a4ae).
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
