### PR TITLE
OCPBUGS-100065: UPSTREAM: <carry>: require all aggregated apiserver endpoints reachable in readyz check

### DIFF
--- a/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -22,13 +23,41 @@ func newOpenshiftAPIServiceReachabilityCheck(ipForKubernetesDefaultService net.I
 	return newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService, "openshift-apiserver", "api")
 }
 
+// requiredConsecutiveSuccesses is the number of consecutive polls on which every endpoint of the aggregated
+// apiserver service must be reachable before the availability check reports complete.  A single successful
+// connection is not enough: right after a node reboot the pod network may still be converging and connectivity
+// flaps, so a lucky one-off connection must not mark this kube-apiserver as ready to serve aggregated APIs.
+const requiredConsecutiveSuccesses = 3
+
+// allEndpointsReachable returns true when the endpoints object lists at least one ready address and every
+// listed ready address accepts a connection.  Any http response (including errors) counts as reachable,
+// consistent with the anonymous probing done by this check.
+func allEndpointsReachable(client *http.Client, endpoints *corev1.Endpoints, port string) bool {
+	addressCount := 0
+	for _, subset := range endpoints.Subsets {
+		for _, address := range subset.Addresses {
+			addressCount++
+			url := fmt.Sprintf("https://%v", net.JoinHostPort(address.IP, port))
+			resp, err := client.Get(url)
+			if err != nil {
+				klog.V(2).Infof("failed to connect to %q: %v", url, err)
+				return false
+			}
+			response, dumpErr := httputil.DumpResponse(resp, true)
+			klog.V(4).Infof("reached to connect to %q: %v\n%v", url, dumpErr, string(response))
+			resp.Body.Close()
+		}
+	}
+	return addressCount > 0
+}
+
 func newOAuthPIServiceReachabilityCheck(ipForKubernetesDefaultService net.IP) *aggregatedAPIServiceAvailabilityCheck {
 	return newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService, "openshift-oauth-apiserver", "api")
 }
 
 // if the API service is not found, then this check returns quickly.
-// if the endpoint is not accessible within 60 seconds, we report ready no matter what
-// otherwise, wait for up to 60 seconds to be able to reach the apiserver
+// if the endpoints are not accessible within 60 seconds, we report ready no matter what
+// otherwise, wait for up to 60 seconds until every endpoint is reachable on consecutive polls
 func newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService net.IP, namespace, service string) *aggregatedAPIServiceAvailabilityCheck {
 	return &aggregatedAPIServiceAvailabilityCheck{
 		done:                          make(chan struct{}),
@@ -109,10 +138,14 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 		}
 	}
 
-	// Start a thread which repeatedly tries to connect to any aggregated apiserver endpoint.
+	// Start a thread which repeatedly tries to connect to every aggregated apiserver endpoint.
 	//  1. if the aggregated apiserver endpoint doesn't exist, logs a warning and reports ready
-	//  2. if a connection cannot be made, after 60 seconds logs an error and reports ready -- this avoids a rebootstrapping cycle
-	//  3. as soon as a connection can be made, logs a time to be ready and reports ready.
+	//  2. if the connections cannot be made, after 60 seconds logs an error and reports ready -- this avoids a rebootstrapping cycle
+	//  3. as soon as every listed endpoint is reachable on requiredConsecutiveSuccesses consecutive polls, logs a time to be
+	//     ready and reports ready.  Requiring all endpoints (instead of any one) on consecutive polls avoids latching ready
+	//     during a window where pod-network connectivity from this node is still flapping (for instance while OVN is still
+	//     converging right after a node reboot).  Connections established during such a window get pinned by the aggregator's
+	//     http2 transport and produce 503 "http2: client connection lost" errors for tens of seconds after the network heals.
 	go func() {
 		defer utilruntime.HandleCrash()
 
@@ -125,6 +158,7 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 			Timeout: 1 * time.Second, // these should all be very fast.  if none work, we continue anyway.
 		}
 
+		consecutiveSuccesses := 0
 		wait.PollImmediateUntil(1*time.Second, func() (bool, error) {
 			ctx := gocontext.TODO()
 			openshiftEndpoints, err := kubeClient.CoreV1().Endpoints(c.namespace).Get(ctx, c.serviceName, metav1.GetOptions{})
@@ -136,24 +170,19 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 			}
 			if err != nil {
 				utilruntime.HandleError(err)
+				consecutiveSuccesses = 0
 				return false, nil
 			}
-			for _, subset := range openshiftEndpoints.Subsets {
-				for _, address := range subset.Addresses {
-					url := fmt.Sprintf("https://%v", net.JoinHostPort(address.IP, "8443"))
-					resp, err := client.Get(url)
-					if err == nil { // any http response is fine.  it means that we made contact
-						response, dumpErr := httputil.DumpResponse(resp, true)
-						klog.V(4).Infof("reached to connect to %q: %v\n%v", url, dumpErr, string(response))
-						close(reachedAggregatedAPIServer)
-						resp.Body.Close()
-						return true, nil
-					}
-					klog.V(2).Infof("failed to connect to %q: %v", url, err)
-				}
+			if !allEndpointsReachable(&client, openshiftEndpoints, "8443") {
+				consecutiveSuccesses = 0
+				return false, nil
 			}
-
-			return false, nil
+			consecutiveSuccesses++
+			if consecutiveSuccesses < requiredConsecutiveSuccesses {
+				return false, nil
+			}
+			close(reachedAggregatedAPIServer)
+			return true, nil
 		}, waitUntilCh)
 	}()
 
@@ -171,7 +200,7 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 
 	case <-reachedAggregatedAPIServer:
 		end := time.Now()
-		klog.Infof("reached %s via SDN after %v milliseconds", c.namespace, end.Sub(start).Milliseconds())
+		klog.Infof("reached all %s endpoints via SDN after %v milliseconds", c.namespace, end.Sub(start).Milliseconds())
 		return
 	}
 }

--- a/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait_test.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait_test.go
@@ -1,0 +1,107 @@
+package openshiftkubeapiserver
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func endpointsWithAddresses(ips ...string) *corev1.Endpoints {
+	addresses := []corev1.EndpointAddress{}
+	for _, ip := range ips {
+		addresses = append(addresses, corev1.EndpointAddress{IP: ip})
+	}
+	return &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{
+			{Addresses: addresses},
+		},
+	}
+}
+
+// newTLSServer starts a TLS server returning 200 and gives back its host and port.
+func newTLSServer(t *testing.T) (*httptest.Server, string, string) {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("failed to split test server host/port: %v", err)
+	}
+	return server, host, port
+}
+
+func TestAllEndpointsReachableAllUp(t *testing.T) {
+	server, host, port := newTLSServer(t)
+	defer server.Close()
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if !allEndpointsReachable(client, endpointsWithAddresses(host), port) {
+		t.Errorf("expected reachable when the only endpoint is up")
+	}
+}
+
+func TestAllEndpointsReachableAnyHTTPResponseCounts(t *testing.T) {
+	// a 500 response still means we made contact
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	host, port, _ := net.SplitHostPort(u.Host)
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if !allEndpointsReachable(client, endpointsWithAddresses(host), port) {
+		t.Errorf("expected reachable when the endpoint answers with any http response")
+	}
+}
+
+func TestAllEndpointsReachableOneDown(t *testing.T) {
+	server, host, port := newTLSServer(t)
+	defer server.Close()
+
+	// grab a port with no listener for the down endpoint
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate port: %v", err)
+	}
+	downHost, downPort, _ := net.SplitHostPort(listener.Addr().String())
+	listener.Close()
+	if downPort != port {
+		// allEndpointsReachable probes a single port for all addresses; to simulate one
+		// down endpoint we need an address that refuses connections on the same port.
+		// 127.0.0.2 on the server port is not listening in the test environment.
+		downHost = "127.0.0.2"
+	}
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if allEndpointsReachable(client, endpointsWithAddresses(host, downHost), port) {
+		t.Errorf("expected not reachable when one of two endpoints is down")
+	}
+}
+
+func TestAllEndpointsReachableNoAddresses(t *testing.T) {
+	client := &http.Client{Timeout: 1 * time.Second}
+
+	if allEndpointsReachable(client, &corev1.Endpoints{}, "8443") {
+		t.Errorf("expected not reachable when there are no endpoint addresses")
+	}
+	if allEndpointsReachable(client, endpointsWithAddresses(), "8443") {
+		t.Errorf("expected not reachable when the subset lists no addresses")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-100065](https://issues.redhat.com/browse/OCPBUGS-100065): 10-15s of `oauth-api-new-connections` / `openshift-api-new-connections` disruption during metal-ipi upgrades (~30-50% of master-updating runs).

- The `api-openshift-apiserver-available` / `api-openshift-oauth-apiserver-available` readyz checks (`sdn_readyz_wait.go`) latched complete on the **first successful connection to any single endpoint** of the aggregated apiserver service. On a freshly rebooted master, kube-apiserver starts while OVN is still converging; connectivity flaps, and a lucky one-off connection marks the instance ready (observed: `reached openshift-oauth-apiserver via SDN after 13067 milliseconds` at 08:30:33 while the availability controller logged `context deadline exceeded` to another endpoint 3s earlier — run [2081616371841503232](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-upgrade-ovn-ipv6/2081616371841503232)).
- The external LB (haproxy on metal) follows `/readyz` and routes ~1/3 of new connections to the instance; aggregator requests ride http2 connections established during the blackhole window and fail with `503 error trying to reach service: http2: client connection lost` + header timeouts for 40-70s until the transport declares the connections dead. Reproduced with identical signature in run [2080091718912315392](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-upgrade-runc/2080091718912315392); 10/10 analyzed runs with >=10s disruption show an episode starting 39-74s after a master `Rebooted` event.
- Fix: require **every listed ready endpoint** to be reachable on **3 consecutive polls** before the check reports complete. This both delays readiness until the pod network actually converged and ensures backend connections are established post-convergence (no dead-conn pinning). Escape hatches unchanged: missing endpoints object completes immediately; the 60s overall timeout still reports ready no matter what to avoid the rebootstrapping deadlock.
- Adds unit tests for the new `allEndpointsReachable` helper.

## Test plan

- [x] `gofmt`, `go vet`, `go build ./openshift-kube-apiserver/...`
- [x] `go test ./openshift-kube-apiserver/openshiftkubeapiserver/` (new + existing tests pass)
- [ ] e2e-metal-ipi upgrade jobs: verify oauth-api-new-connections disruption episodes no longer correlate with master reboots (expect P50 back to ~0-4s)

---
This PR was generated using AI. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SDN readiness checks to verify that all aggregated API endpoints are reachable.
  - Readiness now requires successful connectivity across multiple consecutive polling cycles, resetting after failures.
  - HTTP responses are treated as reachable regardless of status code.
  - Services with no available endpoint addresses are correctly reported as not ready.

- **Tests**
  - Added coverage for multiple endpoints, unavailable endpoints, empty endpoint lists, and varied HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->