### PR TITLE
OCPBUGS-120824: Remove redundant iproute installation from hyperkube image

### DIFF
--- a/openshift-hack/images/hyperkube/Dockerfile.rhel
+++ b/openshift-hack/images/hyperkube/Dockerfile.rhel
@@ -10,7 +10,6 @@ RUN make TAGS="${TAGS}" WHAT='cmd/kube-apiserver cmd/kube-controller-manager cmd
     gzip /tmp/build/k8s-tests-ext
 
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
-RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all
 COPY --from=builder /tmp/build/* /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
The hyperkube Dockerfile explicitly installs `iproute`, but the current `base-rhel9` image already provides it.

`ss` is still used by the cluster-kube-apiserver-operator static-pod startup entrypoint as a fallback when kubelet or CRI-O overlaps the old and new kube-apiserver containers. This change removes only the redundant image-local installation; the package remains inherited from the base image.

Fixes OCPBUGS-120824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the image build step that installed and cleaned up the `iproute` package in the RHEL-based image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->