### PR TITLE
WIP: test csi snapshot metadata in openshift

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -376,6 +376,22 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		// Create snapshot metadata resources (CRD is already created by test runner script)
+		ginkgo.By("Creating snapshot metadata resources")
+		err = utils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+		if err != nil {
+			framework.Failf("failed to create snapshot metadata resources: %v", err)
+		}
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("Cleaning up snapshot metadata resources")
+			err = utils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+			if err != nil {
+				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
+			}
+		})
+	}
+
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -174,6 +174,11 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		// added when patching the deployment.
 		storageframework.CapVolumeLimits: true,
 	}
+	// DO NOT MERGE: pre-merge testing functionality when this env var is true in openshift/release
+	err := os.Setenv("CSI_PROW_ENABLE_SNAPSHOT_METADATA", "true")
+	if err != nil {
+		framework.Failf("failed to set CSI_PROW_ENABLE_SNAPSHOT_METADATA: %v", err)
+	}
 	// TODO: It can be removed after the VolumeGroupSnapshot feature is default enabled
 	if os.Getenv("CSI_PROW_ENABLE_GROUP_SNAPSHOT") == "true" {
 		capabilities[storageframework.CapVolumeGroupSnapshot] = true

--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -307,11 +307,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 
 		config = smDriver.PrepareTest(ctx, f)
 
-		// Create snapshot metadata resources (CRD is already created by test runner script)
-		ginkgo.By("Creating snapshot metadata resources")
-		err = storageutils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-		framework.ExpectNoError(err, "Failed to create snapshot metadata resources")
-
 		pattern.VolMode = v1.PersistentVolumeBlock
 		volume = storageframework.CreateVolumeResource(ctx, smDriver, config, pattern, s.GetTestSuiteInfo().SupportedSizeRange)
 		testPVC = volume.Pvc
@@ -359,14 +354,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 			backupClientPod = nil
 		}
 
-		// Cleanup snapshot metadata resources
-		if config != nil {
-			ginkgo.By("Cleaning up snapshot metadata resources")
-			err := storageutils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-			if err != nil {
-				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
-			}
-		}
 	})
 
 	ginkgo.It("should verify GetMetadataDelta", func(ctx context.Context) {

--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -163,7 +163,7 @@ const (
 	sourceDevicePvcName            = "source-device"
 	targetDevicePvcName            = "target-device"
 	installToolContainerName       = "install-tool"
-	installToolImage               = "golang:1.25.7"
+	installToolImage               = "golang:1.26.1"
 	installToolCommand             = "/bin/sh -c 'go install github.com/kubernetes-csi/external-snapshot-metadata/tools/snapshot-metadata-verifier@main && cp $(go env GOPATH)/bin/snapshot-metadata-verifier /output'"
 	sharedVolumeName               = "shared-volume"
 	sharedVolumeMountPath          = "/tools"


### PR DESCRIPTION
This tests https://github.com/openshift/kubernetes/pull/2739 by temporarily hard coding `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true` so we can see test results when the environment variable is true.

- **e2e: move snapshot metadata resource handling to PrepareTest**
- **DO NOT MERGE: pre-merge testing CSI_PROW_ENABLE_SNAPSHOT_METADATA=true**

/cc @RomanBednar
/hold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved storage integration test coverage for snapshot metadata capabilities.
  * Snapshot metadata resources are now automatically prepared when supported.
  * Added safer deferred cleanup, with cleanup failures reported as warnings rather than interrupting test execution.
  * Removed redundant setup and teardown steps from the snapshot metadata test suite.
  * Updated the snapshot metadata verification environment for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->