### PR TITLE
WIP: UPSTREAM: 141089: mark pods NotReady on False to Unknown

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -719,11 +719,16 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 		}
 
 		if currentReadyCondition != nil {
+			// nodeJustBecameNotReady covers True -> False/Unknown.
+			// nodeStatusWentUnknown covers False -> Unknown (kubernetes#112733).
+			nodeJustBecameNotReady := currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue
+			nodeStatusWentUnknown := currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status != v1.ConditionUnknown
+
 			pods, err := nc.getPodsAssignedToNode(node.Name)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Unable to list pods of node", node.Name)
-				if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
-					// If error happened during node status transition (Ready -> NotReady)
+				if nodeJustBecameNotReady || nodeStatusWentUnknown {
+					// If error happened during node status transition that requires marking pods NotReady,
 					// we need to mark node for retry to force MarkPodsNotReady execution
 					// in the next iteration.
 					nc.nodesToRetry.Store(node.Name, struct{}{})
@@ -733,12 +738,13 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			nc.processTaintBaseEviction(ctx, node, currentReadyCondition)
 
 			_, needsRetry := nc.nodesToRetry.Load(node.Name)
-			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
-				// Report node event only once when status changed.
+			failedAndNeedsRetry := needsRetry && observedReadyCondition.Status != v1.ConditionTrue
+
+			if nodeJustBecameNotReady {
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
-				fallthrough
-			case needsRetry && observedReadyCondition.Status != v1.ConditionTrue:
+			}
+
+			if nodeJustBecameNotReady || nodeStatusWentUnknown || failedAndNeedsRetry {
 				if err = controllerutil.MarkPodsNotReady(ctx, nc.kubeClient, nc.recorder, pods, node.Name); err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to mark all pods NotReady on node; queuing for retry", "node", node.Name)
 					nc.nodesToRetry.Store(node.Name, struct{}{})

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -1933,6 +1933,54 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node created long time ago, with status updated by kubelet exceeds grace period.
+		// Node transitions from False to Unknown.
+		// Expect pods status updated and Unknown node status posted from node controller
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:   v1.NodeReady,
+									Status: v1.ConditionFalse,
+									// Node status hasn't been updated for 1hr.
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+						// Node status hasn't been updated for 1hr.
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true,
+		},
 	}
 
 	tCtx := ktesting.Init(t)


### PR DESCRIPTION
## Summary
- Carry [kubernetes/kubernetes#141089](https://github.com/kubernetes/kubernetes/pull/141089) (`Fixes kubernetes/kubernetes#112733`) into `openshift/kubernetes` while that PR is still open upstream.
- `monitorNodeHealth` now calls `MarkPodsNotReady` on **False → Unknown**, not only True → not-True. DualReplica ACPI posts `Ready=False` (`KubeletNotReady`, node is shutting down) then the 50s grace flips the node to Unknown; without this carry, DaemonSet pods (CoreDNS) stay Ready and EndpointSlice keeps the dead backend.
- Unit test: `TestMonitorNodeHealthMarkPodsNotReady` False → Unknown case.

Drop this commit on the next kube rebase once 141089 is in the upstream tag.

## Test plan
- [x] `go test ./pkg/controller/nodelifecycle/ -run TestMonitorNodeHealthMarkPodsNotReady`
- [ ] Rehearse TNF degraded lane after this is in a release payload (with [openshift/release#83680](https://github.com/openshift/release/pull/83680) ACPI of the KCM non-leader)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of node health transitions, including changes from unhealthy to unknown states.
  * Ensured pod readiness is updated when a node becomes unknown or remains unavailable.
  * Improved retries when retrieving pods during node health changes.
  * Corrected node event recording to reflect transitions from ready to a non-ready state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->