### PR TITLE
[DNM] OCPBUGS-100065: combined payload-testing: readyz gating + aggregator h2 health checking

### DIFF
--- a/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -22,13 +23,41 @@ func newOpenshiftAPIServiceReachabilityCheck(ipForKubernetesDefaultService net.I
 	return newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService, "openshift-apiserver", "api")
 }
 
+// requiredConsecutiveSuccesses is the number of consecutive polls on which every endpoint of the aggregated
+// apiserver service must be reachable before the availability check reports complete.  A single successful
+// connection is not enough: right after a node reboot the pod network may still be converging and connectivity
+// flaps, so a lucky one-off connection must not mark this kube-apiserver as ready to serve aggregated APIs.
+const requiredConsecutiveSuccesses = 3
+
+// allEndpointsReachable returns true when the endpoints object lists at least one ready address and every
+// listed ready address accepts a connection.  Any http response (including errors) counts as reachable,
+// consistent with the anonymous probing done by this check.
+func allEndpointsReachable(client *http.Client, endpoints *corev1.Endpoints, port string) bool {
+	addressCount := 0
+	for _, subset := range endpoints.Subsets {
+		for _, address := range subset.Addresses {
+			addressCount++
+			url := fmt.Sprintf("https://%v", net.JoinHostPort(address.IP, port))
+			resp, err := client.Get(url)
+			if err != nil {
+				klog.V(2).Infof("failed to connect to %q: %v", url, err)
+				return false
+			}
+			response, dumpErr := httputil.DumpResponse(resp, true)
+			klog.V(4).Infof("reached to connect to %q: %v\n%v", url, dumpErr, string(response))
+			resp.Body.Close()
+		}
+	}
+	return addressCount > 0
+}
+
 func newOAuthPIServiceReachabilityCheck(ipForKubernetesDefaultService net.IP) *aggregatedAPIServiceAvailabilityCheck {
 	return newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService, "openshift-oauth-apiserver", "api")
 }
 
 // if the API service is not found, then this check returns quickly.
-// if the endpoint is not accessible within 60 seconds, we report ready no matter what
-// otherwise, wait for up to 60 seconds to be able to reach the apiserver
+// if the endpoints are not accessible within 60 seconds, we report ready no matter what
+// otherwise, wait for up to 60 seconds until every endpoint is reachable on consecutive polls
 func newAggregatedAPIServiceReachabilityCheck(ipForKubernetesDefaultService net.IP, namespace, service string) *aggregatedAPIServiceAvailabilityCheck {
 	return &aggregatedAPIServiceAvailabilityCheck{
 		done:                          make(chan struct{}),
@@ -109,10 +138,14 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 		}
 	}
 
-	// Start a thread which repeatedly tries to connect to any aggregated apiserver endpoint.
+	// Start a thread which repeatedly tries to connect to every aggregated apiserver endpoint.
 	//  1. if the aggregated apiserver endpoint doesn't exist, logs a warning and reports ready
-	//  2. if a connection cannot be made, after 60 seconds logs an error and reports ready -- this avoids a rebootstrapping cycle
-	//  3. as soon as a connection can be made, logs a time to be ready and reports ready.
+	//  2. if the connections cannot be made, after 60 seconds logs an error and reports ready -- this avoids a rebootstrapping cycle
+	//  3. as soon as every listed endpoint is reachable on requiredConsecutiveSuccesses consecutive polls, logs a time to be
+	//     ready and reports ready.  Requiring all endpoints (instead of any one) on consecutive polls avoids latching ready
+	//     during a window where pod-network connectivity from this node is still flapping (for instance while OVN is still
+	//     converging right after a node reboot).  Connections established during such a window get pinned by the aggregator's
+	//     http2 transport and produce 503 "http2: client connection lost" errors for tens of seconds after the network heals.
 	go func() {
 		defer utilruntime.HandleCrash()
 
@@ -125,6 +158,7 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 			Timeout: 1 * time.Second, // these should all be very fast.  if none work, we continue anyway.
 		}
 
+		consecutiveSuccesses := 0
 		wait.PollImmediateUntil(1*time.Second, func() (bool, error) {
 			ctx := gocontext.TODO()
 			openshiftEndpoints, err := kubeClient.CoreV1().Endpoints(c.namespace).Get(ctx, c.serviceName, metav1.GetOptions{})
@@ -136,24 +170,19 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 			}
 			if err != nil {
 				utilruntime.HandleError(err)
+				consecutiveSuccesses = 0
 				return false, nil
 			}
-			for _, subset := range openshiftEndpoints.Subsets {
-				for _, address := range subset.Addresses {
-					url := fmt.Sprintf("https://%v", net.JoinHostPort(address.IP, "8443"))
-					resp, err := client.Get(url)
-					if err == nil { // any http response is fine.  it means that we made contact
-						response, dumpErr := httputil.DumpResponse(resp, true)
-						klog.V(4).Infof("reached to connect to %q: %v\n%v", url, dumpErr, string(response))
-						close(reachedAggregatedAPIServer)
-						resp.Body.Close()
-						return true, nil
-					}
-					klog.V(2).Infof("failed to connect to %q: %v", url, err)
-				}
+			if !allEndpointsReachable(&client, openshiftEndpoints, "8443") {
+				consecutiveSuccesses = 0
+				return false, nil
 			}
-
-			return false, nil
+			consecutiveSuccesses++
+			if consecutiveSuccesses < requiredConsecutiveSuccesses {
+				return false, nil
+			}
+			close(reachedAggregatedAPIServer)
+			return true, nil
 		}, waitUntilCh)
 	}()
 
@@ -171,7 +200,7 @@ func (c *aggregatedAPIServiceAvailabilityCheck) checkForConnection(context gener
 
 	case <-reachedAggregatedAPIServer:
 		end := time.Now()
-		klog.Infof("reached %s via SDN after %v milliseconds", c.namespace, end.Sub(start).Milliseconds())
+		klog.Infof("reached all %s endpoints via SDN after %v milliseconds", c.namespace, end.Sub(start).Milliseconds())
 		return
 	}
 }

--- a/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait_test.go
+++ b/openshift-kube-apiserver/openshiftkubeapiserver/sdn_readyz_wait_test.go
@@ -1,0 +1,107 @@
+package openshiftkubeapiserver
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func endpointsWithAddresses(ips ...string) *corev1.Endpoints {
+	addresses := []corev1.EndpointAddress{}
+	for _, ip := range ips {
+		addresses = append(addresses, corev1.EndpointAddress{IP: ip})
+	}
+	return &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{
+			{Addresses: addresses},
+		},
+	}
+}
+
+// newTLSServer starts a TLS server returning 200 and gives back its host and port.
+func newTLSServer(t *testing.T) (*httptest.Server, string, string) {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("failed to split test server host/port: %v", err)
+	}
+	return server, host, port
+}
+
+func TestAllEndpointsReachableAllUp(t *testing.T) {
+	server, host, port := newTLSServer(t)
+	defer server.Close()
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if !allEndpointsReachable(client, endpointsWithAddresses(host), port) {
+		t.Errorf("expected reachable when the only endpoint is up")
+	}
+}
+
+func TestAllEndpointsReachableAnyHTTPResponseCounts(t *testing.T) {
+	// a 500 response still means we made contact
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	host, port, _ := net.SplitHostPort(u.Host)
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if !allEndpointsReachable(client, endpointsWithAddresses(host), port) {
+		t.Errorf("expected reachable when the endpoint answers with any http response")
+	}
+}
+
+func TestAllEndpointsReachableOneDown(t *testing.T) {
+	server, host, port := newTLSServer(t)
+	defer server.Close()
+
+	// grab a port with no listener for the down endpoint
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate port: %v", err)
+	}
+	downHost, downPort, _ := net.SplitHostPort(listener.Addr().String())
+	listener.Close()
+	if downPort != port {
+		// allEndpointsReachable probes a single port for all addresses; to simulate one
+		// down endpoint we need an address that refuses connections on the same port.
+		// 127.0.0.2 on the server port is not listening in the test environment.
+		downHost = "127.0.0.2"
+	}
+
+	client := server.Client()
+	client.Timeout = 1 * time.Second
+
+	if allEndpointsReachable(client, endpointsWithAddresses(host, downHost), port) {
+		t.Errorf("expected not reachable when one of two endpoints is down")
+	}
+}
+
+func TestAllEndpointsReachableNoAddresses(t *testing.T) {
+	client := &http.Client{Timeout: 1 * time.Second}
+
+	if allEndpointsReachable(client, &corev1.Endpoints{}, "8443") {
+		t.Errorf("expected not reachable when there are no endpoint addresses")
+	}
+	if allEndpointsReachable(client, endpointsWithAddresses(), "8443") {
+		t.Errorf("expected not reachable when the subset lists no addresses")
+	}
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -243,7 +243,8 @@ func (r *proxyHandler) updateAPIService(apiService *apiregistrationv1api.APIServ
 		servicePort:      *apiService.Spec.Service.Port,
 		serviceAvailable: apiregistrationv1apihelper.IsAPIServiceConditionTrue(apiService, apiregistrationv1api.Available),
 	}
-	newInfo.proxyRoundTripper, newInfo.transportBuildingError = transport.New(newInfo.transportConfig)
+	// UPSTREAM: <carry>: use fast http2 health checking for aggregated API backend connections
+	newInfo.proxyRoundTripper, newInfo.transportBuildingError = newAggregatedAPIBackendRoundTripper(newInfo.transportConfig)
 	if newInfo.transportBuildingError != nil {
 		klog.Warning(newInfo.transportBuildingError.Error())
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport.go
@@ -1,0 +1,72 @@
+package apiserver
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
+)
+
+// UPSTREAM: <carry>: fast http2 health checking for aggregated API backend connections
+//
+// The aggregator proxies requests to aggregated apiservers over pooled http2
+// connections.  When such a connection is silently broken (for instance when it was
+// established while the pod network on a freshly rebooted control plane node was
+// still converging), the default health check parameters
+// (ReadIdleTimeout=30s/PingTimeout=15s, see k8s.io/apimachinery/pkg/util/net) keep
+// the dead connection pinned for up to ~45 seconds while every request multiplexed
+// onto it fails with "http2: client connection lost".  Observed as 10-15s of
+// aggregated API disruption during upgrades (OCPBUGS-100065).
+//
+// Detect and drop dead backend connections within seconds instead.  The values are
+// intentionally aggressive: aggregated apiservers are same-cluster backends with
+// sub-second round trips, so a connection that cannot answer a ping for a few
+// seconds is broken for practical purposes and re-dialing is cheap.
+const (
+	aggregatedAPIBackendReadIdleTimeout = 5 * time.Second
+	aggregatedAPIBackendPingTimeout     = 5 * time.Second
+)
+
+// newAggregatedAPIBackendRoundTripper builds the round tripper used to proxy
+// requests to an aggregated apiserver.  It mirrors transport.New for the transport
+// construction, but configures aggressive http2 connection health checking so that
+// broken backend connections are abandoned within seconds.  On any unexpected
+// configuration it falls back to the default transport.New behavior.
+func newAggregatedAPIBackendRoundTripper(cfg *transport.Config) (http.RoundTripper, error) {
+	tlsConfig, err := transport.TLSConfigFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig == nil || cfg.Transport != nil {
+		// no TLS settings or a custom transport: nothing for us to tune, keep the default behavior
+		return transport.New(cfg)
+	}
+
+	// mirror the transport constructed by client-go's transport.New/tlsCache.get
+	t := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSClientConfig:     tlsConfig,
+		TLSHandshakeTimeout: 10 * time.Second,
+		MaxIdleConnsPerHost: 25,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	if cfg.DialHolder != nil {
+		t.DialContext = cfg.DialHolder.Dial
+	}
+
+	t2, err := http2.ConfigureTransports(t)
+	if err != nil {
+		// should not happen; fall back to the default construction rather than failing the APIService
+		klog.Warningf("failed to configure http2 health checking for aggregated API backend transport, falling back to defaults: %v", err)
+		return transport.New(cfg)
+	}
+	t2.ReadIdleTimeout = aggregatedAPIBackendReadIdleTimeout
+	t2.PingTimeout = aggregatedAPIBackendPingTimeout
+
+	// apply the same wrappers (user agent, auth, WrapTransport such as the x509
+	// metrics wrapper) that transport.New would apply
+	return transport.HTTPWrappersForConfig(cfg, t)
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_backend_transport_test.go
@@ -1,0 +1,64 @@
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/client-go/transport"
+)
+
+func TestNewAggregatedAPIBackendRoundTripperServesRequests(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt, err := newAggregatedAPIBackendRoundTripper(&transport.Config{
+		TLS: transport.TLSConfig{Insecure: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building round tripper: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error building request: %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected round trip error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewAggregatedAPIBackendRoundTripperFallsBackWithoutTLS(t *testing.T) {
+	// no TLS settings: must fall back to transport.New without error
+	rt, err := newAggregatedAPIBackendRoundTripper(&transport.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error building fallback round tripper: %v", err)
+	}
+	if rt == nil {
+		t.Fatalf("expected a round tripper")
+	}
+}
+
+func TestNewAggregatedAPIBackendRoundTripperAppliesWrappers(t *testing.T) {
+	wrapped := false
+	cfg := &transport.Config{
+		TLS: transport.TLSConfig{Insecure: true},
+	}
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		wrapped = true
+		return rt
+	})
+	if _, err := newAggregatedAPIBackendRoundTripper(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrapped {
+		t.Errorf("expected the config WrapTransport to be applied")
+	}
+}


### PR DESCRIPTION
## Summary

**Draft / DO NOT MERGE — payload-testing vehicle only.**

Combines #2730 (readyz: require all aggregated apiserver endpoints reachable) and #2732 (kube-aggregator: fast http2 health checking) to validate both halves of the [OCPBUGS-100065](https://issues.redhat.com/browse/OCPBUGS-100065) fix together, since `/payload-aggregate-with-prs` on #2732 is not being processed (aggregator infra issues).

Will be closed after results are collected; the individual PRs remain the merge vehicles.

---
This PR was generated using AI. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Aggregated API readiness now requires all available endpoints to be reachable.
  * Readiness is confirmed only after multiple consecutive successful checks.
  * Broken backend connections are detected and discarded more quickly.

* **Bug Fixes**
  * Prevented readiness from being reported when any endpoint is unavailable.
  * Improved handling of backend responses and connection failures.

* **Tests**
  * Added coverage for endpoint reachability, unavailable endpoints, HTTP error responses, TLS connections, and transport fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->