### PR TITLE
OCPBUGS-92836: UPSTREAM: <carry>: upkeep cpu partitioning admission webhook

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
@@ -187,16 +186,6 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, fmt.Errorf("%s node or namespace or infra config cache not synchronized", PluginName))
 	}
 
-	nodes, err := a.nodeLister.List(labels.Everything())
-	if err != nil {
-		return admission.NewForbidden(attr, err) // can happen due to informer latency
-	}
-
-	// we still need to have nodes under the cluster to decide if the management resource enabled or not
-	if len(nodes) == 0 {
-		return admission.NewForbidden(attr, fmt.Errorf("%s the cluster does not have any nodes", PluginName))
-	}
-
 	clusterInfra, err := a.infraConfigLister.Get(infraClusterName)
 	if err != nil {
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
@@ -215,7 +204,7 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 	}
 
 	// Check if we are in CPU Partitioning mode for AllNodes
-	if !isCPUPartitioning(clusterInfra.Status, nodes, workloadType) {
+	if !isCPUPartitioning(clusterInfra.Status) {
 		return nil
 	}
 
@@ -284,18 +273,7 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 	return nil
 }
 
-func isCPUPartitioning(infraStatus configv1.InfrastructureStatus, nodes []*corev1.Node, workloadType string) bool {
-	// If status is not for CPU partitioning and we're single node we also check nodes to support upgrade event
-	// TODO: This should not be needed after 4.13 as all clusters after should have this feature on at install time, or updated by migration in NTO.
-	if infraStatus.CPUPartitioning != configv1.CPUPartitioningAllNodes && infraStatus.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
-		managedResource := fmt.Sprintf("%s.%s", workloadType, containerWorkloadResourceSuffix)
-		for _, node := range nodes {
-			// We only expect a single node to exist, so we return on first hit
-			if _, ok := node.Status.Allocatable[corev1.ResourceName(managedResource)]; ok {
-				return true
-			}
-		}
-	}
+func isCPUPartitioning(infraStatus configv1.InfrastructureStatus) bool {
 	return infraStatus.CPUPartitioning == configv1.CPUPartitioningAllNodes
 }
 

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -87,7 +87,7 @@ func TestAdmit(t *testing.T) {
 			pod:                testManagedPodWithWorkloadAnnotation("500m", "250m", "500Mi", "250Mi", "non-existent"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the pod namespace %q does not allow the workload type non-existent", "managed-namespace"),
 		},
@@ -96,7 +96,7 @@ func TestAdmit(t *testing.T) {
 			pod:                testPod("500m", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 		},
 		{
 			name: "should return admission error when the pod has more than one workload annotation",
@@ -112,7 +112,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the pod can not have more than one workload annotations"),
 		},
@@ -129,7 +129,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the workload annotation key should have format %s<workload_type>", podWorkloadTargetAnnotationPrefix),
 		},
@@ -146,7 +146,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: failed to parse "{" annotation value: unexpected end of JSON input`),
 		},
@@ -163,7 +163,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNodeWithManagementResource()},
+			nodes:              []*corev1.Node{testNode()},
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: the workload annotation value map["test":"test"] does not have "effect" key`),
 			infra:              testClusterSNOInfra(),
 		},
@@ -183,7 +183,7 @@ func TestAdmit(t *testing.T) {
 				workloadAdmissionWarning: "skipping pod CPUs requests modifications because the namespace namespace is not annotated with workload.openshift.io/allowed to allow workload partitioning",
 			},
 			namespace: testNamespace(),
-			nodes:     []*corev1.Node{testNodeWithManagementResource()},
+			nodes:     []*corev1.Node{testNode()},
 			infra:     testClusterSNOInfra(),
 		},
 		{
@@ -196,7 +196,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s":256}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -209,7 +209,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s": 2}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -221,7 +221,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 				kubetypes.ConfigSourceAnnotationKey:                                            kubetypes.FileSource,
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -232,7 +232,7 @@ func TestAdmit(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				workloadAdmissionWarning: "skip pod CPUs requests modifications because it has guaranteed QoS class",
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -245,7 +245,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s":256,"cpulimit":500}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -256,7 +256,7 @@ func TestAdmit(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				workloadAdmissionWarning: fmt.Sprintf("skip pod CPUs requests modifications because it will change the pod QoS class from %s to %s", corev1.PodQOSBurstable, corev1.PodQOSBestEffort),
 			},
-			nodes: []*corev1.Node{testNodeWithManagementResource()},
+			nodes: []*corev1.Node{testNode()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -266,15 +266,6 @@ func TestAdmit(t *testing.T) {
 			namespace:          testManagedNamespace(),
 			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterInfraWithoutWorkloadPartitioning(),
-		},
-		{
-			name:               "should return admission error when the cluster does not have any nodes",
-			pod:                testManagedPod("500m", "250m", "500Mi", "250Mi"),
-			expectedCpuRequest: resource.MustParse("250m"),
-			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{},
-			infra:              testClusterSNOInfra(),
-			expectedError:      fmt.Errorf("the cluster does not have any nodes"),
 		},
 	}
 


### PR DESCRIPTION
cpu partitioning no longer needs to check node for resource types as of 4.13, removing check to clean up any error noise during bootstrap and remove call for nodes since it is no longer needed.

the previous flow checked node resource type for older clusters before the authoritative flag of `cpuPartitioning` was introduced

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU partitioning eligibility evaluation during admission by relying on cluster infrastructure status instead of node listings.
  * Removed an edge case that could incorrectly block or misclassify clusters when no nodes are available.
* **Tests**
  * Updated admission coverage to reflect the new eligibility behavior and removed the obsolete “no nodes” admission expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->