### PR TITLE
[4.22] OCPBUGS-98604: Add NodeSelectorAdjuster admission plugin for HCP clusters (part 2)

### DIFF
--- a/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission.go
+++ b/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission.go
@@ -96,11 +96,14 @@ func (p *nodeSelectorAdjuster) ValidateInitialization() error {
 // opts it in to node placement and lives in a namespace where that
 // label is expected. Control-plane-adjacent Day 2 operators can be added here.
 func requiresNodeSelectorAdjustment(pod *coreapi.Pod) bool {
-	// For VPA, we only want to update if the sole node selector is the
-	// master role key, which is the default from the 4.x VPA operator manifests.
+	// Only adjust when the node selector matches the exact default set from
+	// the 4.x VPA operator manifests. A cluster admin who customises the
+	// selector should not have their intent overridden.
 	if pod.Labels[vpaOperatorLabelKey] == vpaOperatorLabelValue &&
-		pod.Namespace == vpaOperatorNamespace && len(pod.Spec.NodeSelector) == 1 {
-		if _, found := pod.Spec.NodeSelector[masterRoleKey]; found {
+		pod.Namespace == vpaOperatorNamespace && len(pod.Spec.NodeSelector) == 2 {
+		_, hasMaster := pod.Spec.NodeSelector[masterRoleKey]
+		osVal, hasOS := pod.Spec.NodeSelector["kubernetes.io/os"]
+		if hasMaster && hasOS && osVal == "linux" {
 			return true
 		}
 	}

--- a/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission_test.go
+++ b/openshift-kube-apiserver/admission/scheduler/nodeselectoradjuster/admission_test.go
@@ -20,14 +20,24 @@ func TestAdmit(t *testing.T) {
 		expectedNodeSelector map[string]string
 	}{
 		{
-			name: "VPA operator pod with master node selector: selector is removed",
+			name: "VPA operator pod with default node selectors (os + master): master selector is removed",
+			pod: makePod(
+				withNamespace(vpaOperatorNamespace),
+				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
+				withNodeSelector(map[string]string{"kubernetes.io/os": "linux", masterRoleKey: ""}),
+			),
+			resource:             coreapi.Resource("pods").WithVersion("v1"),
+			expectedNodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+		},
+		{
+			name: "VPA operator pod with only master node selector: not modified",
 			pod: makePod(
 				withNamespace(vpaOperatorNamespace),
 				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
 				withNodeSelector(map[string]string{masterRoleKey: ""}),
 			),
 			resource:             coreapi.Resource("pods").WithVersion("v1"),
-			expectedNodeSelector: map[string]string{},
+			expectedNodeSelector: map[string]string{masterRoleKey: ""},
 		},
 		{
 			name: "VPA operator pod with no node selector: not modified",
@@ -49,7 +59,7 @@ func TestAdmit(t *testing.T) {
 			expectedNodeSelector: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
 		},
 		{
-			name: "VPA operator pod with extra node selectors including master: not modified",
+			name: "VPA operator pod with custom node selectors including master: not modified",
 			pod: makePod(
 				withNamespace(vpaOperatorNamespace),
 				withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}),
@@ -158,9 +168,14 @@ func TestRequiresNodeSelectorAdjustment(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "VPA operator with master node selector: match",
-			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{masterRoleKey: ""})),
+			name:     "VPA operator with default node selectors (os + master): match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{"kubernetes.io/os": "linux", masterRoleKey: ""})),
 			expected: true,
+		},
+		{
+			name:     "VPA operator with only master node selector: no match",
+			pod:      makePod(withNamespace(vpaOperatorNamespace), withLabels(map[string]string{vpaOperatorLabelKey: vpaOperatorLabelValue}), withNodeSelector(map[string]string{masterRoleKey: ""})),
+			expected: false,
 		},
 		{
 			name:     "VPA operator with no node selector: no match",


### PR DESCRIPTION
This is a follow-up to #2718 from joelsmith/release-4.22

The original PR missed the fact that the default VPA label selector
changed as a result of the VPA-operator-side fix backport.

Here is the new actual VPA operator `nodeSelector` from a 4.22 cluster:
```
    nodeSelector:
      kubernetes.io/os: linux
      node-role.kubernetes.io/master: ""
```