### PR TITLE
DNM: OCPBUGS-100065: UPSTREAM: <carry>: kube-aggregator: aggregated-apiservice-reachable readyz check

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -372,6 +372,15 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 			go remote.Run(5, context.Done())
 			return nil
 		})
+
+		// expose the per-instance aggregated API reachability signal computed by the
+		// remote availability controller in readyz, so that external load balancers can
+		// avoid routing traffic to an instance that cannot reach its aggregated backends
+		// (probeable individually via /readyz/aggregated-apiservice-reachable and
+		// excludable via /readyz?exclude=aggregated-apiservice-reachable).
+		if err := s.GenericAPIServer.AddReadyzChecks(NewAggregatedAPIServiceReachableCheck(metrics)); err != nil {
+			return nil, err
+		}
 	}
 
 	s.GenericAPIServer.AddPostStartHookOrDie("apiservice-registration-controller", func(context genericapiserver.PostStartHookContext) error {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/readyz.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/readyz.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/server/healthz"
+	availabilitymetrics "k8s.io/kube-aggregator/pkg/controllers/status/metrics"
+)
+
+// NewAggregatedAPIServiceReachableCheck returns a readyz check that reports
+// failure while any remote (Spec.Service != nil) APIService is considered
+// unavailable from this apiserver instance's point of view.
+//
+// The verdicts come from the remote AvailableConditionController, which
+// probes each APIService's discovery endpoint from this instance over the
+// same proxy transport (and therefore the same pooled connections) used by
+// the aggregation proxy handler. This makes the check a truthful,
+// per-instance signal of aggregated API reachability that an external load
+// balancer can consume, either via the root /readyz or directly via the
+// /readyz/aggregated-apiservice-reachable subpath:
+//   - during a local dataplane outage (e.g. the node's pod network has not
+//     converged after a reboot) the probes fail and the check reports
+//     unready, keeping this instance out of the load balancer rotation;
+//   - if pooled backend connections silently break after readiness, the
+//     probes share the broken pool and the check flips back to unready
+//     until the pool recovers.
+//
+// APIServices that have not been probed yet are treated as reachable, so a
+// freshly started apiserver is not blocked on the first controller sync.
+// Only APIServices that are unavailable because the discovery probe itself
+// failed ("FailedDiscoveryCheck") make the check report unready; structural
+// unavailability (missing Service or Endpoints, e.g. while the aggregated
+// apiserver is still being deployed at install time) is deliberately ignored
+// so that all instances do not drop out of the load balancer at once while a
+// backend is absent cluster-wide.
+func NewAggregatedAPIServiceReachableCheck(metrics *availabilitymetrics.Metrics) healthz.HealthChecker {
+	return &aggregatedAPIServiceReachableCheck{metrics: metrics}
+}
+
+// failedDiscoveryCheckReason is the Available condition reason set by the
+// remote AvailableConditionController when the discovery probe to an
+// APIService's endpoints fails from this instance.
+const failedDiscoveryCheckReason = "FailedDiscoveryCheck"
+
+type aggregatedAPIServiceReachableCheck struct {
+	metrics *availabilitymetrics.Metrics
+}
+
+func (c *aggregatedAPIServiceReachableCheck) Name() string {
+	return "aggregated-apiservice-reachable"
+}
+
+func (c *aggregatedAPIServiceReachableCheck) Check(_ *http.Request) error {
+	if unreachable := c.metrics.UnavailableAPIServices(failedDiscoveryCheckReason); len(unreachable) > 0 {
+		return fmt.Errorf("aggregated APIServices unreachable from this instance: %v", unreachable)
+	}
+	return nil
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/readyz_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/readyz_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	availabilitymetrics "k8s.io/kube-aggregator/pkg/controllers/status/metrics"
+)
+
+func newAPIServiceWithAvailability(name string, available bool, reason string) *apiregistrationv1.APIService {
+	status := apiregistrationv1.ConditionFalse
+	if available {
+		status = apiregistrationv1.ConditionTrue
+	}
+	return &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: apiregistrationv1.APIServiceStatus{
+			Conditions: []apiregistrationv1.APIServiceCondition{{
+				Type:   apiregistrationv1.Available,
+				Status: status,
+				Reason: reason,
+			}},
+		},
+	}
+}
+
+func TestAggregatedAPIServiceReachableCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiServices  []*apiregistrationv1.APIService
+		forget       []string
+		wantHealthy  bool
+		wantInErrMsg []string
+	}{
+		{
+			name:        "no apiservices probed yet",
+			wantHealthy: true,
+		},
+		{
+			name: "all available",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", true, "Passed"),
+				newAPIServiceWithAvailability("v1.route.openshift.io", true, "Passed"),
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "one unreachable via failed discovery check",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", false, "FailedDiscoveryCheck"),
+				newAPIServiceWithAvailability("v1.route.openshift.io", true, "Passed"),
+			},
+			wantHealthy:  false,
+			wantInErrMsg: []string{"v1.oauth.openshift.io"},
+		},
+		{
+			name: "structurally unavailable apiservices are ignored",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", false, "MissingEndpoints"),
+				newAPIServiceWithAvailability("v1.route.openshift.io", false, "ServiceNotFound"),
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "recovery clears the failure",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", false, "FailedDiscoveryCheck"),
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", true, "Passed"),
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "forgotten apiservice clears the failure",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", false, "FailedDiscoveryCheck"),
+			},
+			forget:      []string{"v1.oauth.openshift.io"},
+			wantHealthy: true,
+		},
+		{
+			name: "multiple unreachable are all reported sorted",
+			apiServices: []*apiregistrationv1.APIService{
+				newAPIServiceWithAvailability("v1.route.openshift.io", false, "FailedDiscoveryCheck"),
+				newAPIServiceWithAvailability("v1.oauth.openshift.io", false, "FailedDiscoveryCheck"),
+			},
+			wantHealthy:  false,
+			wantInErrMsg: []string{"v1.oauth.openshift.io", "v1.route.openshift.io"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := availabilitymetrics.New()
+			for _, apiService := range tc.apiServices {
+				m.SetUnavailableGauge(apiService)
+			}
+			for _, name := range tc.forget {
+				m.ForgetAPIService(name)
+			}
+
+			check := NewAggregatedAPIServiceReachableCheck(m)
+			if got, want := check.Name(), "aggregated-apiservice-reachable"; got != want {
+				t.Errorf("Name() = %q, want %q", got, want)
+			}
+
+			err := check.Check(nil)
+			if tc.wantHealthy {
+				if err != nil {
+					t.Fatalf("expected healthy, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected unhealthy, got nil error")
+			}
+			for _, fragment := range tc.wantInErrMsg {
+				if !strings.Contains(err.Error(), fragment) {
+					t.Errorf("error %q does not contain %q", err.Error(), fragment)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"sort"
 	"sync"
 
 	"k8s.io/component-base/metrics"
@@ -47,6 +48,11 @@ type Metrics struct {
 	unavailableCounter *metrics.CounterVec
 
 	*availabilityCollector
+
+	// reasonsMtx guards unavailableReasons, the per-instance record of why each
+	// currently-unavailable APIService was marked unavailable by this instance.
+	reasonsMtx         sync.RWMutex
+	unavailableReasons map[string]string
 }
 
 func New() *Metrics {
@@ -60,6 +66,7 @@ func New() *Metrics {
 			[]string{"name", "reason"},
 		),
 		availabilityCollector: newAvailabilityCollector(),
+		unavailableReasons:    make(map[string]string),
 	}
 }
 
@@ -96,10 +103,16 @@ type availabilityCollector struct {
 // SetUnavailableGauge set the metrics so that it reflect the current state base on availability of the given service
 func (m *Metrics) SetUnavailableGauge(newAPIService *apiregistrationv1.APIService) {
 	if apiregistrationv1apihelper.IsAPIServiceConditionTrue(newAPIService, apiregistrationv1.Available) {
+		m.setUnavailableReason(newAPIService.Name, "")
 		m.SetAPIServiceAvailable(newAPIService.Name)
 		return
 	}
 
+	reason := "UnknownReason"
+	if condition := apiregistrationv1apihelper.GetAPIServiceConditionByType(newAPIService, apiregistrationv1.Available); condition != nil {
+		reason = condition.Reason
+	}
+	m.setUnavailableReason(newAPIService.Name, reason)
 	m.SetAPIServiceUnavailable(newAPIService.Name)
 }
 
@@ -174,4 +187,65 @@ func (c *availabilityCollector) ForgetAPIService(apiServiceKey string) {
 	defer c.mtx.Unlock()
 
 	delete(c.availabilities, apiServiceKey)
+}
+
+// UnavailableAPIServices returns the names of the APIServices currently
+// considered unavailable from this apiserver instance's point of view,
+// together with the reason recorded for the unavailability. Only APIServices
+// whose unavailability reason is contained in the given set are returned; an
+// empty set returns all unavailable APIServices.
+func (m *Metrics) UnavailableAPIServices(reasons ...string) []string {
+	unavailable := m.availabilityCollector.unavailableAPIServices()
+	if len(reasons) == 0 {
+		return unavailable
+	}
+
+	m.reasonsMtx.RLock()
+	defer m.reasonsMtx.RUnlock()
+
+	var filtered []string
+	for _, name := range unavailable {
+		for _, reason := range reasons {
+			if m.unavailableReasons[name] == reason {
+				filtered = append(filtered, name)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// ForgetAPIService removes all records of the given apiservice. It shadows
+// the embedded availabilityCollector method to also clear the recorded
+// unavailability reason.
+func (m *Metrics) ForgetAPIService(apiServiceKey string) {
+	m.setUnavailableReason(apiServiceKey, "")
+	m.availabilityCollector.ForgetAPIService(apiServiceKey)
+}
+
+func (m *Metrics) setUnavailableReason(apiServiceKey, reason string) {
+	m.reasonsMtx.Lock()
+	defer m.reasonsMtx.Unlock()
+
+	if reason == "" {
+		delete(m.unavailableReasons, apiServiceKey)
+		return
+	}
+	m.unavailableReasons[apiServiceKey] = reason
+}
+
+// unavailableAPIServices returns the names of the APIServices currently
+// considered unavailable from this apiserver instance's point of view.
+func (c *availabilityCollector) unavailableAPIServices() []string {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	var unavailable []string
+	for apiServiceName, isAvailable := range c.availabilities {
+		if !isAvailable {
+			unavailable = append(unavailable, apiServiceName)
+		}
+	}
+	sort.Strings(unavailable)
+	return unavailable
 }


### PR DESCRIPTION
**DNM — downstream prototype / payload test vehicle.** Do not review for merge yet; if payload results are good this will drive the upstream discussion in kubernetes/kubernetes#141318.

## What

Exposes the per-instance aggregated API reachability verdicts already computed by the remote `AvailableConditionController` as a named readyz check, `aggregated-apiservice-reachable`:

- probeable individually at `/readyz/aggregated-apiservice-reachable`
- excludable via `/readyz?exclude=aggregated-apiservice-reachable`
- registered unconditionally in this prototype (an upstream version would be flag-gated, default off)

## Why

The remote availability controller probes each APIService's discovery endpoint *from this instance* over the same proxy transport — and, via the client-go transport cache (`transport/cache.go` keys on identical `{certs, CA, serverName, DialHolder}`), **the same pooled http2 connections** — used by the aggregation proxy handler. Its verdicts are therefore a truthful per-instance LB signal that covers **both halves** of OCPBUGS-100065:

1. During the post-reboot OVN convergence window the probes fail → this kas reports unready → haproxy (which already probes `/readyz`) keeps it out of the API VIP rotation. Subsumes the effect of #2730 for LB purposes.
2. If pooled backend connections silently break *after* readiness, the probes share the broken pool → the check flips back to unready until the pool recovers — covering the ~45s `http2: client connection lost` pinning window that is the residual 11-14s tail in every experiment so far (this PR alone, #2730 alone, this-PR+#2730). This is the half that previously only #2732 addressed, now covered without any client-go transport API change (addressing the design objection raised against kubernetes/kubernetes#141320).

## Design guards

- Only `FailedDiscoveryCheck` unavailability (actual probe failure) makes the check report unready. Structural unavailability (`ServiceNotFound`, `MissingEndpoints`, ...) is ignored so all instances don't drop out of the LB at once while a backend is absent cluster-wide (e.g. install time).
- Never-probed APIServices are treated as reachable — a freshly started apiserver isn't blocked on the first controller sync.
- Known residual coupling: a genuine cluster-wide backend network failure would still fail the check on all instances. Acceptable for the prototype; the upstream version would be flag-gated so operators choose.

## Validation

- `go test ./staging/src/k8s.io/kube-aggregator/...` passes; `go build ./cmd/kube-apiserver` OK.
- Payload plan: `/payload-aggregate periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-upgrade-ovn-ipv6 10`, comparing `oauth-api-new-connections` per-run totals against baseline (~31-50% runs ≥10s), #2730 alone (max 12s), MCO#6400 alone (max 11s), MCO#6400+#2730 (max 14s), and #2730+#2732 (max 3s). Hypothesis: this single carry approaches the #2730+#2732 result, bounded by probe latency + haproxy check interval.

Related: OCPBUGS-100065, kubernetes/kubernetes#141318, #2730, #2732, openshift/machine-config-operator#6400.

---
_This PR description was generated using AI. Please verify before acting on it._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness check that reports when aggregated API services cannot be reached.
  * Readiness status now identifies services failing discovery checks and updates as services recover.
  * Unavailable services are reported consistently and in sorted order.

* **Bug Fixes**
  * Improved readiness reporting by excluding unprobed or structurally unavailable services from reachability failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->