### PR TITLE
OCPBUGS-92798: Add NodeSelectorAdjuster admission plugin for standalone clusters (part 2)

### DIFF
--- a/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission.go
+++ b/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission.go
@@ -32,6 +32,19 @@ const (
 	// vpaOperatorNamespace is the namespace the VPA operator is expected to run in.
 	vpaOperatorNamespace = "openshift-vertical-pod-autoscaler"
 
+	// croOperatorLabelKey / croOperatorLabelValue identify the CRO operator pod.
+	croOperatorLabelKey   = "clusterresourceoverride.operator"
+	croOperatorLabelValue = "true"
+	// croOperatorNamespace is the namespace the CRO operator is expected to run in.
+	croOperatorNamespace = "openshift-cluster-resource-override"
+
+	// cmaOperatorLabelKey / cmaOperatorLabelValue identify the CMA operator pod.
+	cmaOperatorLabelKey   = "name"
+	cmaOperatorLabelValue = "custom-metrics-autoscaler-operator"
+
+	// cmaOperatorNamespace is the namespace the CMA operator is expected to run in.
+	cmaOperatorNamespace = "openshift-keda"
+
 	// standaloneEnvVar is the environment variable checked at start-up.
 	// It is injected by the downward API and reflects the namespace the
 	// kube-apiserver pod runs in.
@@ -93,14 +106,56 @@ func (p *nodeSelectorAdjuster) ValidateInitialization() error {
 
 // requiresNodeSelectorAdjustment returns true when the pod carries a label that
 // opts it in to control-plane node placement and lives in a namespace where that
-// label is expected. Currently the VPA operator pod opts in via its well-known
-// label. Future control-plane-adjacent Day 2 operators can be added here.
+// label is expected. Control-plane-adjacent Day 2 operators can be added here.
 func requiresNodeSelectorAdjustment(pod *coreapi.Pod) bool {
+	// for VPA, we only want to update if the node selector is the default from
+	// https://github.com/openshift/vertical-pod-autoscaler-operator/blob/main/config/manager/manager.yaml
 	if pod.Labels[vpaOperatorLabelKey] == vpaOperatorLabelValue &&
-		pod.Namespace == vpaOperatorNamespace {
+		pod.Namespace == vpaOperatorNamespace && len(pod.Spec.NodeSelector) == 1 &&
+		pod.Spec.NodeSelector["kubernetes.io/os"] == "linux" {
 		return true
 	}
+	// for CRO, we only want to update if the node selector empty
+	if pod.Labels[croOperatorLabelKey] == croOperatorLabelValue &&
+		pod.Namespace == croOperatorNamespace && len(pod.Spec.NodeSelector) == 0 {
+		return true
+	}
+	// for CMA, we want to update if the node selector is empty
+	// and if it has a toleration that would tolerate the master NoSchedule taint
+	if pod.Labels[cmaOperatorLabelKey] == cmaOperatorLabelValue &&
+		pod.Namespace == cmaOperatorNamespace && len(pod.Spec.NodeSelector) == 0 {
+		masterTaint := coreapi.Taint{
+			Key:    "node-role.kubernetes.io/master",
+			Effect: coreapi.TaintEffectNoSchedule,
+		}
+		for _, tol := range pod.Spec.Tolerations {
+			if toleratesTaint(tol, masterTaint) {
+				return true
+			}
+		}
+	}
 	return false
+}
+
+// toleratesTaint checks if a toleration tolerates a given taint, following the
+// same rules as corev1.Toleration.ToleratesTaint: an empty effect matches all
+// effects, the Exists operator matches any value, and an empty key with Exists
+// matches all keys.
+func toleratesTaint(tol coreapi.Toleration, taint coreapi.Taint) bool {
+	if len(tol.Effect) > 0 && tol.Effect != taint.Effect {
+		return false
+	}
+	if len(tol.Key) > 0 && tol.Key != taint.Key {
+		return false
+	}
+	switch tol.Operator {
+	case "", coreapi.TolerationOpEqual:
+		return tol.Value == taint.Value
+	case coreapi.TolerationOpExists:
+		return true
+	default:
+		return false
+	}
 }
 
 // addControlPlaneNodeSelector ensures spec.nodeSelector contains the control-plane role key.

--- a/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission_test.go
+++ b/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission_test.go
@@ -20,29 +20,52 @@ func TestAdmit(t *testing.T) {
 		expectedNodeSelector map[string]string
 	}{
 		{
-			name: "VPA operator pod: control-plane node selector is added",
+			name: "VPA operator pod with default node selector: control-plane node selector is added",
+			pod: makePod(
+				withNamespace(vpaOperatorNamespace),
+				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux"}),
+			),
+			resource: coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{
+				controlPlaneRoleKey: "",
+				"kubernetes.io/os":  "linux",
+			},
+		},
+		{
+			name: "VPA operator pod with no node selector: not modified",
 			pod: makePod(
 				withNamespace(vpaOperatorNamespace),
 				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
 			),
 			resource:             coreapi.Resource("pods").WithVersion("v1"),
-			expectedNodeSelector: map[string]string{controlPlaneRoleKey: ""},
+			expectedNodeSelector: nil,
 		},
 		{
-			name: "VPA operator pod: control-plane node selector added alongside existing selectors",
+			name: "VPA operator pod with non-default node selector: not modified",
 			pod: makePod(
 				withNamespace(vpaOperatorNamespace),
 				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
 				withNodeSelector(map[string]string{"topology.kubernetes.io/zone": "us-east-1a"}),
 			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+		{
+			name: "VPA operator pod with extra node selectors: not modified",
+			pod: makePod(
+				withNamespace(vpaOperatorNamespace),
+				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux", "topology.kubernetes.io/zone": "us-east-1a"}),
+			),
 			resource: coreapi.Resource("pods").WithVersion("v1"),
 			expectedNodeSelector: map[string]string{
-				controlPlaneRoleKey:           "",
+				"kubernetes.io/os":            "linux",
 				"topology.kubernetes.io/zone": "us-east-1a",
 			},
 		},
 		{
-			name: "VPA operator pod: control-plane node selector already present is left unchanged",
+			name: "VPA operator pod with control-plane selector already present: not modified",
 			pod: makePod(
 				withNamespace(vpaOperatorNamespace),
 				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
@@ -50,6 +73,125 @@ func TestAdmit(t *testing.T) {
 			),
 			resource:             coreapi.Resource("pods").WithVersion("v1"),
 			expectedNodeSelector: map[string]string{controlPlaneRoleKey: ""},
+		},
+		{
+			name: "CRO operator pod with no node selector: control-plane node selector is added",
+			pod: makePod(
+				withNamespace(croOperatorNamespace),
+				withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{controlPlaneRoleKey: ""},
+		},
+		{
+			name: "CRO operator pod with existing node selector: not modified",
+			pod: makePod(
+				withNamespace(croOperatorNamespace),
+				withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux"}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+		},
+		{
+			name: "CRO operator pod in wrong namespace: not modified",
+			pod: makePod(
+				withNamespace("other-namespace"),
+				withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "CRO operator label with wrong value: not modified",
+			pod: makePod(
+				withNamespace(croOperatorNamespace),
+				withLabels(map[string]string{croOperatorLabelKey: "false"}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "CMA operator pod with master toleration: control-plane node selector is added",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{controlPlaneRoleKey: ""},
+		},
+		{
+			name: "CMA operator pod with broad tolerate-all toleration: control-plane node selector is added",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{controlPlaneRoleKey: ""},
+		},
+		{
+			name: "CMA operator pod without master toleration: not modified",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "CMA operator pod with wrong toleration key: not modified",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/control-plane", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "CMA operator pod with existing node selector: not modified",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux"}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+		},
+		{
+			name: "CMA operator pod in wrong namespace: not modified",
+			pod: makePod(
+				withNamespace("other-namespace"),
+				withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "CMA operator label with wrong value: not modified",
+			pod: makePod(
+				withNamespace(cmaOperatorNamespace),
+				withLabels(map[string]string{cmaOperatorLabelKey: "wrong-operator"}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: nil,
 		},
 		{
 			name: "non-qualifying pod: not modified",
@@ -148,13 +290,102 @@ func TestRequiresNodeSelectorAdjustment(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "VPA operator label in correct namespace: match",
-			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue})),
+			name:     "VPA operator with default node selector: match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{"kubernetes.io/os": "linux"})),
 			expected: true,
 		},
 		{
-			name:     "VPA operator label in wrong namespace: no match",
-			pod:      makePod(withNamespace("other-namespace"), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue})),
+			name:     "VPA operator with no node selector: no match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue})),
+			expected: false,
+		},
+		{
+			name:     "VPA operator with non-default node selector: no match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{"topology.kubernetes.io/zone": "us-east-1a"})),
+			expected: false,
+		},
+		{
+			name:     "VPA operator with extra node selectors: no match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{"kubernetes.io/os": "linux", "extra": "value"})),
+			expected: false,
+		},
+		{
+			name:     "VPA operator in wrong namespace: no match",
+			pod:      makePod(withNamespace("other-namespace"), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{"kubernetes.io/os": "linux"})),
+			expected: false,
+		},
+		{
+			name:     "CRO operator with no node selector: match",
+			pod:      makePod(withNamespace(croOperatorNamespace), withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue})),
+			expected: true,
+		},
+		{
+			name:     "CRO operator with existing node selector: no match",
+			pod:      makePod(withNamespace(croOperatorNamespace), withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue}), withNodeSelector(map[string]string{"kubernetes.io/os": "linux"})),
+			expected: false,
+		},
+		{
+			name:     "CRO operator in wrong namespace: no match",
+			pod:      makePod(withNamespace("other-namespace"), withLabels(map[string]string{croOperatorLabelKey: croOperatorLabelValue})),
+			expected: false,
+		},
+		{
+			name:     "CRO operator label with wrong value: no match",
+			pod:      makePod(withNamespace(croOperatorNamespace), withLabels(map[string]string{croOperatorLabelKey: "false"})),
+			expected: false,
+		},
+		{
+			name: "CMA operator with master toleration: match",
+			pod: makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				})),
+			expected: true,
+		},
+		{
+			name: "CMA operator with broad tolerate-all toleration: match",
+			pod: makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Operator: coreapi.TolerationOpExists},
+				})),
+			expected: true,
+		},
+		{
+			name:     "CMA operator without master toleration: no match",
+			pod:      makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue})),
+			expected: false,
+		},
+		{
+			name: "CMA operator with wrong toleration key: no match",
+			pod: makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/control-plane", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				})),
+			expected: false,
+		},
+		{
+			name: "CMA operator with existing node selector: no match",
+			pod: makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux"}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				})),
+			expected: false,
+		},
+		{
+			name: "CMA operator in wrong namespace: no match",
+			pod: makePod(withNamespace("other-namespace"), withLabels(map[string]string{cmaOperatorLabelKey: cmaOperatorLabelValue}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				})),
+			expected: false,
+		},
+		{
+			name: "CMA operator label with wrong value: no match",
+			pod: makePod(withNamespace(cmaOperatorNamespace), withLabels(map[string]string{cmaOperatorLabelKey: "wrong-operator"}),
+				withTolerations([]coreapi.Toleration{
+					{Key: "node-role.kubernetes.io/master", Effect: coreapi.TaintEffectNoSchedule, Operator: coreapi.TolerationOpExists},
+				})),
 			expected: false,
 		},
 		{
@@ -241,6 +472,12 @@ func withNamespace(ns string) func(*coreapi.Pod) {
 func withLabels(labels map[string]string) func(*coreapi.Pod) {
 	return func(p *coreapi.Pod) {
 		p.Labels = labels
+	}
+}
+
+func withTolerations(tolerations []coreapi.Toleration) func(*coreapi.Pod) {
+	return func(p *coreapi.Pod) {
+		p.Spec.Tolerations = tolerations
 	}
 }
 


### PR DESCRIPTION
This is a follow-up to #2695 to address a regression where cluster-adming provided node selector in the operator subscription are ignored.

It also updates NodeSelectorAdjuster to allow Cluster Resource Override and Custom Metrics Autoscaler Operators to run on masters on stand-alone OpenShift clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded automatic node selector adjustment to include additional control-plane-adjacent operator pods (CRO and CMA).
  * Added stricter eligibility checks for VPA, CRO, and CMA, including toleration-aware handling for CMA.
* **Bug Fixes**
  * Avoided node selector mutations when pods already define selectors, have non-empty selectors, or don’t meet required label/namespace and selector-shape (and CMA toleration) conditions.
* **Tests**
  * Expanded admission plugin test coverage with new VPA/CRO/CMA match and non-match cases, including negative toleration permutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->