### PR TITLE
OCPBUGS-92836: fix bootstrap deadlock when ManagementCPUsOverride rejects pods with 0 nodes

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -192,9 +192,11 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
 	}
 
-	// we still need to have nodes under the cluster to decide if the management resource enabled or not
+	// if the cluster has no nodes yet (e.g. during bootstrap), we cannot determine whether
+	// CPU partitioning is enabled — allow the pod without mutation rather than blocking it,
+	// which would prevent the machine-approver from starting and create a deadlock.
 	if len(nodes) == 0 {
-		return admission.NewForbidden(attr, fmt.Errorf("%s the cluster does not have any nodes", PluginName))
+		return nil
 	}
 
 	clusterInfra, err := a.infraConfigLister.Get(infraClusterName)

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -268,13 +268,12 @@ func TestAdmit(t *testing.T) {
 			infra:              testClusterInfraWithoutWorkloadPartitioning(),
 		},
 		{
-			name:               "should return admission error when the cluster does not have any nodes",
+			name:               "should allow pod without mutation when the cluster does not have any nodes",
 			pod:                testManagedPod("500m", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
 			nodes:              []*corev1.Node{},
 			infra:              testClusterSNOInfra(),
-			expectedError:      fmt.Errorf("the cluster does not have any nodes"),
 		},
 	}
 


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-92836

## Summary

During Baremetal IPI bootstrap (specifically IBM Fusion HCI / Cistern environments), the
ManagementCPUsOverride admission plugin hard-rejects pod creation when `len(nodes) == 0`.
This blocks the machine-approver from starting, which prevents nodes from joining
(CSRs cannot be approved), creating a circular deadlock and stalling the installation
indefinitely.

## Root Cause

In `openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go`,
the `Admit` function returned `admission.NewForbidden(...)` when the node list was empty.
During initial bootstrap, no nodes exist yet, so every pod creation — including critical
infrastructure like the machine-approver — was rejected with:

```
pods "openshift-apiserver-operator-765bd75869-" is forbidden:
autoscaling.openshift.io/ManagementCPUsOverride the cluster does not have any nodes
```

## Fix

Return `nil` (allow without mutation) when `len(nodes) == 0`. This is safe because:

- The plugin cannot determine CPU partitioning status without nodes
- Pods are allowed through unmodified (no incorrect mutations applied)
- Once nodes join, the plugin resumes normal operation for subsequent pod creations
- The customer-verified workaround (disabling the plugin entirely) confirms this code path is correct

## Testing

- Unit tests pass: `go test ./openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/`
- Existing test case updated to validate the new behavior (no error, pod passes through unmodified)
- Customer workaround (manually disabling the plugin on bootstrap) confirms installations succeed once the admission rejection is removed

/cc @ehila