### PR TITLE
WIP: UPSTREAM: 141218: test: create snapshot metadata resources in PrepareTest when CapSnapshotMetadata is enabled

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -376,6 +376,22 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		// Create snapshot metadata resources (CRD is already created by test runner script)
+		ginkgo.By("Creating snapshot metadata resources")
+		err = utils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+		if err != nil {
+			framework.Failf("failed to create snapshot metadata resources: %v", err)
+		}
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("Cleaning up snapshot metadata resources")
+			err = utils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+			if err != nil {
+				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
+			}
+		})
+	}
+
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -174,6 +174,11 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		// added when patching the deployment.
 		storageframework.CapVolumeLimits: true,
 	}
+	// DO NOT MERGE: pre-merge testing functionality when this env var is true in openshift/release
+	err := os.Setenv("CSI_PROW_ENABLE_SNAPSHOT_METADATA", "true")
+	if err != nil {
+		framework.Failf("failed to set CSI_PROW_ENABLE_SNAPSHOT_METADATA: %v", err)
+	}
 	// TODO: It can be removed after the VolumeGroupSnapshot feature is default enabled
 	if os.Getenv("CSI_PROW_ENABLE_GROUP_SNAPSHOT") == "true" {
 		capabilities[storageframework.CapVolumeGroupSnapshot] = true

--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -307,11 +307,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 
 		config = smDriver.PrepareTest(ctx, f)
 
-		// Create snapshot metadata resources (CRD is already created by test runner script)
-		ginkgo.By("Creating snapshot metadata resources")
-		err = storageutils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-		framework.ExpectNoError(err, "Failed to create snapshot metadata resources")
-
 		pattern.VolMode = v1.PersistentVolumeBlock
 		volume = storageframework.CreateVolumeResource(ctx, smDriver, config, pattern, s.GetTestSuiteInfo().SupportedSizeRange)
 		testPVC = volume.Pvc
@@ -359,14 +354,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 			backupClientPod = nil
 		}
 
-		// Cleanup snapshot metadata resources
-		if config != nil {
-			ginkgo.By("Cleaning up snapshot metadata resources")
-			err := storageutils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-			if err != nil {
-				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
-			}
-		}
 	})
 
 	ginkgo.It("should verify GetMetadataDelta", func(ctx context.Context) {


### PR DESCRIPTION
## Summary

Cherry-pick of upstream PR https://github.com/kubernetes/kubernetes/pull/141218

When `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true`, `PrepareTest()` deploys the csi-hostpath
StatefulSet with the `csi-snapshot-metadata` sidecar that mounts a TLS secret volume.
Previously, the secret, Service, and SnapshotMetadataService CR were only created in
the snapshot metadata test suite's `BeforeEach`. Non-snapshot-metadata tests never
created these resources, causing `FailedMount` errors on the secret volume.

This moves resource creation into `PrepareTest()` so all tests that deploy the sidecar
also have the backing resources. Cleanup is handled via `DeferCleanup`.

## Why this is needed downstream

OpenShift CI runs the full CSI suite with snapshot metadata enabled, unlike upstream
which isolates snapshot metadata tests with `FOCUS=[Feature:snapshotmetadata]`. The
bug causes every non-snapshot-metadata CSI hostpath test to fail with:

```
FailedMount: MountVolume.SetUp failed for volume "csi-snapshot-metadata-server-certs":
secret "csi-snapshot-metadata-server-certs" not found
```

## Changes

- `test/e2e/storage/drivers/csi.go`: Call `CreateSnapshotMetadataResources` in `PrepareTest()` when `CapSnapshotMetadata` is enabled, with `DeferCleanup` for teardown
- `test/e2e/storage/testsuites/snapshot-metadata.go`: Remove duplicate resource creation and cleanup from the snapshot metadata test suite (now handled by `PrepareTest`)

/cc @dobsonj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved storage end-to-end test coverage for drivers supporting snapshot metadata.
  - Snapshot metadata resources are now created automatically during test preparation.
  - Added deferred cleanup to help prevent leftover test resources after test execution.
  - Resource creation failures now fail tests clearly, while cleanup issues are logged for troubleshooting.
  - Simplified test teardown by centralizing snapshot metadata resource management across applicable test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->