### PR TITLE
STOR-2961: UPSTREAM: 138768: move VolumeGroupSnapshot to V1

### DIFF
--- a/test/e2e/storage/utils/volume_group_snapshot.go
+++ b/test/e2e/storage/utils/volume_group_snapshot.go
@@ -33,16 +33,16 @@ const (
 	// VolumeGroupSnapshot is the group snapshot api
 	VolumeGroupSnapshotAPIGroup = "groupsnapshot.storage.k8s.io"
 	// VolumeGroupSnapshotAPIVersion is the group snapshot api version
-	VolumeGroupSnapshotAPIVersion = "groupsnapshot.storage.k8s.io/v1beta2"
+	VolumeGroupSnapshotAPIVersion = "groupsnapshot.storage.k8s.io/v1"
 )
 
 var (
 
 	// VolumeGroupSnapshotGVR is GroupVersionResource for volumegroupsnapshots
-	VolumeGroupSnapshotGVR = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1beta2", Resource: "volumegroupsnapshots"}
+	VolumeGroupSnapshotGVR = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1", Resource: "volumegroupsnapshots"}
 	// VolumeGroupSnapshotClassGVR is GroupVersionResource for volumegroupsnapshotsclasses
-	VolumeGroupSnapshotClassGVR   = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1beta2", Resource: "volumegroupsnapshotclasses"}
-	VolumeGroupSnapshotContentGVR = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1beta2", Resource: "volumegroupsnapshotcontents"}
+	VolumeGroupSnapshotClassGVR   = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1", Resource: "volumegroupsnapshotclasses"}
+	VolumeGroupSnapshotContentGVR = schema.GroupVersionResource{Group: VolumeGroupSnapshotAPIGroup, Version: "v1", Resource: "volumegroupsnapshotcontents"}
 )
 
 // WaitForVolumeGroupSnapshotReady waits for a VolumeGroupSnapshot to be ready to use or until timeout occurs, whichever comes first.

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -354,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -373,7 +373,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
This is a re-creation of #138768. It updates the group snapshot e2e tests to use v1 group snapshot API and also updates the test manifests to use external-snapshotter that actually supports v1.

The upstream PR is waiting for upstream csi-driver-hostpath release, but in the end it should converge to something like this, only with more image bumps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated storage snapshot support to use the stable v1 API in end-to-end testing utilities.
  * Refreshed snapshotter-sidecar images across CSI test manifests to a newer release.

* **Bug Fixes**
  * Improved compatibility for volume group snapshot test coverage by aligning resources with the current API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->