### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Revert "upkeep cpu partitioning admission webhook" (experimental, OCPBUGS-100298)

### DIFF
--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
@@ -186,6 +187,16 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 		return admission.NewForbidden(attr, fmt.Errorf("%s node or namespace or infra config cache not synchronized", PluginName))
 	}
 
+	nodes, err := a.nodeLister.List(labels.Everything())
+	if err != nil {
+		return admission.NewForbidden(attr, err) // can happen due to informer latency
+	}
+
+	// we still need to have nodes under the cluster to decide if the management resource enabled or not
+	if len(nodes) == 0 {
+		return admission.NewForbidden(attr, fmt.Errorf("%s the cluster does not have any nodes", PluginName))
+	}
+
 	clusterInfra, err := a.infraConfigLister.Get(infraClusterName)
 	if err != nil {
 		return admission.NewForbidden(attr, err) // can happen due to informer latency
@@ -204,7 +215,7 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 	}
 
 	// Check if we are in CPU Partitioning mode for AllNodes
-	if !isCPUPartitioning(clusterInfra.Status) {
+	if !isCPUPartitioning(clusterInfra.Status, nodes, workloadType) {
 		return nil
 	}
 
@@ -273,7 +284,18 @@ func (a *managementCPUsOverride) Admit(ctx context.Context, attr admission.Attri
 	return nil
 }
 
-func isCPUPartitioning(infraStatus configv1.InfrastructureStatus) bool {
+func isCPUPartitioning(infraStatus configv1.InfrastructureStatus, nodes []*corev1.Node, workloadType string) bool {
+	// If status is not for CPU partitioning and we're single node we also check nodes to support upgrade event
+	// TODO: This should not be needed after 4.13 as all clusters after should have this feature on at install time, or updated by migration in NTO.
+	if infraStatus.CPUPartitioning != configv1.CPUPartitioningAllNodes && infraStatus.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
+		managedResource := fmt.Sprintf("%s.%s", workloadType, containerWorkloadResourceSuffix)
+		for _, node := range nodes {
+			// We only expect a single node to exist, so we return on first hit
+			if _, ok := node.Status.Allocatable[corev1.ResourceName(managedResource)]; ok {
+				return true
+			}
+		}
+	}
 	return infraStatus.CPUPartitioning == configv1.CPUPartitioningAllNodes
 }
 

--- a/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
+++ b/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride/admission_test.go
@@ -87,7 +87,7 @@ func TestAdmit(t *testing.T) {
 			pod:                testManagedPodWithWorkloadAnnotation("500m", "250m", "500Mi", "250Mi", "non-existent"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the pod namespace %q does not allow the workload type non-existent", "managed-namespace"),
 		},
@@ -96,7 +96,7 @@ func TestAdmit(t *testing.T) {
 			pod:                testPod("500m", "250m", "500Mi", "250Mi"),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 		},
 		{
 			name: "should return admission error when the pod has more than one workload annotation",
@@ -112,7 +112,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the pod can not have more than one workload annotations"),
 		},
@@ -129,7 +129,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf("the workload annotation key should have format %s<workload_type>", podWorkloadTargetAnnotationPrefix),
 		},
@@ -146,7 +146,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			infra:              testClusterSNOInfra(),
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: failed to parse "{" annotation value: unexpected end of JSON input`),
 		},
@@ -163,7 +163,7 @@ func TestAdmit(t *testing.T) {
 			),
 			expectedCpuRequest: resource.MustParse("250m"),
 			namespace:          testManagedNamespace(),
-			nodes:              []*corev1.Node{testNode()},
+			nodes:              []*corev1.Node{testNodeWithManagementResource()},
 			expectedError:      fmt.Errorf(`failed to get workload annotation effect: the workload annotation value map["test":"test"] does not have "effect" key`),
 			infra:              testClusterSNOInfra(),
 		},
@@ -183,7 +183,7 @@ func TestAdmit(t *testing.T) {
 				workloadAdmissionWarning: "skipping pod CPUs requests modifications because the namespace namespace is not annotated with workload.openshift.io/allowed to allow workload partitioning",
 			},
 			namespace: testNamespace(),
-			nodes:     []*corev1.Node{testNode()},
+			nodes:     []*corev1.Node{testNodeWithManagementResource()},
 			infra:     testClusterSNOInfra(),
 		},
 		{
@@ -196,7 +196,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s":256}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -209,7 +209,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s": 2}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -221,7 +221,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 				kubetypes.ConfigSourceAnnotationKey:                                            kubetypes.FileSource,
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -232,7 +232,7 @@ func TestAdmit(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				workloadAdmissionWarning: "skip pod CPUs requests modifications because it has guaranteed QoS class",
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -245,7 +245,7 @@ func TestAdmit(t *testing.T) {
 				fmt.Sprintf("%s%s", containerResourcesAnnotationPrefix, "initTest"):            fmt.Sprintf(`{"%s":256,"cpulimit":500}`, containerResourcesAnnotationValueKeyCPUShares),
 				fmt.Sprintf("%s%s", podWorkloadTargetAnnotationPrefix, workloadTypeManagement): fmt.Sprintf(`{"%s":"%s"}`, podWorkloadAnnotationEffect, workloadEffectPreferredDuringScheduling),
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -256,7 +256,7 @@ func TestAdmit(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				workloadAdmissionWarning: fmt.Sprintf("skip pod CPUs requests modifications because it will change the pod QoS class from %s to %s", corev1.PodQOSBurstable, corev1.PodQOSBestEffort),
 			},
-			nodes: []*corev1.Node{testNode()},
+			nodes: []*corev1.Node{testNodeWithManagementResource()},
 			infra: testClusterSNOInfra(),
 		},
 		{
@@ -266,6 +266,15 @@ func TestAdmit(t *testing.T) {
 			namespace:          testManagedNamespace(),
 			nodes:              []*corev1.Node{testNode()},
 			infra:              testClusterInfraWithoutWorkloadPartitioning(),
+		},
+		{
+			name:               "should return admission error when the cluster does not have any nodes",
+			pod:                testManagedPod("500m", "250m", "500Mi", "250Mi"),
+			expectedCpuRequest: resource.MustParse("250m"),
+			namespace:          testManagedNamespace(),
+			nodes:              []*corev1.Node{},
+			infra:              testClusterSNOInfra(),
+			expectedError:      fmt.Errorf("the cluster does not have any nodes"),
 		},
 	}
 


### PR DESCRIPTION
**DO NOT MERGE — experimental revert for regression diagnosis.**

Reverts #2713 ; tracked by [OCPBUGS-100298](https://issues.redhat.com/browse/OCPBUGS-100298)

This is an *experimental* draft revert used to test whether #2713 is responsible for the internal-LB new-connections disruption regression during kube-apiserver rollouts in `periodic-ci-openshift-release-main-nightly-5.0-e2e-gcp-ovn-serial` observed since Jul 25, 2026.

Context:
- Payload image diff between the last clean payload (`5.0.0-0.nightly-2026-07-25-093347`) and the first affected payload (`5.0.0-0.nightly-2026-07-25-184959`) shows the hyperkube bump `ce96c469a -> 63ee93dac` (= exactly this PR) as the only kube-apiserver code change in the regression window. The previously suspected cluster-kube-apiserver-operator#2247 is provably not in the first affected payload.
- The diff of #2713 looks functionally inert for multi-node GCP clusters, so this experiment is expected to *exonerate* it — in which case a GCP-side infrastructure change becomes the leading hypothesis (see OCPBUGS-100298 comments for the full analysis).

Evaluation plan: run `/payload-job periodic-ci-openshift-release-main-nightly-5.0-e2e-gcp-ovn-serial` (ideally several times, since the regression expresses in ~75% of runs) and inspect internal-LB new-connections disruption counts in the spyglass interval files.

This draft will be closed once the experiment concludes; if the revert eliminates the disruption, a TRT bug will be filed and this will be promoted to a real revert per [OpenShift quick-revert policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert).

CC: @eggfoobar

---
This PR was generated using AI (Assisted-By: Claude Fable 5). Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation when clusters have no nodes, preventing invalid admission decisions.
  * Enhanced CPU partitioning detection for single-replica clusters with workload-specific managed resources.
  * Strengthened node listing validation during initialization to ensure robust cluster configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->