### PR TITLE
OCPBUGS-109667: UPSTREAM: <carry>: kubelet: keep admission-rejected pods from StatusUnknown

### DIFF
--- a/openshift-hack/repro/OCPBUGS-109667/smt-odd-cpu-deployment.yaml
+++ b/openshift-hack/repro/OCPBUGS-109667/smt-odd-cpu-deployment.yaml
@@ -1,0 +1,58 @@
+# Lab repro for OCPBUGS-109667.
+#
+# CPU Manager static + full-pcpus-only will not admit a Guaranteed pod whose
+# CPU request is not a multiple of threads-per-core. This Deployment asks
+# for 5 CPUs, so on an SMT worker (2 threads per core) kubelet rejects it
+# with SMTAlignmentError. That part is expected.
+#
+# The status-manager bug is what happens next: TerminatePod used to stamp
+# the still-Waiting container as ContainerStatusUnknown, which hid the
+# admission reason. ReplicaSet then treats the pod as dead and creates
+# another one, so you get a replica storm even with replicas: 1.
+#
+# Need an SMT worker and kubelet CPU Manager static with
+# full-pcpus-only: "true" (PerformanceProfile or KubeletConfig):
+#   oc debug node/<node> -- chroot /host sh -c 'lscpu | grep Thread'
+#   oc get kubeletconfig -o yaml | grep -A2 full-pcpus-only
+#
+# oc new-project smt-repro
+# oc apply -f smt-odd-cpu-deployment.yaml
+# wait 20-30s, then:
+#   oc get pods -n smt-repro -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,REASON:.status.reason,MSG:.status.message'
+#   oc get pods -n smt-repro -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[0].state}{"\n"}{end}'
+#
+# Before the kubelet change: StatusUnknown / ContainerStatusUnknown, and
+# the pod count climbs. After: Failed + SMTAlignmentError, container still
+# Waiting. ReplicaSet may still replace Failed pods; that is a separate
+# scheduler/controller problem.
+#
+# oc delete project smt-repro
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smt-odd-cpu
+  namespace: smt-repro
+  labels:
+    app: smt-odd-cpu
+    bug: OCPBUGS-109667
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smt-odd-cpu
+  template:
+    metadata:
+      labels:
+        app: smt-odd-cpu
+        bug: OCPBUGS-109667
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            cpu: "5"
+            memory: 100Mi
+          limits:
+            cpu: "5"
+            memory: 100Mi

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -707,18 +707,25 @@ func (m *manager) TerminatePod(logger klog.Logger, pod *v1.Pod) {
 	_, notification = m.updateStatusInternal(logger, pod, status, true, true)
 }
 
-// hasPodInitialized returns true if the pod has no evidence of ever starting a regular container, which
-// implies those containers should not be transitioned to terminated status.
+// hasPodInitialized returns true if the pod has evidence of ever starting a regular container, or
+// if initialization has completed. Pods with no evidence of initialization should not have their
+// regular containers transitioned to terminated/Unknown status (for example admission-rejected pods).
 func hasPodInitialized(logger klog.Logger, pod *v1.Pod) bool {
-	// a pod without init containers is always initialized
-	if len(pod.Spec.InitContainers) == 0 {
-		return true
-	}
 	// if any container has ever moved out of waiting state, the pod has initialized
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.LastTerminationState.Terminated != nil || status.State.Waiting == nil {
 			return true
 		}
+	}
+
+	// a pod that is running has initialized
+	if pod.Status.Phase == v1.PodRunning {
+		return true
+	}
+
+	// a pod without init containers is initialized only if one of its containers started
+	if len(pod.Spec.InitContainers) == 0 {
+		return false
 	}
 	// if the last init container has ever completed with a zero exit code, the pod is initialized
 	if l := len(pod.Status.InitContainerStatuses); l > 0 {

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -958,6 +958,27 @@ func TestTerminatePod_DefaultUnknownStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "admission-rejected pod without init containers keeps Failed reason and does not become StatusUnknown",
+			pod: newPod(0, 1, func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyNever
+				pod.Status.Phase = v1.PodFailed
+				pod.Status.Reason = "SMTAlignmentError"
+				pod.Status.Message = "Pod was rejected: SMT Alignment Error: requested 5 cpus not multiple cpus per core = 2"
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{Name: "0", State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{}}},
+				}
+			}),
+			expectFn: func(t *testing.T, status v1.PodStatus) {
+				if status.Phase != v1.PodFailed {
+					t.Fatalf("expected Failed phase, got %s", status.Phase)
+				}
+				if status.Reason != "SMTAlignmentError" {
+					t.Fatalf("expected SMTAlignmentError to be preserved, got %q", status.Reason)
+				}
+				expectWaiting(t, status.ContainerStatuses[0].State)
+			},
+		},
+		{
 			name: "uninitialized pod defaults the first init container",
 			pod: newPod(1, 1, func(pod *v1.Pod) {
 				pod.Spec.RestartPolicy = v1.RestartPolicyNever


### PR DESCRIPTION
OCPBUGS-109667

Carry of kubernetes/kubernetes#136592, which is still open upstream, so this is `UPSTREAM: <carry>` rather than a numbered backport. Related: OCPBUGS-56710, [RFE-7821](https://redhat.atlassian.net/browse/RFE-7821), kubernetes/kubernetes#133733.

On SMT workers with kubelet CPU Manager `static` and `full-pcpus-only: "true"`, a Guaranteed pod whose CPU request is not a multiple of threads-per-core is rejected at admission with `SMTAlignmentError`. That rejection is correct. We are not changing CPU Manager policy and we are not admitting odd CPU requests.

The bug is what kubelet does to the pod status afterwards.

Admission writes Failed + `SMTAlignmentError` with the container still Waiting. The status manager then calls `TerminatePod`. `TerminatePod` uses `hasPodInitialized` to decide whether regular containers should be moved to terminated / `ContainerStatusUnknown`. That helper treated any pod with no init containers as already initialized, so those Waiting containers got overwritten with `ContainerStatusUnknown`. Operators then see `StatusUnknown` instead of the admission reason.

ReplicaSet/Deployment still see a failed pod and create a replacement. That is how you get a replica storm with `replicas: 1` and, in the bad cases, thousands of pods stressing the API server and etcd. This PR does not stop that replacement loop by itself. Failed pods are still Failed. Stopping the storm needs a scheduler SMT filter or controller backoff (that is the [RFE-7821](https://redhat.atlassian.net/browse/RFE-7821) side). What this does is stop kubelet from destroying the real failure reason so the pod is at least diagnosable.

`hasPodInitialized` in `pkg/kubelet/status/status_manager.go` now does this:

- If a regular container has ever left Waiting (or has a last termination state), the pod has initialized. Same as before.
- A Running pod is treated as initialized. That keeps the existing `TerminatePod` case for a Running pod with a still-Waiting container, which should still become StatusUnknown.
- A pod with no init containers is not assumed initialized. If nothing has started, return false so admission-rejected pods keep Failed / Waiting.

`TestTerminatePod_DefaultUnknownStatus` has a new case: Failed + `SMTAlignmentError` + Waiting container must stay Waiting and keep the reason. The old Running + Waiting case is still there so we do not regress that path.

`openshift-hack/repro/OCPBUGS-109667/smt-odd-cpu-deployment.yaml` is a lab Deployment (`UPSTREAM: <drop>`). Guaranteed pause container, 5 CPU request/limit. Use it on an SMT worker (threads per core = 2) with CPU Manager static + `full-pcpus-only`.

How to test
Unit:

```
GOWORK=off go test ./pkg/kubelet/status/ -run TestTerminatePod
```

Check the new case stays Failed / `SMTAlignmentError` / Waiting, and the existing Running + Waiting case still becomes StatusUnknown.

Cluster:

```
oc new-project smt-repro
oc apply -f openshift-hack/repro/OCPBUGS-109667/smt-odd-cpu-deployment.yaml
# wait ~20-30s
oc get pods -n smt-repro -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,REASON:.status.reason,MSG:.status.message'
oc get pods -n smt-repro -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[0].state}{"\n"}{end}'
oc delete project smt-repro
```

Before this change: `ContainerStatusUnknown` / StatusUnknown, and with `replicas: 1` the pod count still climbs. After: Failed + `SMTAlignmentError`, container still Waiting. ReplicaSet may still replace the Failed pod until something filters SMT-misaligned requests in the scheduler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod initialization tracking for pods without init containers.
  * Preserved failure reasons and waiting container states for admission-rejected pods during termination.
* **Documentation**
  * Added a deployment manifest and instructions to reproduce CPU allocation behavior on SMT nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->