### PR TITLE
OCPBUGS-77990: kubelet: close resize race in sync pod

### DIFF
--- a/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
+++ b/openshift-hack/cmd/k8s-tests-ext/disabled_tests.go
@@ -176,9 +176,6 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 
 			// https://issues.redhat.com/browse/OCPBUGS-61378
 			"[sig-network] Conntrack should be able to cleanup conntrack entries when UDP service target port changes for a NodePort service",
-
-			// https://redhat.atlassian.net/browse/OCPBUGS-64847
-			"[sig-node] [Serial] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-2",
 		},
 		// tests that may work, but we don't support them
 		"Unsupported": {

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -110,6 +110,15 @@ type Manager interface {
 
 	// RetryPendingResizes retries all pending resizes.
 	RetryPendingResizes(trigger string)
+
+	// CheckResizeProgress atomically reads the current allocation and checks
+	// whether a resize is still in progress. This is serialized with
+	// retryPendingResizes to prevent a stale SyncPod snapshot from clearing
+	// the PodResizeInProgressCondition that the allocation manager just set.
+	// The isResizeInProgress callback receives the pod with current allocation
+	// applied and should return true if the resize has not yet been actuated.
+	// Returns the cleared generation and true if the resize completed.
+	CheckResizeProgress(pod *v1.Pod, isResizeInProgress func(allocatedPod *v1.Pod) bool) (int64, bool)
 }
 
 type manager struct {
@@ -544,6 +553,19 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 	}
 
 	return ok, reason, message
+}
+
+func (m *manager) CheckResizeProgress(pod *v1.Pod, isResizeInProgress func(allocatedPod *v1.Pod) bool) (int64, bool) {
+	m.allocationMutex.Lock()
+	defer m.allocationMutex.Unlock()
+
+	allocatedPod, _ := m.UpdatePodFromAllocation(pod)
+	if isResizeInProgress(allocatedPod) {
+		m.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
+		return 0, false
+	}
+	generation, cleared := m.statusManager.ClearPodResizeInProgressCondition(pod.UID)
+	return generation, cleared
 }
 
 func (m *manager) RemovePod(uid types.UID) {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -46,27 +46,28 @@ type FakePod struct {
 // FakeRuntime is a fake container runtime for testing.
 type FakeRuntime struct {
 	sync.Mutex
-	CalledFunctions     []string
-	PodList             []*FakePod
-	AllPodList          []*FakePod
-	ImageList           []kubecontainer.Image
-	ImageFsStats        []*runtimeapi.FilesystemUsage
-	ContainerFsStats    []*runtimeapi.FilesystemUsage
-	APIPodStatus        v1.PodStatus
-	PodStatus           kubecontainer.PodStatus
-	StartedPods         []string
-	KilledPods          []string
-	StartedContainers   []string
-	KilledContainers    []string
-	RuntimeStatus       *kubecontainer.RuntimeStatus
-	VersionInfo         string
-	APIVersionInfo      string
-	RuntimeType         string
-	PodResizeInProgress bool
-	SyncResults         *kubecontainer.PodSyncResult
-	Err                 error
-	InspectErr          error
-	StatusErr           error
+	CalledFunctions         []string
+	PodList                 []*FakePod
+	AllPodList              []*FakePod
+	ImageList               []kubecontainer.Image
+	ImageFsStats            []*runtimeapi.FilesystemUsage
+	ContainerFsStats        []*runtimeapi.FilesystemUsage
+	APIPodStatus            v1.PodStatus
+	PodStatus               kubecontainer.PodStatus
+	StartedPods             []string
+	KilledPods              []string
+	StartedContainers       []string
+	KilledContainers        []string
+	RuntimeStatus           *kubecontainer.RuntimeStatus
+	VersionInfo             string
+	APIVersionInfo          string
+	RuntimeType             string
+	PodResizeInProgress     bool
+	PodResizeInProgressFunc func(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool
+	SyncResults             *kubecontainer.PodSyncResult
+	Err                     error
+	InspectErr              error
+	StatusErr               error
 	// If BlockImagePulls is true, then all PullImage() calls will be blocked until
 	// UnblockImagePulls() is called. This is used to simulate image pull latency
 	// from container runtime.
@@ -592,6 +593,9 @@ func (f *FakeRuntime) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Contai
 }
 
 func (f *FakeRuntime) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+	if f.PodResizeInProgressFunc != nil {
+		return f.PodResizeInProgressFunc(allocatedPod, podStatus)
+	}
 	return f.PodResizeInProgress
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2072,17 +2072,13 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		// Check whether a resize is in progress so we can set the PodResizeInProgressCondition accordingly.
-		if kl.containerRuntime.IsPodResizeInProgress(pod, podStatus) {
-			kl.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
-		} else if generation, cleared := kl.statusManager.ClearPodResizeInProgressCondition(pod.UID); cleared {
-			// (Allocated == Actual) => clear the resize in-progress status.
+		generation, completed := kl.allocationManager.CheckResizeProgress(pod, func(allocatedPod *v1.Pod) bool {
+			return kl.containerRuntime.IsPodResizeInProgress(allocatedPod, podStatus)
+		})
+		if completed {
 			msg := events.PodResizeCompletedMsg(logger, pod, generation)
 			kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeNormal, events.ResizeCompleted, "%s", msg)
 		}
-		// TODO(natasha41575): There is a race condition here, where the goroutine in the
-		// allocation manager may allocate a new resize and unconditionally set the
-		// PodResizeInProgressCondition before we set the status below.
 	}
 
 	// Generate final API pod status with pod and status manager status

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -162,10 +163,21 @@ type TestKubelet struct {
 	fakeClock            *testingclock.FakeClock
 	mounter              mount.Interface
 	volumePlugin         *volumetest.FakeVolumePlugin
+	// podSyncWG tracks pod syncs triggered asynchronously by the allocation
+	// manager (e.g. from retryPendingResizes), mirroring the production pod
+	// worker which dispatches syncs on a separate goroutine. Tests that trigger
+	// these syncs should Wait on it before asserting or tearing down.
+	podSyncWG *sync.WaitGroup
 }
 
 func (tk *TestKubelet) Cleanup() {
 	if tk.kubelet != nil {
+		// Drain any pod syncs triggered asynchronously by the allocation
+		// manager (via triggerPodSync) before tearing down, so a stray
+		// goroutine can't run SyncPod against a removed root directory.
+		if tk.podSyncWG != nil {
+			tk.podSyncWG.Wait()
+		}
 		os.RemoveAll(tk.kubelet.rootDirectory)
 		tk.kubelet = nil
 	}
@@ -333,9 +345,21 @@ func newTestKubeletWithImageList(
 		Namespace: "",
 	}
 
+	podSyncWG := &sync.WaitGroup{}
 	kubelet.allocationManager = allocation.NewInMemoryManager(
 		kubelet.statusManager,
-		func(pod *v1.Pod) { kubelet.HandlePodSyncs(tCtx, []*v1.Pod{pod}) },
+		// The production pod worker dispatches syncs asynchronously, so the
+		// allocation manager can trigger a sync while holding allocationMutex
+		// (e.g. from retryPendingResizes) without the resulting SyncPod, which
+		// re-acquires allocationMutex via CheckResizeProgress, deadlocking.
+		// Mirror that here by running the sync on a separate goroutine.
+		func(pod *v1.Pod) {
+			podSyncWG.Add(1)
+			go func() {
+				defer podSyncWG.Done()
+				kubelet.HandlePodSyncs(tCtx, []*v1.Pod{pod})
+			}()
+		},
 		kubelet.GetActivePods,
 		kubelet.podManager.GetPodByUID,
 		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }),
@@ -464,7 +488,7 @@ func newTestKubeletWithImageList(
 	kubelet.AddPodSyncLoopHandler(activeDeadlineHandler)
 	kubelet.AddPodSyncHandler(activeDeadlineHandler)
 	kubelet.kubeletConfiguration.LocalStorageCapacityIsolation = localStorageCapacityIsolation
-	return &TestKubelet{kubelet, fakeRuntime, fakeContainerManager, fakeKubeClient, fakeMirrorClient, fakeClock, nil, plug}
+	return &TestKubelet{kubelet, fakeRuntime, fakeContainerManager, fakeKubeClient, fakeMirrorClient, fakeClock, nil, plug, podSyncWG}
 }
 
 func newTestPods(count int) []*v1.Pod {
@@ -4118,6 +4142,109 @@ func TestSyncPodWithErrorsDuringInPlacePodResize(t *testing.T) {
 	}
 }
 
+func TestSyncPodResizeCompletionUsesCurrentAllocation(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	tCtx := ktesting.Init(t)
+
+	testKubelet := newTestKubeletExcludeAdmitHandlers(t, false /* controllerAttachDetachEnabled */, true /*enableResizing*/)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+	kubelet.recorder = record.NewFakeRecorder(20)
+
+	cpu100m := resource.MustParse("100m")
+	cpu200m := resource.MustParse("200m")
+
+	pod := podWithUIDNameNsSpec("resize-race-pod", "resize-race-pod", "ns", v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "c1",
+				Image: "i1",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu100m},
+				},
+			},
+		},
+	})
+	pod.Generation = 2
+	kubelet.podManager.SetPods([]*v1.Pod{pod})
+
+	t.Run("stale snapshot should not clear in-progress condition", func(t *testing.T) {
+		// Set allocation to 100m, then update to 200m (simulating the
+		// allocation manager goroutine accepting a deferred resize).
+		require.NoError(t, kubelet.allocationManager.SetAllocatedResources(pod))
+		resizedPod := pod.DeepCopy()
+		resizedPod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = cpu200m
+		require.NoError(t, kubelet.allocationManager.SetAllocatedResources(resizedPod))
+		kubelet.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
+
+		// Simulate actuated state at 100m: resize is in progress if
+		// allocated != 100m.
+		testKubelet.fakeRuntime.PodResizeInProgressFunc = func(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+			allocatedCPU := allocatedPod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU]
+			return !allocatedCPU.Equal(cpu100m)
+		}
+
+		// SyncPod receives the stale 100m pod. Without the fix it would
+		// pass 100m to IsPodResizeInProgress, see 100m == actuated, and
+		// clear the condition. With the fix it re-reads allocation (200m),
+		// sees 200m != actuated, and keeps the condition.
+		isTerminal, _, err := kubelet.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+		require.False(t, isTerminal)
+		require.NoError(t, err)
+
+		gotConditions := kubelet.statusManager.GetPodResizeConditions(pod.UID)
+		require.NotNil(t, gotConditions, "PodResizeInProgress condition should not have been cleared")
+		var foundInProgress bool
+		for _, c := range gotConditions {
+			if c.Type == v1.PodResizeInProgress {
+				foundInProgress = true
+			}
+		}
+		require.True(t, foundInProgress, "PodResizeInProgress condition should still be set")
+
+		fakeRecorder := kubelet.recorder.(*record.FakeRecorder)
+		for len(fakeRecorder.Events) > 0 {
+			event := <-fakeRecorder.Events
+			require.NotContains(t, event, "ResizeCompleted", "unexpected ResizeCompleted event: %s", event)
+		}
+	})
+
+	t.Run("completed resize should clear condition and emit event", func(t *testing.T) {
+		// Set allocation to 200m, and actuated state to also be 200m, so
+		// the resize is no longer in progress.
+		resizedPod := pod.DeepCopy()
+		resizedPod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = cpu200m
+		require.NoError(t, kubelet.allocationManager.SetAllocatedResources(resizedPod))
+		kubelet.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
+		testKubelet.fakeRuntime.PodResizeInProgressFunc = func(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+			allocatedCPU := allocatedPod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU]
+			return !allocatedCPU.Equal(cpu200m)
+		}
+
+		isTerminal, _, err := kubelet.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+		require.False(t, isTerminal)
+		require.NoError(t, err)
+
+		gotConditions := kubelet.statusManager.GetPodResizeConditions(pod.UID)
+		for _, c := range gotConditions {
+			require.NotEqual(t, v1.PodResizeInProgress, c.Type, "PodResizeInProgress condition should have been cleared")
+		}
+
+		fakeRecorder := kubelet.recorder.(*record.FakeRecorder)
+		var foundCompleted bool
+		for len(fakeRecorder.Events) > 0 {
+			event := <-fakeRecorder.Events
+			if strings.Contains(event, "ResizeCompleted") {
+				foundCompleted = true
+			}
+		}
+		require.True(t, foundCompleted, "expected ResizeCompleted event")
+	})
+}
+
 func TestHandlePodUpdates_RecordContainerRequestedResizes(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	metrics.Register()
@@ -4898,6 +5025,10 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 
 			kubelet.statusManager.ClearPodResizePendingCondition(pendingResizeDesired.UID)
 			kubelet.HandlePodReconcile(tCtx, []*v1.Pod{tc.newPod})
+			// Wait for any pod syncs triggered by retryPendingResizes (which run
+			// asynchronously, mirroring the production pod worker) to finish
+			// before asserting and tearing down.
+			testKubelet.podSyncWG.Wait()
 			require.Equal(t, tc.shouldRetryPendingResize, kubelet.statusManager.IsPodResizeDeferred(pendingResizeDesired.UID))
 
 			kubelet.allocationManager.RemovePod(pendingResizeDesired.UID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
Formerly there was a race condition where SyncPod would check whether a resize was in progress using a stale snapshot of the pod. The pod worker snapshots the allocation at UpdatePod time, but the allocation manager goroutine may accept a new resize before SyncPod runs, so IsPodResizeInProgress could compare the stale allocation against actuated state and prematurely clear the PodResizeInProgress condition.

Move the resize progress check into the allocation manager (CheckResizeProgress), where it is serialized with retryPendingResizes under allocationMutex. This reads the current allocation and manages the condition atomically, closing the race.

fixes flakes in pod-resize-retry-deferred-test-2 seen in openshift CI

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
co-authored by claude 4.8 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-place pod resizing progress tracking.
  * Pod resize status now remains accurate when allocation data is temporarily outdated.
  * Resize completion is reported only after resources are fully applied.
  * Improved handling of pending resize operations and completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->