### PR TITLE
WIP: UPSTREAM: <carry>: nodelifecycle: populate nodeHealthMap before pod w…

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -455,6 +455,13 @@ func (nc *Controller) Run(ctx context.Context) {
 		return
 	}
 
+	// Seed nodeHealthMap before pod workers drain the initial Add storm.
+	// processPod returns without requeue when the map is empty, so workers
+	// started first permanently skip pods on nodes that are already NotReady.
+	if err := nc.monitorNodeHealth(ctx); err != nil {
+		logger.Error(err, "Error monitoring node health")
+	}
+
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
 		logger.Info("Starting", "controller", taintEvictionController)
 		wg.Go(func() {
@@ -719,11 +726,15 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 		}
 
 		if currentReadyCondition != nil {
+			transitionedToNotReady := currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue
+			transitionedToUnreachable := currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status == v1.ConditionFalse
+			shouldMarkNotReady := transitionedToNotReady || transitionedToUnreachable
+
 			pods, err := nc.getPodsAssignedToNode(node.Name)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Unable to list pods of node", node.Name)
-				if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
-					// If error happened during node status transition (Ready -> NotReady)
+				if shouldMarkNotReady {
+					// If error happened during node status transition (Ready -> NotReady/Unknown)
 					// we need to mark node for retry to force MarkPodsNotReady execution
 					// in the next iteration.
 					nc.nodesToRetry.Store(node.Name, struct{}{})
@@ -732,13 +743,14 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			}
 			nc.processTaintBaseEviction(ctx, node, currentReadyCondition)
 
-			_, needsRetry := nc.nodesToRetry.Load(node.Name)
-			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
-				// Report node event only once when status changed.
+			if currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status != v1.ConditionUnknown {
+				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeUnreachable")
+			} else if currentReadyCondition.Status == v1.ConditionFalse && observedReadyCondition.Status == v1.ConditionTrue {
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
-				fallthrough
-			case needsRetry && observedReadyCondition.Status != v1.ConditionTrue:
+			}
+
+			_, needsRetry := nc.nodesToRetry.Load(node.Name)
+			if shouldMarkNotReady || (needsRetry && observedReadyCondition.Status != v1.ConditionTrue) {
 				if err = controllerutil.MarkPodsNotReady(ctx, nc.kubeClient, nc.recorder, pods, node.Name); err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to mark all pods NotReady on node; queuing for retry", "node", node.Name)
 					nc.nodesToRetry.Store(node.Name, struct{}{})

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -1933,6 +1933,53 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node status updated to False. Then grace period passes and it goes to Unknown.
+		// Expect pods status updated.
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  fakeNow,
+									LastTransitionTime: fakeNow,
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			// newNodeStatus represents the input status in the fake client before monitorNodeHealth runs.
+			// The heartbeat is expired, so the controller will transition the status to Unknown.
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionFalse,
+						LastHeartbeatTime:  fakeNow,
+						LastTransitionTime: fakeNow,
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true,
+		},
 	}
 
 	tCtx := ktesting.Init(t)
@@ -2233,6 +2280,63 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 				{
 					timeToPass: 1 * time.Minute,
 					newNodes:   makeNodes(v1.ConditionFalse, timePlusTwoMinutes, timePlusTwoMinutes),
+				},
+			},
+			expectedPodStatusUpdates: 1,
+		},
+		// Node created long time ago, with status updated by kubelet exceeds grace period.
+		// First monitorNodeHealth check will fail to list pods (with False -> Unknown transition).
+		// Second monitorNodeHealth check will update pod status to NotReady (retry).
+		{
+			desc: "unsuccessful pod list on false -> unknown transition, retry required",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  timeNow,
+									LastTransitionTime: timeNow,
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			fakeGetPodsAssignedToNode: func(c *fake.Clientset) func(string) ([]*v1.Pod, error) {
+				i := 0
+				f := fakeGetPodsAssignedToNode(c)
+				return func(nodeName string) ([]*v1.Pod, error) {
+					i++
+					if i == 1 {
+						return nil, fmt.Errorf("fake error")
+					}
+					return f(nodeName)
+				}
+			},
+			nodeIterations: []nodeIteration{
+				{
+					timeToPass: 0,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+				{
+					timeToPass: 1 * time.Minute,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+				{
+					timeToPass: 1 * time.Minute,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
 				},
 			},
 			expectedPodStatusUpdates: 1,
@@ -3899,5 +4003,122 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 				t.Errorf("expect pod status updated to be %v, but got %v", item.expectedPodStatusUpdate, podStatusUpdated)
 			}
 		})
+	}
+}
+
+func TestNodeStatusChangeEventGeneration(t *testing.T) {
+	fakeNow := metav1.Date(2016, 9, 10, 12, 0, 0, 0, time.UTC)
+	fakeNodeHandler := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					UID:               "1234567890",
+					CreationTimestamp: metav1.Date(2015, 8, 10, 0, 0, 0, 0, time.UTC),
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionTrue,
+							LastHeartbeatTime:  fakeNow,
+							LastTransitionTime: fakeNow,
+						},
+					},
+				},
+			},
+		},
+		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+	}
+
+	tCtx := ktesting.Init(t)
+	nodeController, _ := newNodeLifecycleControllerFromClient(
+		tCtx,
+		fakeNodeHandler,
+		testRateLimiterQPS,
+		testRateLimiterQPS,
+		testLargeClusterThreshold,
+		testUnhealthyThreshold,
+		testNodeMonitorGracePeriod,
+		testNodeMonitorGracePeriod,
+		testNodeMonitorPeriod,
+	)
+	nodeController.now = func() metav1.Time { return fakeNow }
+	fakeRecorder := testutil.NewFakeRecorder()
+	nodeController.recorder = fakeRecorder
+	nodeController.getPodsAssignedToNode = fakeGetPodsAssignedToNode(fakeNodeHandler.Clientset)
+
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// First run to populate nodeHealthMap
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Clear events (RegisteredNode event is recorded on first run)
+	fakeRecorder.Events = []*v1.Event{}
+
+	// 1. Transition True -> Unknown (via heartbeat expiration)
+	nodeController.now = func() metav1.Time { return metav1.Time{Time: fakeNow.Add(10 * time.Minute)} } // Exceeds grace period
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Expect NodeUnreachable event
+	foundUnreachable := false
+	for _, event := range fakeRecorder.Events {
+		if event.Reason == "NodeUnreachable" {
+			foundUnreachable = true
+			break
+		}
+	}
+	if !foundUnreachable {
+		t.Errorf("Expected NodeUnreachable event not found. Events: %v", fakeRecorder.Events)
+	}
+
+	// Clear events and reset node for False -> Unknown test
+	fakeRecorder.Events = []*v1.Event{}
+	nodeController.now = func() metav1.Time { return fakeNow }
+	fakeNodeHandler.UpdatedNodes = nil
+	fakeNodeHandler.UpdatedNodeStatuses = nil
+	fakeNodeHandler.Existing[0].Status.Conditions[0].Status = v1.ConditionFalse
+	fakeNodeHandler.Existing[0].Status.Conditions[0].LastHeartbeatTime = fakeNow
+	fakeNodeHandler.Existing[0].Status.Conditions[0].LastTransitionTime = fakeNow
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Run once to update nodeHealthMap with False status
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	fakeRecorder.Events = []*v1.Event{}
+
+	// 2. Transition False -> Unknown (via heartbeat expiration)
+	nodeController.now = func() metav1.Time { return metav1.Time{Time: fakeNow.Add(10 * time.Minute)} } // Exceeds grace period
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Expect NodeUnreachable event
+	foundUnreachable = false
+	for _, event := range fakeRecorder.Events {
+		if event.Reason == "NodeUnreachable" {
+			foundUnreachable = true
+			break
+		}
+	}
+	if !foundUnreachable {
+		t.Errorf("Expected NodeUnreachable event not found. Events: %v", fakeRecorder.Events)
 	}
 }


### PR DESCRIPTION
…orkers

Call monitorNodeHealth once after cache sync so processPod does not drop the startup Add storm while the map is still empty.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved node health monitoring during startup.
  - Correctly treats transitions to an unknown node state as unavailable.
  - Records node-unreachable events when node status becomes unknown.
  - Ensures affected pods are marked for retry when nodes become not ready or unreachable.
  - Improves handling when pod information cannot be retrieved during node transitions.
- **Tests**
  - Added coverage for node status transitions, event generation, and pod retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->