### PR TITLE
OCPBUGS-98100: e2e: storage snapshot tests should read custom timeouts from manifest

### DIFF
--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -266,7 +266,7 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 		targetDeviceName string
 	)
 
-	f := framework.NewDefaultFramework("snapshotmetadata")
+	f := framework.NewFrameworkWithCustomTimeouts("snapshotmetadata", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	createBackupClientPod := func(ctx context.Context, source, target *v1.PersistentVolumeClaim) *v1.Pod {

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -108,7 +108,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
-	f := framework.NewDefaultFramework("snapshotting")
+	f := framework.NewFrameworkWithCustomTimeouts("snapshotting", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Describe("volume snapshot controller", func() {

--- a/test/e2e/storage/testsuites/snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/snapshottable_stress.go
@@ -120,7 +120,7 @@ func (t *snapshottableStressTestSuite) DefineTests(driver storageframework.TestD
 
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
-	f := framework.NewDefaultFramework("snapshottable-stress")
+	f := framework.NewFrameworkWithCustomTimeouts("snapshottable-stress", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	init := func(ctx context.Context) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-98100

This change is needed so that timeouts specified in https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/175 will take effect during e2e tests.

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot-related end-to-end tests to use storage-driver-specific timeout settings.
  * Improved test reliability across drivers with varying operation durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->