### PR TITLE
OCPBUGS-85262: Re-enable kubectl kuberc commands e2e tests

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -177,9 +177,6 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 			// https://issues.redhat.com/browse/OCPBUGS-61378
 			"[sig-network] Conntrack should be able to cleanup conntrack entries when UDP service target port changes for a NodePort service",
 
-			// https://redhat.atlassian.net/browse/OCPBUGS-85262
-			"[sig-cli] kubectl kuberc commands",
-
 			// https://redhat.atlassian.net/browse/OCPBUGS-64847
 			"[sig-node] [Serial] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-2",
 		},


### PR DESCRIPTION
* The `[sig-cli] kubectl kuberc commands` e2e tests were disabled during the Kubernetes 1.36 rebase because the kuberc subcommand is not yet registered in oc. The test framework prepends `--server/--kubeconfig flags` before the command arguments, and since oc doesn't recognize kuberc as a subcommand, it falls through to the plugin handler which errors with: Error: flags cannot be placed before plugin name: --server=https://.... Once oc is bumped to 1.36 and the kuberc subcommand is properly registered, these tests should be re-enabled by removing the `[sig-cli] kubectl kuberc` commands entry from the RebaseInProgress section in `openshift-hack/cmd/k8s-tests-ext/disabled_tests.go`.      

* `oc` is now bumped to `1.36` in https://github.com/openshift/oc/pull/2318.  So re-enabling the tests                                                                                                                                               


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Re-enabled the `kubectl kuberc commands` CLI test that was previously disabled.
  * Temporarily disabled the Conntrack cleanup test for UDP services when NodePort target ports change.
  * Updated the disabled-test list to reflect these current test coverage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->