### PR TITLE
OCPBUGS-113816: UPSTREAM: 139107: oc adm top pod: apply --field-selector via Pod API so spec.nodeName works

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -85,7 +85,10 @@ var (
 		kubectl top pod POD_NAME --containers
 
 		# Show metrics for the pods defined by label name=myLabel
-		kubectl top pod -l name=myLabel`))
+		kubectl top pod -l name=myLabel
+
+		# Show metrics for all pods on a specific node
+		kubectl top pod -A --field-selector spec.nodeName=NODE_NAME`))
 )
 
 func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.IOStreams) *cobra.Command {
@@ -197,9 +200,16 @@ func (o TopPodOptions) RunTopPod() error {
 	if !metricsAPIAvailable {
 		return errors.New("Metrics API not available")
 	}
-	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector, fieldSelector)
+	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector)
 	if err != nil {
 		return err
+	}
+
+	if len(metrics.Items) != 0 && len(o.FieldSelector) > 0 {
+		metrics, err = filterPodMetricsByFieldSelector(o, metrics, labelSelector, fieldSelector)
+		if err != nil {
+			return err
+		}
 	}
 
 	// First we check why no metrics have been received.
@@ -222,7 +232,7 @@ func (o TopPodOptions) RunTopPod() error {
 	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum)
 }
 
-func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {
+func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector) (*metricsapi.PodMetricsList, error) {
 	var err error
 	ns := metav1.NamespaceAll
 	if !allNamespaces {
@@ -236,7 +246,7 @@ func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespac
 		}
 		versionedMetrics.Items = []metricsv1beta1api.PodMetrics{*m}
 	} else {
-		versionedMetrics, err = metricsClient.MetricsV1beta1().PodMetricses(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String(), FieldSelector: fieldSelector.String()})
+		versionedMetrics, err = metricsClient.MetricsV1beta1().PodMetricses(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 		if err != nil {
 			return nil, err
 		}
@@ -287,4 +297,34 @@ func checkPodAge(pod *corev1.Pod) error {
 		klog.V(2).Infof("Metrics not yet available for pod %s/%s, age: %s", pod.Namespace, pod.Name, age.String())
 		return nil
 	}
+}
+
+func filterPodMetricsByFieldSelector(o TopPodOptions, metrics *metricsapi.PodMetricsList, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {
+	ns := metav1.NamespaceAll
+	if !o.AllNamespaces {
+		ns = o.Namespace
+	}
+
+	pods, err := o.PodClient.Pods(ns).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+		FieldSelector: fieldSelector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	selectedPods := make(map[string]struct{}, len(pods.Items))
+	for _, pod := range pods.Items {
+		selectedPods[pod.Namespace+"/"+pod.Name] = struct{}{}
+	}
+
+	filtered := make([]metricsapi.PodMetrics, 0, len(metrics.Items))
+	for _, metric := range metrics.Items {
+		if _, ok := selectedPods[metric.Namespace+"/"+metric.Name]; ok {
+			filtered = append(filtered, metric)
+		}
+	}
+
+	metrics.Items = filtered
+	return metrics, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -89,6 +89,14 @@ func TestTopPod(t *testing.T) {
 		namespaces         []string
 		containers         bool
 		listsNamespaces    bool
+		// extraPaths overrides the response of the pod list endpoint, e.g. to
+		// simulate server-side filtering by the core API.
+		extraPaths func(req *http.Request) (*http.Response, error)
+		// expectedInOutput/nonExpectedInOutput override the pod names derived
+		// from namespaces, for cases where the printed pods differ from what
+		// the metrics API returned (e.g. client-side field selector filtering).
+		expectedInOutput    []string
+		nonExpectedInOutput []string
 	}{
 		{
 			name:            "all namespaces",
@@ -116,6 +124,16 @@ func TestTopPod(t *testing.T) {
 			options:       &TopPodOptions{FieldSelector: "key=value"},
 			expectedQuery: "fieldSelector=" + url.QueryEscape("key=value"),
 			namespaces:    []string{testNS, testNS},
+		},
+		{
+			// The metrics API returns all three pods, while the pod list
+			// endpoint only returns pod1, so the client must drop pod2 and pod3.
+			name:                "pod with field selector filtering metrics",
+			options:             &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
+			namespaces:          []string{testNS, testNS, testNS},
+			extraPaths:          onlyPod1ListResponse,
+			expectedInOutput:    []string{"pod1"},
+			nonExpectedInOutput: []string{"pod2", "pod3"},
 		},
 		{
 			name:    "pod with container metrics",
@@ -215,6 +233,7 @@ func TestTopPod(t *testing.T) {
 			defer tf.Cleanup()
 
 			ns := scheme.Codecs.WithoutConversion()
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 
 			tf.Client = &fake.RESTClient{
 				NegotiatedSerializer: ns,
@@ -224,6 +243,11 @@ func TestTopPod(t *testing.T) {
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
 					case p == "/apis":
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+					case p == "/api/v1/namespaces/"+testNS+"/pods", p == "/api/v1/pods":
+						if testCase.extraPaths != nil {
+							return testCase.extraPaths(req)
+						}
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, defaultTopPodList(testNS))}, nil
 					default:
 						t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
 							testCase.name, req, req.URL)
@@ -258,24 +282,37 @@ func TestTopPod(t *testing.T) {
 
 			// Check the presence of pod names&namespaces/container names in the output.
 			result := buf.String()
-			if testCase.containers {
-				for _, containerName := range expectedContainerNames {
-					if !strings.Contains(result, containerName) {
-						t.Errorf("missing metrics for container %s: \n%s", containerName, result)
+			if testCase.expectedInOutput != nil || testCase.nonExpectedInOutput != nil {
+				for _, name := range testCase.expectedInOutput {
+					if !strings.Contains(result, name) {
+						t.Errorf("missing metrics for %s: \n%s", name, result)
 					}
 				}
-			}
-			for _, m := range expectedMetrics {
-				if !strings.Contains(result, m.Name) {
-					t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+				for _, name := range testCase.nonExpectedInOutput {
+					if strings.Contains(result, name) {
+						t.Errorf("unexpected metrics for %s: \n%s", name, result)
+					}
 				}
-				if testCase.listsNamespaces && !strings.Contains(result, m.Namespace) {
-					t.Errorf("missing metrics for %s/%s: \n%s", m.Namespace, m.Name, result)
+			} else {
+				if testCase.containers {
+					for _, containerName := range expectedContainerNames {
+						if !strings.Contains(result, containerName) {
+							t.Errorf("missing metrics for container %s: \n%s", containerName, result)
+						}
+					}
 				}
-			}
-			for _, name := range nonExpectedMetricsNames {
-				if strings.Contains(result, name) {
-					t.Errorf("unexpected metrics for %s: \n%s", name, result)
+				for _, m := range expectedMetrics {
+					if !strings.Contains(result, m.Name) {
+						t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+					}
+					if testCase.listsNamespaces && !strings.Contains(result, m.Namespace) {
+						t.Errorf("missing metrics for %s/%s: \n%s", m.Namespace, m.Name, result)
+					}
+				}
+				for _, name := range nonExpectedMetricsNames {
+					if strings.Contains(result, name) {
+						t.Errorf("unexpected metrics for %s: \n%s", name, result)
+					}
 				}
 			}
 			if testCase.expectedPods != nil {
@@ -568,4 +605,42 @@ func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
 			},
 		},
 	}
+}
+
+func defaultTopPodList(namespace string) *v1.PodList {
+	return &v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: namespace},
+				Spec:       v1.PodSpec{NodeName: "node-a"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: namespace},
+				Spec:       v1.PodSpec{NodeName: "node-b"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: namespace},
+				Spec:       v1.PodSpec{NodeName: "node-c"},
+			},
+		},
+	}
+}
+
+// onlyPod1ListResponse serves a pod list containing only pod1, simulating the
+// core API filtering pods by a field selector.
+func onlyPod1ListResponse(req *http.Request) (*http.Response, error) {
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     cmdtesting.DefaultHeader(),
+		Body: cmdtesting.ObjBody(codec, &v1.PodList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+			Items: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "testns"},
+					Spec:       v1.PodSpec{NodeName: "node-a"},
+				},
+			},
+		}),
+	}, nil
 }


### PR DESCRIPTION
/kind bug

OCPBUGS-113816

Carry of kubernetes/kubernetes#139107 into OpenShift kubectl so `oc adm top pod --field-selector spec.nodeName=<node>` works.

#### What this PR does / why we need it:

`oc adm top pod` currently sends `--field-selector` to the Metrics API. That API only supports `metadata.name` and `metadata.namespace`, so selectors such as `spec.nodeName` fail with:

```
Error from server (BadRequest): "spec.nodeName" is not a known field selector: only "metadata.name", "metadata.namespace"
```

Upstream kubectl already fixed this in kubernetes/kubernetes#139107 by listing matching pods from the core Pod API and filtering the returned metrics locally. OpenShift has not carried that change.

This PR does **not** add a `--node` flag. kubernetes/kubernetes#141581 was closed because SIG CLI rejected a dedicated flag; `--field-selector spec.nodeName` is the supported interface.

Support case: 04520084

#### Which issue(s) this PR is related to:

OCPBUGS-113816
Upstream: kubernetes/kubernetes#139107
Not a reopen of kubernetes/kubernetes#141581

#### Special notes for your reviewer:

`getMetricsFromMetricsAPI` no longer forwards `FieldSelector` to the Metrics API. When `--field-selector` is set and metrics are non-empty, `filterPodMetricsByFieldSelector` lists pods with that selector and keeps metrics whose namespace/name match.

#### Does this PR introduce a user-facing change?

```release-note
Apply --field-selector to pod metrics when invoking oc adm top pod / kubectl top pod, so spec.nodeName filtering works.
```