### PR TITLE
OCPBUGS-100065: UPSTREAM: <carry>: kube-aggregator: fast http2 health checking for backend connections

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -243,7 +243,8 @@ func (r *proxyHandler) updateAPIService(apiService *apiregistrationv1api.APIServ
 		servicePort:      *apiService.Spec.Service.Port,
 		serviceAvailable: apiregistrationv1apihelper.IsAPIServiceConditionTrue(apiService, apiregistrationv1api.Available),
 	}
-	newInfo.proxyRoundTripper, newInfo.transportBuildingError = transport.New(newInfo.transportConfig)
+	// UPSTREAM: <carry>: use fast http2 health checking for aggregated API backend connections
+	newInfo.proxyRoundTripper, newInfo.transportBuildingError = newAggregatedAPIBackendRoundTripper(newInfo.transportConfig)
 	if newInfo.transportBuildingError != nil {
 		klog.Warning(newInfo.transportBuildingError.Error())
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport.go
@@ -1,0 +1,72 @@
+package apiserver
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
+)
+
+// UPSTREAM: <carry>: fast http2 health checking for aggregated API backend connections
+//
+// The aggregator proxies requests to aggregated apiservers over pooled http2
+// connections.  When such a connection is silently broken (for instance when it was
+// established while the pod network on a freshly rebooted control plane node was
+// still converging), the default health check parameters
+// (ReadIdleTimeout=30s/PingTimeout=15s, see k8s.io/apimachinery/pkg/util/net) keep
+// the dead connection pinned for up to ~45 seconds while every request multiplexed
+// onto it fails with "http2: client connection lost".  Observed as 10-15s of
+// aggregated API disruption during upgrades (OCPBUGS-100065).
+//
+// Detect and drop dead backend connections within seconds instead.  The values are
+// intentionally aggressive: aggregated apiservers are same-cluster backends with
+// sub-second round trips, so a connection that cannot answer a ping for a few
+// seconds is broken for practical purposes and re-dialing is cheap.
+const (
+	aggregatedAPIBackendReadIdleTimeout = 5 * time.Second
+	aggregatedAPIBackendPingTimeout     = 5 * time.Second
+)
+
+// newAggregatedAPIBackendRoundTripper builds the round tripper used to proxy
+// requests to an aggregated apiserver.  It mirrors transport.New for the transport
+// construction, but configures aggressive http2 connection health checking so that
+// broken backend connections are abandoned within seconds.  On any unexpected
+// configuration it falls back to the default transport.New behavior.
+func newAggregatedAPIBackendRoundTripper(cfg *transport.Config) (http.RoundTripper, error) {
+	tlsConfig, err := transport.TLSConfigFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig == nil || cfg.Transport != nil {
+		// no TLS settings or a custom transport: nothing for us to tune, keep the default behavior
+		return transport.New(cfg)
+	}
+
+	// mirror the transport constructed by client-go's transport.New/tlsCache.get
+	t := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSClientConfig:     tlsConfig,
+		TLSHandshakeTimeout: 10 * time.Second,
+		MaxIdleConnsPerHost: 25,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	if cfg.DialHolder != nil {
+		t.DialContext = cfg.DialHolder.Dial
+	}
+
+	t2, err := http2.ConfigureTransports(t)
+	if err != nil {
+		// should not happen; fall back to the default construction rather than failing the APIService
+		klog.Warningf("failed to configure http2 health checking for aggregated API backend transport, falling back to defaults: %v", err)
+		return transport.New(cfg)
+	}
+	t2.ReadIdleTimeout = aggregatedAPIBackendReadIdleTimeout
+	t2.PingTimeout = aggregatedAPIBackendPingTimeout
+
+	// apply the same wrappers (user agent, auth, WrapTransport such as the x509
+	// metrics wrapper) that transport.New would apply
+	return transport.HTTPWrappersForConfig(cfg, t)
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport_test.go
@@ -1,0 +1,64 @@
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/client-go/transport"
+)
+
+func TestNewAggregatedAPIBackendRoundTripperServesRequests(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt, err := newAggregatedAPIBackendRoundTripper(&transport.Config{
+		TLS: transport.TLSConfig{Insecure: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building round tripper: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error building request: %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected round trip error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewAggregatedAPIBackendRoundTripperFallsBackWithoutTLS(t *testing.T) {
+	// no TLS settings: must fall back to transport.New without error
+	rt, err := newAggregatedAPIBackendRoundTripper(&transport.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error building fallback round tripper: %v", err)
+	}
+	if rt == nil {
+		t.Fatalf("expected a round tripper")
+	}
+}
+
+func TestNewAggregatedAPIBackendRoundTripperAppliesWrappers(t *testing.T) {
+	wrapped := false
+	cfg := &transport.Config{
+		TLS: transport.TLSConfig{Insecure: true},
+	}
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		wrapped = true
+		return rt
+	})
+	if _, err := newAggregatedAPIBackendRoundTripper(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrapped {
+		t.Errorf("expected the config WrapTransport to be applied")
+	}
+}


### PR DESCRIPTION
## Summary

Second half of the fix for [OCPBUGS-100065](https://issues.redhat.com/browse/OCPBUGS-100065) (companion to #2730).

- The aggregator proxies requests to aggregated apiservers over pooled http2 connections. When such a connection is silently broken — e.g. established while the pod network on a freshly rebooted master was still converging — the default health check parameters (`ReadIdleTimeout=30s` / `PingTimeout=15s` from `k8s.io/apimachinery/pkg/util/net`) keep the dead connection pinned for up to ~45s while every request multiplexed onto it fails with `503 error trying to reach service: http2: client connection lost`.
- #2730 (readyz reachability gating) reduced the ≥10s disruption incidence from ~31-50% to 1/11 in payload testing, but the [remaining 12s run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-kubernetes-2730-nightly-5.0-e2e-metal-ipi-upgrade-ovn-ipv6/2082271087302807552) proved connections can break *after* readiness (connectivity regressed ~55s post-readyz during the next master's drain) — a readiness gate cannot protect against that; only fast dead-connection detection can.
- This PR configures the aggregator's backend proxy transport with `ReadIdleTimeout=5s` / `PingTimeout=5s`, bounding the impact of any dead backend connection to ~10s of a single endpoint being slow-failed, after which the transport re-dials. Aggregated apiservers are same-cluster backends with sub-second RTTs, so these values are safe.
- Construction mirrors `client-go transport.New` (TLS config, dial holder, wrappers — the x509 metrics wrapper still applies) and falls back to `transport.New` on any unexpected configuration. Touches only the proxy path (`handler_proxy.go`); the availability controller keeps its own transport.

Note for upstreaming: unlike #2730 (OpenShift-specific carry), this change is a candidate for upstream `kube-aggregator` — either as configurable transport health-check parameters or better defaults for same-cluster backends. Will pursue after downstream validation.

## Test plan

- [x] `gofmt`, `go vet`, `go build ./staging/src/k8s.io/kube-aggregator/...`
- [x] `go test ./staging/src/k8s.io/kube-aggregator/pkg/apiserver/` (new + existing tests pass)
- [ ] `/payload-aggregate` metal-ipi upgrade jobs together with #2730: expect oauth-api-new-connections ≤ ~3s across all runs, no ≥10s episodes

---
This PR was generated using AI. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved proxy connections to aggregated API servers with more responsive HTTP/2 health checks.
  - Preserved existing TLS, transport customization, and error-handling behavior.
  - Added safe fallback behavior when enhanced HTTP/2 configuration is unavailable.

- **Tests**
  - Added coverage for secure connections, non-TLS fallback, and transport wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->